### PR TITLE
[FIX] grunt connect config - properly set default port

### DIFF
--- a/grunt/config/connect.js
+++ b/grunt/config/connect.js
@@ -2,16 +2,13 @@ var fs = require('fs');
 
 module.exports = function(grunt, config) {
 
-	// set default port
-	if (typeof grunt.option('port') !== 'number') {
-		grunt.option('port', 8080);
-	}
-
 	return {
 
 		options: {
-
-			port: '<%= grunt.option("port") %>',
+			// set default port
+			port: typeof grunt.option('port') === 'number' ? grunt.option('port') : 8080,
+			// use the next best port if specified port is already in use
+			useAvailablePort: true,
 			hostname: '*'
 
 		},

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2232,9 +2232,9 @@
       }
     },
     "grunt-contrib-connect": {
-      "version": "0.9.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-0.9.0.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-0.9.0.tgz",
+      "version": "0.10.1",
+      "from": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-0.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-0.10.1.tgz",
       "dependencies": {
         "connect": {
           "version": "2.28.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-compress": "^0.13.0",
     "grunt-contrib-concat": "^0.5.0",
-    "grunt-contrib-connect": "^0.9.0",
+    "grunt-contrib-connect": "^0.10.1",
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
on a mac `grunt test` previously failed with the following message:
```
Running "connect:src" (connect) task
Fatal error: port should be > 0 and < 65536: 0
```