### PR TITLE
Temporary change of HANA URLs to bridge the migration downtime

### DIFF
--- a/download.html
+++ b/download.html
@@ -61,14 +61,14 @@
 				<a name="stableRelease"></a><h3>Latest stable release: 1.24.6 (2015-01-12)</h3>
 				When in doubt, get this version.
 				<div class="downloadbuttons">
-					<a href="https://openui5.hana.ondemand.com/downloads/openui5-runtime-1.24.6.zip" class="downloadbutton">Download OpenUI5 Runtime</a> 
-					<a href="https://openui5.hana.ondemand.com/downloads/openui5-sdk-1.24.6.zip" class="downloadbutton">Download OpenUI5 SDK</a><br>
-					<a href="https://openui5.hana.ondemand.com/docs/guide/relnotes/ReleaseNotes-1.24.html" target="_blank">Release Notes</a>
+					<a href="https://openui5test.hana.ondemand.com/downloads/openui5-runtime-1.24.6.zip" class="downloadbutton">Download OpenUI5 Runtime</a> 
+					<a href="https://openui5test.hana.ondemand.com/downloads/openui5-sdk-1.24.6.zip" class="downloadbutton">Download OpenUI5 SDK</a><br>
+					<a href="https://openui5test.hana.ondemand.com/docs/guide/relnotes/ReleaseNotes-1.24.html" target="_blank">Release Notes</a>
 				</div>
 
 				<p>
 				The <span class="strong">Runtime</span> package contains everything needed to run a UI5 application, including all mobile resources.<br>
-				The <span class="strong">SDK</span> package also contains the complete documentation and samples as a web page to deploy on your own server. It is a copy of our <a href="https://openui5.hana.ondemand.com">public SDK</a>.<br> 
+				The <span class="strong">SDK</span> package also contains the complete documentation and samples as a web page to deploy on your own server. It is a copy of our <a href="https://openui5test.hana.ondemand.com">public SDK</a>.<br> 
 				</p>
 				Other packages and versions are available <a href="#versionList">below</a>.
 				
@@ -98,16 +98,16 @@
 				
 				<ul class="download">
 					<li>
-						<a href="https://openui5.hana.ondemand.com/downloads/openui5-runtime-1.24.6.zip">UI5 Runtime</a>
+						<a href="https://openui5test.hana.ondemand.com/downloads/openui5-runtime-1.24.6.zip">UI5 Runtime</a>
 						</li>
 					<li>
-						<a href="https://openui5.hana.ondemand.com/downloads/openui5-runtime-mobile-1.24.6.zip">UI5 Runtime Mobile</a>
+						<a href="https://openui5test.hana.ondemand.com/downloads/openui5-runtime-mobile-1.24.6.zip">UI5 Runtime Mobile</a>
 					</li>
 					<li>
-						<a href="https://openui5.hana.ondemand.com/downloads/openui5-sdk-1.24.6.zip">UI5 SDK</a>
+						<a href="https://openui5test.hana.ondemand.com/downloads/openui5-sdk-1.24.6.zip">UI5 SDK</a>
 					</li>
 					<li>
-						<a href="https://openui5.hana.ondemand.com/docs/guide/relnotes/ReleaseNotes-1.24.html">Release Notes</a>
+						<a href="https://openui5test.hana.ondemand.com/docs/guide/relnotes/ReleaseNotes-1.24.html">Release Notes</a>
 					</li>
 				</ul>
 				
@@ -119,16 +119,16 @@
 				
 				<ul class="download">
 					<li>
-						<a href="https://openui5.hana.ondemand.com/downloads/openui5-runtime-1.22.10.zip">UI5 Runtime</a>
+						<a href="https://openui5test.hana.ondemand.com/downloads/openui5-runtime-1.22.10.zip">UI5 Runtime</a>
 						</li>
 					<li>
-						<a href="https://openui5.hana.ondemand.com/downloads/openui5-runtime-mobile-1.22.10.zip">UI5 Runtime Mobile</a>
+						<a href="https://openui5test.hana.ondemand.com/downloads/openui5-runtime-mobile-1.22.10.zip">UI5 Runtime Mobile</a>
 					</li>
 					<li>
