### PR TITLE
[FIX] getting started docs cleanup

### DIFF
--- a/getstarted.html
+++ b/getstarted.html
@@ -236,7 +236,7 @@ btn.placeAt(<span class="shString">'content'</span>);
 			<span class="shAttr">actionName</span>: <span class="shString">"Say Hello"</span>
 		};
 		// instantiate the View
-		<span class="sh-js-keyword">var</span> myView = sap.ui.xmlview(<span class="shString>“getStarted”</span>);
+		<span class="sh-js-keyword">var</span> myView = sap.ui.xmlview(<span class="shString">“getStarted”</span>);
 		// create a Model and assign it to the View
 		<span class="sh-js-keyword">var</span> oModel = <span class="sh-js-keyword">new</span> sap.ui.model.json.JSONModel();
 		oModel.setData(data);


### PR DESCRIPTION
Inserted a missing double-quote which had caused invalid code to display on the Get Started page.
