### PR TITLE
[FEATURE] sap.m.Page: new showSubHeader property

### DIFF
--- a/src/sap.m/src/sap/m/Page.js
+++ b/src/sap.m/src/sap/m/Page.js
@@ -49,6 +49,11 @@ sap.ui.define(['jquery.sap.global', './library', 'sap/ui/core/Control'],
 			showHeader : {type : "boolean", group : "Appearance", defaultValue : true},
 	
 			/**
+			 * Whether this page shall show the subheader.
+			 */
+			showSubHeader : {type : "boolean", group : "Appearance", defaultValue : true},
+	
+			/**
 			 * The text of the nav button when running in iOS (if shown) in case it deviates from the default, which is "Back". This property is mvi-theme-dependent and will not have any effect in other themes.
 			 * @deprecated Since version 1.20. 
 			 * Deprecated since the MVI theme is removed now. This property only affected the NavButton in that theme.

--- a/src/sap.m/src/sap/m/PageRenderer.js
+++ b/src/sap.m/src/sap/m/PageRenderer.js
@@ -22,14 +22,17 @@ sap.ui.define(['jquery.sap.global'],
 	PageRenderer.render = function(rm, oPage) {
 		var oHeader = null,
 			oFooter = null,
+			oSubHeader = null,
 			sEnableScrolling = oPage.getEnableScrolling() ? " sapMPageScrollEnabled" : "";
 	
 		if (oPage.getShowHeader()) {
 			oHeader = oPage._getAnyHeader();
 		}
 	
-		var oSubHeader = oPage.getSubHeader();
-		
+		if (oPage.getShowSubHeader()) {
+			oSubHeader = oPage.getSubHeader();
+		}
+	
 		if (oPage.getShowFooter()) {
 			oFooter = oPage.getFooter();
 		}


### PR DESCRIPTION
- allows for binding to the property.

- unlike setting visible on the subHeader's bar,
this automatically controls the sapMPageWithSubHeader class.

I agree to the Contributors License Agreement.