-						<a href="https://openui5.hana.ondemand.com/downloads/openui5-sdk-1.22.10.zip">UI5 SDK</a>
+						<a href="https://openui5test.hana.ondemand.com/downloads/openui5-sdk-1.22.10.zip">UI5 SDK</a>
 					</li>
 					<li>
-						<a href="https://openui5.hana.ondemand.com/docs/guide/relnotes/ReleaseNotes-1.22.html">Release Notes</a>
+						<a href="https://openui5test.hana.ondemand.com/docs/guide/relnotes/ReleaseNotes-1.22.html">Release Notes</a>
 					</li>
 				</ul>		
 				
@@ -140,16 +140,16 @@
 				<h4>Version 1.20.10 (2014-07-09)</h4>
 				<ul class="download">
 					<li>
-						<a href="https://openui5.hana.ondemand.com/downloads/openui5-runtime-1.20.10.zip">UI5 Runtime</a>
+						<a href="https://openui5test.hana.ondemand.com/downloads/openui5-runtime-1.20.10.zip">UI5 Runtime</a>
 						</li>
 					<li>
-						<a href="https://openui5.hana.ondemand.com/downloads/openui5-runtime-mobile-1.20.10.zip">UI5 Runtime Mobile</a>
+						<a href="https://openui5test.hana.ondemand.com/downloads/openui5-runtime-mobile-1.20.10.zip">UI5 Runtime Mobile</a>
 					</li>
 					<li>
-						<a href="https://openui5.hana.ondemand.com/downloads/openui5-sdk-1.20.10.zip">UI5 SDK</a>
+						<a href="https://openui5test.hana.ondemand.com/downloads/openui5-sdk-1.20.10.zip">UI5 SDK</a>
 					</li>
 					<li>
-						<a href="https://openui5.hana.ondemand.com/docs/guide/relnotes/ReleaseNotes-1.20.html">Release Notes</a>
+						<a href="https://openui5test.hana.ondemand.com/docs/guide/relnotes/ReleaseNotes-1.20.html">Release Notes</a>
 					</li>
 				</ul>
 				
@@ -162,16 +162,16 @@
 				<h4>Version 1.18.12 (2014-04-14)</h4>
 				<ul class="download">
 					<li>
-						<a href="https://openui5.hana.ondemand.com/downloads/openui5-runtime-1.18.12.zip">UI5 Runtime</a>
+						<a href="https://openui5test.hana.ondemand.com/downloads/openui5-runtime-1.18.12.zip">UI5 Runtime</a>
 						</li>
 					<li>
-						<a href="https://openui5.hana.ondemand.com/downloads/openui5-runtime-mobile-1.18.12.zip">UI5 Runtime Mobile</a>
+						<a href="https://openui5test.hana.ondemand.com/downloads/openui5-runtime-mobile-1.18.12.zip">UI5 Runtime Mobile</a>
 					</li>
 					<li>
-						<a href="https://openui5.hana.ondemand.com/downloads/openui5-sdk-1.18.12.zip">UI5 SDK</a>
+						<a href="https://openui5test.hana.ondemand.com/downloads/openui5-sdk-1.18.12.zip">UI5 SDK</a>
 					</li>
 					<li>
-						<a href="https://openui5.hana.ondemand.com/docs/guide/relnotes/ReleaseNotes-1.18.html">Release Notes</a>
+						<a href="https://openui5test.hana.ondemand.com/docs/guide/relnotes/ReleaseNotes-1.18.html">Release Notes</a>
 					</li>
 				</ul>
 
@@ -194,7 +194,7 @@
 			<div class="wrap_ie9">
 				<div class="inner">
 					<p class="copyright">&copy; SAP SE, made available under Apache License 2.0</p>
-					<img class="counter" src="https://openui5.hana.ondemand.com/resources/sap/ui/core/themes/base/img/1x1.gif?page=download" style="width:1px;height:1px"  alt="counter">
+					<img class="counter" src="https://openui5test.hana.ondemand.com/resources/sap/ui/core/themes/base/img/1x1.gif?page=download" style="width:1px;height:1px"  alt="counter">
 					<a class="legal" href="impressum.html">Legal Disclosure / Impressum</a>
 					<a class="legal" href="http://global.sap.com/corporate-en/legal/privacy.epx">Privacy</a>
 					<a class="legal" href="http://www.sap.com/germany/about/legal/privacy.html">Datenschutz</a>

