### PR TITLE
sap.ui.core.CSSSize supports css calc()

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/library.js
+++ b/src/sap.ui.core/src/sap/ui/core/library.js
@@ -575,7 +575,7 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/base/DataType', './Core'],
 	 */
 	sap.ui.core.CSSSize = DataType.createType('sap.ui.core.CSSSize', {
 	    isValid : function(vValue) {
-	      return /^(auto|inherit|[-+]?(0*|([0-9]+|[0-9]*\.[0-9]+)(rem|em|ex|px|cm|mm|in|pt|pc|%))|calc\(([+*/-]?\s*[-+]?(0*|([0-9]+|[0-9]*\.[0-9]+)(|rem|em|ex|px|cm|mm|in|pt|pc|%)))+\))$/i.test(vValue);
+	      return /^(auto|inherit|[-+]?(0*|([0-9]+|[0-9]*\.[0-9]+)(rem|em|ex|px|cm|mm|in|pt|pc|%))|calc\(([-+]?([0-9]+|[0-9]*\.[0-9]+)(|rem|em|ex|px|cm|mm|in|pt|pc|%))(\s*[+*/-]?\s*([-+]?([0-9]+|[0-9]*\.[0-9]+)(|rem|em|ex|px|cm|mm|in|pt|pc|%)))*\))$/i.test(vValue);
 	    }
 	
 	  },

--- a/src/sap.ui.core/src/sap/ui/core/library.js
+++ b/src/sap.ui.core/src/sap/ui/core/library.js
@@ -574,9 +574,9 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/base/DataType', './Core'],
 	 * @ui5-metamodel This simple type also will be described in the UI5 (legacy) designtime metamodel
 	 */
 	sap.ui.core.CSSSize = DataType.createType('sap.ui.core.CSSSize', {
-	    isValid : function(vValue) {
-	      return /^(auto|inherit|[-+]?(0*|([0-9]+|[0-9]*\.[0-9]+)([rR][eE][mM]|[eE][mM]|[eE][xX]|[pP][xX]|[cC][mM]|[mM][mM]|[iI][nN]|[pP][tT]|[pP][cC]|%)))$/.test(vValue);
-	    }
+		isValid : function(vValue) {
+			return /^(auto|inherit|[-+]?(0*|([0-9]+|[0-9]*\.[0-9]+)(rem|em|ex|px|cm|mm|in|pt|pc|%))|calc\(([+*/-]?\s*[-+]?(0*|([0-9]+|[0-9]*\.[0-9]+)(|rem|em|ex|px|cm|mm|in|pt|pc|%)))+\))$/i.test(vValue);
+		}
 	
 	  },
 	  DataType.getType('string')

--- a/src/sap.ui.core/src/sap/ui/core/library.js
+++ b/src/sap.ui.core/src/sap/ui/core/library.js
@@ -574,9 +574,9 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/base/DataType', './Core'],
 	 * @ui5-metamodel This simple type also will be described in the UI5 (legacy) designtime metamodel
 	 */
 	sap.ui.core.CSSSize = DataType.createType('sap.ui.core.CSSSize', {
-		isValid : function(vValue) {
-			return /^(auto|inherit|[-+]?(0*|([0-9]+|[0-9]*\.[0-9]+)(rem|em|ex|px|cm|mm|in|pt|pc|%))|calc\(([+*/-]?\s*[-+]?(0*|([0-9]+|[0-9]*\.[0-9]+)(|rem|em|ex|px|cm|mm|in|pt|pc|%)))+\))$/i.test(vValue);
-		}
+	    isValid : function(vValue) {
+	      return /^(auto|inherit|[-+]?(0*|([0-9]+|[0-9]*\.[0-9]+)(rem|em|ex|px|cm|mm|in|pt|pc|%))|calc\(([+*/-]?\s*[-+]?(0*|([0-9]+|[0-9]*\.[0-9]+)(|rem|em|ex|px|cm|mm|in|pt|pc|%)))+\))$/i.test(vValue);
+	    }
 	
 	  },
 	  DataType.getType('string')

--- a/src/sap.ui.core/src/sap/ui/core/library.js
+++ b/src/sap.ui.core/src/sap/ui/core/library.js
@@ -575,14 +575,7 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/base/DataType', './Core'],
 	 */
 	sap.ui.core.CSSSize = DataType.createType('sap.ui.core.CSSSize', {
 	    isValid : function(vValue) {
-            var unitsExpr   = "([rR][eE][mM]|[eE][mM]|[eE][xX]|[pP][xX]|[cC][mM]|[mM][mM]|[iI][nN]|[pP][tT]|[pP][cC]|%)";
-            var keyWordExpr = "auto|inherit";
-            var sizeExpr    = "[-+]?(0*|([0-9]+|[0-9]*\\.[0-9]+)" + unitsExpr + ")";
-            var calcArgExpr = "[-+]?(([0-9]+|[0-9]*\\.[0-9]+)" + unitsExpr + "?)";
-            var calcExpr    = "calc\\(" + calcArgExpr + "(\\s*[+*/-]?\\s*(" + calcArgExpr + "))*\\)";
-            var regexp      = new RegExp("^(" + keyWordExpr + "|" + sizeExpr + "|" + calcExpr + ")$");
-
-            return regexp.test(vValue);
+            return /^(auto|inherit|[-+]?(0*|([0-9]+|[0-9]*\.[0-9]+)([rR][eE][mM]|[eE][mM]|[eE][xX]|[pP][xX]|[cC][mM]|[mM][mM]|[iI][nN]|[pP][tT]|[pP][cC]|%))|calc\([-+]?(([0-9]+|[0-9]*\.[0-9]+)([rR][eE][mM]|[eE][mM]|[eE][xX]|[pP][xX]|[cC][mM]|[mM][mM]|[iI][nN]|[pP][tT]|[pP][cC]|%)?)(\s*[+*\/-]?\s*([-+]?(([0-9]+|[0-9]*\.[0-9]+)([rR][eE][mM]|[eE][mM]|[eE][xX]|[pP][xX]|[cC][mM]|[mM][mM]|[iI][nN]|[pP][tT]|[pP][cC]|%)?)))*\))$/.test(vValue);
 	    }
 	
 	  },

--- a/src/sap.ui.core/src/sap/ui/core/library.js
+++ b/src/sap.ui.core/src/sap/ui/core/library.js
@@ -575,7 +575,14 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/base/DataType', './Core'],
 	 */
 	sap.ui.core.CSSSize = DataType.createType('sap.ui.core.CSSSize', {
 	    isValid : function(vValue) {
-	      return /^(auto|inherit|[-+]?(0*|([0-9]+|[0-9]*\.[0-9]+)(rem|em|ex|px|cm|mm|in|pt|pc|%))|calc\(([-+]?([0-9]+|[0-9]*\.[0-9]+)(|rem|em|ex|px|cm|mm|in|pt|pc|%))(\s*[+*/-]?\s*([-+]?([0-9]+|[0-9]*\.[0-9]+)(|rem|em|ex|px|cm|mm|in|pt|pc|%)))*\))$/i.test(vValue);
+            var unitsExpr   = "([rR][eE][mM]|[eE][mM]|[eE][xX]|[pP][xX]|[cC][mM]|[mM][mM]|[iI][nN]|[pP][tT]|[pP][cC]|%)";
+            var keyWordExpr = "auto|inherit";
+            var sizeExpr    = "[-+]?(0*|([0-9]+|[0-9]*\\.[0-9]+)" + unitsExpr + ")";
+            var calcArgExpr = "[-+]?(([0-9]+|[0-9]*\\.[0-9]+)" + unitsExpr + "?)";
+            var calcExpr    = "calc\\(" + calcArgExpr + "(\\s*[+*/-]?\\s*(" + calcArgExpr + "))*\\)";
+            var regexp      = new RegExp("^(" + keyWordExpr + "|" + sizeExpr + "|" + calcExpr + ")$");
+
+            return regexp.test(vValue);
 	    }
 	
 	  },

--- a/src/sap.ui.core/test/sap/ui/core/qunit/DataType.qunit.html
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/DataType.qunit.html
@@ -154,10 +154,10 @@
 			equal(type.isValid(" 20px"), false, "a partial match must not be valid");
 			equal(type.isValid("100% 20px"), false, "a partial match must not be valid");
 			equal(type.isValid("100% "), false, "a partial match must not be valid");
-            equal(type.isValid("calc(100%-20rem)"), true,  "an valid calc() expression must be valid");
-            equal(type.isValid("calc(100%-"),       false, "an invalid calc() expression must be invalid");
-            equal(type.isValid("calc(2 * -20rem / 23)"), true,  "an valid calc() expression must be valid");
-            equal(type.isValid("calc(100%)"),       true,  "an valid calc() expression must be valid");
+			equal(type.isValid("calc(100%-20rem)"), true,  "an valid calc() expression must be valid");
+			equal(type.isValid("calc(100%-"),       false, "an invalid calc() expression must be invalid");
+			equal(type.isValid("calc(2 * -20rem / 23)"), true,  "an valid calc() expression must be valid");
+			equal(type.isValid("calc(100%)"),       true,  "an valid calc() expression must be valid");
 		});
 
 		test("type CSSSize[]", function() {

--- a/src/sap.ui.core/test/sap/ui/core/qunit/DataType.qunit.html
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/DataType.qunit.html
@@ -154,10 +154,14 @@
 			equal(type.isValid(" 20px"), false, "a partial match must not be valid");
 			equal(type.isValid("100% 20px"), false, "a partial match must not be valid");
 			equal(type.isValid("100% "), false, "a partial match must not be valid");
-			equal(type.isValid("calc(100%-20rem)"), true,  "an valid calc() expression must be valid");
-			equal(type.isValid("calc(100%-"),       false, "an invalid calc() expression must be invalid");
-			equal(type.isValid("calc(2 * -20rem / 23)"), true,  "an valid calc() expression must be valid");
-			equal(type.isValid("calc(100%)"),       true,  "an valid calc() expression must be valid");
+
+			equal(type.isValid("calc(100%-20rem)"), true, "a valid calc() expression must be valid");
+			equal(type.isValid("calc(100%-"), false, "an invalid calc() expression must be invalid");
+			equal(type.isValid("calc(* - 100%)"), false, "an invalid calc() expression must be invalid");
+			equal(type.isValid("calc(2 * -20rem / 23)"), true, "a valid calc() expression must be valid");
+			equal(type.isValid("calc(100%)"), true, "a valid calc() expression must be valid");
+			equal(type.isValid("calc(3rem + 10)"), true, "a valid calc() expression must be valid");  // this has a valid syntax but isn't a valid expression
+			equal(type.isValid("calc(10 + 3rem)"), true, "a valid calc() expression must be valid");  // this has a valid syntax but isn't a valid expression
 		});
 
 		test("type CSSSize[]", function() {

--- a/src/sap.ui.core/test/sap/ui/core/qunit/DataType.qunit.html
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/DataType.qunit.html
@@ -154,6 +154,10 @@
 			equal(type.isValid(" 20px"), false, "a partial match must not be valid");
 			equal(type.isValid("100% 20px"), false, "a partial match must not be valid");
 			equal(type.isValid("100% "), false, "a partial match must not be valid");
+            equal(type.isValid("calc(100%-20rem)"), true,  "an valid calc() expression must be valid");
+            equal(type.isValid("calc(100%-"),       false, "an invalid calc() expression must be invalid");
+            equal(type.isValid("calc(2 * -20rem / 23)"), true,  "an valid calc() expression must be valid");
+            equal(type.isValid("calc(100%)"),       true,  "an valid calc() expression must be valid");
 		});
 
 		test("type CSSSize[]", function() {

--- a/src/sap.ui.core/test/sap/ui/core/qunit/DataType.qunit.html
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/DataType.qunit.html
@@ -155,13 +155,12 @@
 			equal(type.isValid("100% 20px"), false, "a partial match must not be valid");
 			equal(type.isValid("100% "), false, "a partial match must not be valid");
 
-			equal(type.isValid("calc(100%-20rem)"), true, "a valid calc() expression must be valid");
-			equal(type.isValid("calc(100%-"), false, "an invalid calc() expression must be invalid");
-			equal(type.isValid("calc(* - 100%)"), false, "an invalid calc() expression must be invalid");
-			equal(type.isValid("calc(2 * -20rem / 23)"), true, "a valid calc() expression must be valid");
-			equal(type.isValid("calc(100%)"), true, "a valid calc() expression must be valid");
-			equal(type.isValid("calc(3rem + 10)"), true, "a valid calc() expression must be valid");  // this has a valid syntax but isn't a valid expression
+			equal(type.isValid("calc(100%-20rem)"), true, "can substract two arguments");
+			equal(type.isValid("calc(2 * -20rem / 23)"), true, "arguments dont always need units");
+			equal(type.isValid("calc(100%)"), true, "a single value is valid");
 			equal(type.isValid("calc(10 + 3rem)"), true, "a valid calc() expression must be valid");  // this has a valid syntax but isn't a valid expression
+			equal(type.isValid("calc(100%-"), false, "can't substract undefined");
+			equal(type.isValid("calc(* - 100%)"), false, "arguments need to have digits");
 		});
 
 		test("type CSSSize[]", function() {


### PR DESCRIPTION
First things first: **I hereby declare to agree to the OpenUI5 Individual Contributor License Agreement.**

This PR should fix #185. 

Should I add more test cases? 

There is one little problem with the current implementation (beside the regexp beeing way to big): It doesn't check for logical errors like "3 + 10rem". 
Additionally it does not support features like attr() in calc() (yet).

I don't expect this PR to be pulled immediately, just wanted to get some input on how to get this done. 