### PR TITLE
Little config change to fix blog post titles linking to the wrong URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ email:
 
 # If publishing to a subdirectory as in http://site.com/project set 'root: /project'
 root: /openui5
-permalink: /openui5/blog/:year/:month/:day/:title/
+permalink: /blog/:year/:month/:day/:title/
 source: source
 destination: public
 plugins: plugins


### PR DESCRIPTION
Should work now, seem as though octopress combines the root with the permalink path automatically.