--- a/index.html
+++ b/index.html
@@ -87,18 +87,18 @@
 				</p>
 				<h2>View it!</h2>
 				<p>
-					Check out our <a href="https://openui5.hana.ondemand.com/explored.html">Explored application</a> for controls running on phones, tablets and desktops, the <a href="https://openui5.hana.ondemand.com/#content/Controls/index.html">interactive control playground</a> for controls running on desktops as well as a number of
-					<a href="https://openui5.hana.ondemand.com/#demoapps.html">sample applications</a>
+					Check out our <a href="https://openui5test.hana.ondemand.com/explored.html">Explored application</a> for controls running on phones, tablets and desktops, the <a href="https://openui5test.hana.ondemand.com/#content/Controls/index.html">interactive control playground</a> for controls running on desktops as well as a number of
+					<a href="https://openui5test.hana.ondemand.com/#demoapps.html">sample applications</a>
 				</p>
 
 				<h2>Get it!</h2>
-				<p>It's <b>FREE</b>. Download the latest stable <a href="https://openui5.hana.ondemand.com/downloads/openui5-runtime-1.24.6.zip">UI5 Runtime</a>, the <a href="https://openui5.hana.ondemand.com/downloads/openui5-sdk-1.24.6.zip">UI5 SDK</a> containing all documentation, or go to the <a href="download.html">download page</a> for more options.<br>
+				<p>It's <b>FREE</b>. Download the latest stable <a href="https://openui5test.hana.ondemand.com/downloads/openui5-runtime-1.24.6.zip">UI5 Runtime</a>, the <a href="https://openui5test.hana.ondemand.com/downloads/openui5-sdk-1.24.6.zip">UI5 SDK</a> containing all documentation, or go to the <a href="download.html">download page</a> for more options.<br>
 				</p>
 
 				<h2>Get started!</h2>
 				<p>Try the <a href="getstarted.html">Hello World</a>, read the
-					<a href="https://openui5.hana.ondemand.com/#docs/guide/Documentation.html">Developer Guide</a> and refer to the
-					<a href="https://openui5.hana.ondemand.com/#docs/api/symbols/sap.ui.html">API Reference</a>. Check out <a href="http://stackoverflow.com/questions/tagged/sapui5">stackoverflow.com</a> to discuss code-related problems and questions. The OpenUI5 team will check regularly here for questions tagged with 'sapui5'. Or join the discussion in <a href="http://scn.sap.com/community/developer-center/front-end">SAP Community Network (SCN)</a>.
+					<a href="https://openui5test.hana.ondemand.com/#docs/guide/Documentation.html">Developer Guide</a> and refer to the
+					<a href="https://openui5test.hana.ondemand.com/#docs/api/symbols/sap.ui.html">API Reference</a>. Check out <a href="http://stackoverflow.com/questions/tagged/sapui5">stackoverflow.com</a> to discuss code-related problems and questions. The OpenUI5 team will check regularly here for questions tagged with 'sapui5'. Or join the discussion in <a href="http://scn.sap.com/community/developer-center/front-end">SAP Community Network (SCN)</a>.
 				</p>
 				
 				<h2>Contribute!</h2>
@@ -118,7 +118,7 @@
 			<div class="wrap_ie9">
 				<div class="inner">
 					<p class="copyright">&copy; SAP SE, made available under Apache License 2.0</p>
-					<img class="counter" src="https://openui5.hana.ondemand.com/resources/sap/ui/core/themes/base/img/1x1.gif?page=index" style="width:1px;height:1px" alt="counter">
+					<img class="counter" src="https://openui5test.hana.ondemand.com/resources/sap/ui/core/themes/base/img/1x1.gif?page=index" style="width:1px;height:1px" alt="counter">
 					<a class="legal" href="impressum.html">Legal Disclosure / Impressum</a>
 					<a class="legal" href="http://global.sap.com/corporate-en/legal/privacy.epx">Privacy</a>
 					<a class="legal" href="http://www.sap.com/germany/about/legal/privacy.html">Datenschutz</a>


### PR DESCRIPTION
Use openui5test instead of openui5
Do not merge before 9am WDF time on January 16th, 2015