### PR TITLE
Fix ux3 facet filter example when switching a facet from one active filter to another

### DIFF
--- a/src/sap.ui.ux3/test/sap/ui/ux3/demokit/FacetFilter.html
+++ b/src/sap.ui.ux3/test/sap/ui/ux3/demokit/FacetFilter.html
@@ -18,6 +18,8 @@
 		var aFilters1 = [];
 		var aFilters2 = [];
 		var aFilters3 = [];
+
+		var prevFilter1, prevFilter2, prevFilter3;
 			
 		var oData = {cars : [
 				{brand: "BMW", model: "320d", type: "Limousine"},
@@ -130,11 +132,19 @@
 				
 			if(oEvent.getParameter("all")) {
 				applyFilter(oFFL2, oFFL3, [], []);
+				prevFilter1 = undefined;
 				return;
+			}
+
+			// If a previous filter was already in place, we must unfilter first so that
+			// the lists of check items in calcFilter contain all possible values.
+			if(prevFilter1 && prevFilter1.length > 0) {
+				applyFilter(oFFL2, oFFL3, [], []);
 			}
 
 			var oFilters = calcFilter(oEvent, "brand", oFFL2, "model", oFFL3, "type");
 			aFilters1 = oFilters.filter;
+			prevFilter1 = oEvent.getParameter("selectedItems");
 			applyFilter(oFFL2, oFFL3, oFilters.crossFilters1, oFilters.crossFilters2);	
 		});
 		oFacetFilter.addList(oFFL1);
@@ -149,11 +159,19 @@
 				
 			if(oEvent.getParameter("all")) {
 				applyFilter(oFFL1, oFFL3, [], []);
+				prevFilter2 = undefined;
 				return;
+			}
+
+			// If a previous filter was already in place, we must unfilter first so that
+			// the lists of check items in calcFilter contain all possible values.
+			if(prevFilter2 && prevFilter2.length > 0) {
+				applyFilter(oFFL1, oFFL3, [], []);
 			}
 
 			var oFilters = calcFilter(oEvent, "model", oFFL1, "brand", oFFL3, "type");
 			aFilters2 = oFilters.filter;
+			prevFilter2 = oEvent.getParameter("selectedItems");
 			applyFilter(oFFL1, oFFL3, oFilters.crossFilters1, oFilters.crossFilters2);	
 		});
 		oFacetFilter.addList(oFFL2);
@@ -167,11 +185,19 @@
 				
 			if(oEvent.getParameter("all")) {
 				applyFilter(oFFL1, oFFL2, [], []);
+				prevFilter3 = undefined;
 				return;
+			}
+
+			// If a previous filter was already in place, we must unfilter first so that
+			// the lists of check items in calcFilter contain all possible values.
+			if(prevFilter3 && prevFilter3.length > 0) {
+				applyFilter(oFFL1, oFFL2, [], []);
 			}
 
  			var oFilters = calcFilter(oEvent, "type", oFFL1, "brand", oFFL2, "model");
 			aFilters2 = oFilters.filter;
+			prevFilter3 = oEvent.getParameter("selectedItems");
  			applyFilter(oFFL1, oFFL2, oFilters.crossFilters1, oFilters.crossFilters2);	
 		});
 		oFacetFilter.addList(oFFL3);


### PR DESCRIPTION
I hereby declare to agree to the OpenUI5 Individual Contributor License Agreement

A couple of comments on this change:

To recreate the issue prior to application of this pull request, load up the ux3 FacetFilter demo, click on Car Model "325i", then click on Car Model "320d". At this point the "Type" facet list only contains "Limousine" but it should contain all three types that exist under model number 320d. This happens because the calcFilter function only considers values that appear in the facet under the current filter, but this logic is not correct in the event that a filter is changed from one value to another. In this case, we must consider all possible values of the facet.

This change is a bit of a hack, but unfortunately it doesn't appear there is a good way to access the unfiltered values of a model. If we could do this, then we could have the calcFilter function use those values and would not need to remove and re-apply the filter.

In general, I recommend using libraries designed for coordinated filtering and not writing this code on a one-off basis, as exactly this type of issue occurs often and library implementations will usually be more efficient. Libraries like Crossfilter are a good option. It might make sense to mention this as an option in the example description in addition to mentioning the possibility of server-side processing.
