### PR TITLE
Change logic to use http post when bUseBatch is true instead of false

### DIFF
--- a/src/sap.ui.core/src/sap/ui/model/odata/ODataModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/ODataModel.js
@@ -1893,7 +1893,7 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/model/Model', './ODataUtils', './Cou
 			oChangeHeader["Content-Type"] = "application/json";
 		}
 
-		if (sMethod == "MERGE" && !this.bUseBatch) {
+		if (sMethod == "MERGE" && this.bUseBatch) {
 			oChangeHeader["x-http-method"] = "MERGE";
 			sMethod = "POST";
 		}

--- a/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
@@ -2690,7 +2690,7 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/model/Model', 'sap/ui/model/odata/OD
 		}
 
 		// format handling
-		if (sMethod === "MERGE" && !this.bUseBatch) {
+		if (sMethod === "MERGE" && this.bUseBatch) {
 			mHeaders["x-http-method"] = "MERGE";
 			sMethod = "POST";
 		}


### PR DESCRIPTION
[Fix] sap.ui.model.odata(.v2).ODataModel: all requests are post when not using batch

The odata model is currently changing all requests to a http POST when bUseBatch is false. This commit reverses this logic so when bUseBatch is false the original http method (MERGE, PUT) is used.
 
I hereby declare to agree to the OpenUI5 Individual Contributor License Agreement
Can create pull-requests for 1.26 and 1.28 if desired. 