### PR TITLE
read params from global Configuration with camelCase

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/Configuration.js
+++ b/src/sap.ui.core/src/sap/ui/core/Configuration.js
@@ -231,10 +231,10 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/base/Object', './Locale', 'sap/ui/th
 			var oCfg = window["sap-ui-config"] || {};
 			oCfg.oninit = oCfg.oninit || oCfg["evt-oninit"];
 			for (var n in M_SETTINGS) {
-				if ( oCfg.hasOwnProperty(n.toLowerCase()) ) {
-					setValue(n, oCfg[n.toLowerCase()]);
-				} else if ( !/^xx-/.test(n) && oCfg.hasOwnProperty("xx-" + n.toLowerCase()) ) {
-					setValue(n, oCfg["xx-" + n.toLowerCase()]);
+				if ( oCfg.hasOwnProperty(n) ) {
+					setValue(n, oCfg[n]);
+				} else if ( !/^xx-/.test(n) && oCfg.hasOwnProperty("xx-" + n) ) {
+					setValue(n, oCfg["xx-" + n]);
 				}
 			}
 


### PR DESCRIPTION
Hi,

I just noticed that different to the docs https://openui5.hana.ondemand.com/docs/guide/91f2d03b6f4d1014b6dd926db0e91070.html at the moment options are read as lowercase options from the global Configuration object .
This leads to the situation that the following option (which is set before bootstrapping) will not work:
```js
window["sap-ui-config"] = {
    "xx-bindingSyntax": 'complex'    // doesn't work
};
```
Instead at the moment one has to specifcy the options in lowercase letters, different to the script params, which is really weird and not as documented.
```js
window["sap-ui-config"] = {
    "xx-bindingsyntax": 'complex'   // inconsintent and not as documented
};
```

In fact it took me more than 1 hour to get my [opa tests running in karma](https://github.com/SAP/karma-openui5/issues/1) because I couldn't activate the complex binding syntax. I was only able to resolve resolve the problem by looking at ui5's source code.

This pull request fixes that behaviour and reads the params as they are documented (and like in the script tag params).