### PR TITLE
run tests directly in travis' firefox browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: node_js
 
 node_js:
-  - "0.10"
+  - "0.12"
 
 before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
   - npm install -g eslint
   - npm install -g grunt-cli
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "OpenUI5 Core & Runtime",
   "private": true,
   "scripts": {
-    "test": "grunt lint"
+    "test": "grunt lint test --browsers=\"firefox\""
   },
   "keywords": [
     "openui5",


### PR DESCRIPTION
As you can see the build is still failing, so I don't expect this to be merged. Nevertheless I think it would be useful when someone would complete this so that not only eslint but also the tests are ran as part of the ci build. Might make sense to integrate this also with coveralls.io and / or code climate. The review ninja colleagues might be able to help here (they're using those 2 services): https://github.com/reviewninja/review.ninja
