### PR TITLE
[FIX] IconTabBar - bubble IconTabHeader selectedKey update up to parent ...

### DIFF
--- a/src/sap.m/src/sap/m/IconTabHeader.js
+++ b/src/sap.m/src/sap/m/IconTabHeader.js
@@ -317,6 +317,9 @@ sap.ui.define(['jquery.sap.global', './library', 'sap/ui/core/Control', 'sap/ui/
 		var sSelectedKey = this.oSelectedItem._getNonEmptyKey();
 		this.oSelectedItem = oItem;
 		this.setProperty("selectedKey", sSelectedKey, true);
+		if (this.getParent() instanceof sap.m.IconTabBar) {
+			this.getParent().setProperty("selectedKey", sSelectedKey, true);
+		}
 
 		if (!bAPIchange) {
 			// fire event on iconTabBar


### PR DESCRIPTION
When the IconTabHeader is created internally as part of the IconTabBar, the 'selectedKay' value is passed down from the IconTabBar to the IconTabHeader; however, the model binding is not correctly attached to this property on the IconTabHeader.  In order for the model to be updated when a new tab is selected, the update must be bubbled up from the IconTabHeader to the IconTabBar.