### PR TITLE
implement global window.onerror handler

### DIFF
--- a/grunt/config/concat.js
+++ b/grunt/config/concat.js
@@ -19,6 +19,7 @@ module.exports = function(grunt, config) {
 				footer: 'if (!window["sap-ui-debug"]) { jQuery.sap.preloadModules("sap.ui.core.library-preload", false); } jQuery.sap.require("sap.ui.core.Core"); sap.ui.getCore().boot && sap.ui.getCore().boot();'
 			},
 			src: [
+				sSourcesFolder + 'sap/ui/core/globalErrorHandler.js',
 				sSourcesFolder + 'sap/ui/Device.js',
 				sSourcesFolder + 'sap/ui/thirdparty/URI.js',
 				sSourcesFolder + 'sap/ui/thirdparty/es6-promise.js',
@@ -31,6 +32,7 @@ module.exports = function(grunt, config) {
 				footer:  '<%= concat.coreNoJQueryJS.options.footer %>'
 			},
 			src: [
+				sSourcesFolder + 'sap/ui/core/globalErrorHandler.js',
 				sSourcesFolder + 'sap/ui/thirdparty/jquery.js',
 				sSourcesFolder + 'sap/ui/thirdparty/jqueryui/jquery-ui-position.js',
 				'<%= concat.coreNoJQueryJS.src %>'

--- a/src/sap.m/src/sap/m/ErrorDialog.js
+++ b/src/sap.m/src/sap/m/ErrorDialog.js
@@ -1,0 +1,146 @@
+/*!
+ * ${copyright}
+ */
+sap.ui.define(['jquery.sap.global', './Dialog', './Button', './Label', './TextArea', './library'],
+	function(jQuery, Dialog, Button, Label, TextArea, library) {
+	"use strict";
+
+	/**
+	 * Constructor for a new ErrorDialog.
+	 *
+	 * @param {string} [sId] id for the new control, generated automatically if no id is given
+	 * @param {object} [mSettings] initial settings for the new control
+	 *
+	 * An ErrorDialog is a dialog containing error information and a close button.
+	 *
+	 * The error information is displayed in a textarea and is mostly the stack-trace of the error.
+	 * The textarea can be hidden and shown.
+	 *
+	 * This control is used by the global error handler when window.onerror is invoked by an unchecked exception.
+	 *
+	 * @author Jonathan Brink (Jonathan.Brink@sas.com)
+	 * @version ${version}
+	 *
+	 * @class
+	 * @constructor
+	 * @public
+	 */
+	var ErrorDialog = Dialog.extend("sap.m.ErrorDialog", /** @lends sap.m.ErrorDialog.prototype */ {
+		metadata: {
+			library: "sap.m",
+			properties: {
+				/**
+				 * The error text that appears in the textarea
+				 */
+				message: {type: "string", group: "Appearance", defaultValue: ""}
+			},
+			associations: {
+				/**
+				 * generic message label ("An error occurred...")
+				 */
+				label: {type: "sap.m.Label"},
+
+				/**
+				 * holds error details (stack-trace, etc)
+				 */
+				textArea: {type: "sap.m.TextArea"}
+			}
+		},
+		renderer: {}
+	});
+
+	/**
+	 * Initializes the control
+	 * @private
+	 */
+	ErrorDialog.prototype.init = function () {
+		var self = this,
+			sId = this.getId(),
+			bundle = sap.ui.getCore().getLibraryResourceBundle("sap.m"),
+			oTextArea = new TextArea({
+				id: sId + "-textarea",
+				editable: false,
+				visible: false,
+				width: "100%",
+				rows: 10
+			}),
+			oBeginButton = new Button({
+				id: sId + "-beginButton",
+				text: bundle.getText("MSGBOX_CLOSE"),
+				press: function() {
+					self.close();
+				}
+			}),
+			oEndButton = new Button({
+				id: sId + "-endButton",
+				text: bundle.getText("ERRORDIALOG_SHOW"),
+				press: function() {
+					self._toggleTextarea();
+				}
+			}),
+			oGenericMessageLabel = new Label({
+				id: sId + "-genericMessageLabel",
+				text: bundle.getText("ERRORDIALOG_GENERICMESSAGE")
+			});
+
+		// invoke super function
+		if (Dialog.prototype.init) {
+			Dialog.prototype.init.apply(this, arguments);
+		}
+
+		// set title of ErrorDialog
+		this.setTitle(window.__sap.title || bundle.getText("ERRORDIALOG_TITLE"));
+
+		// add sub-controls to ErrorDialog
+		this.addContent(oGenericMessageLabel);
+		this.addContent(oTextArea);
+		this.setBeginButton(oBeginButton);
+		this.setEndButton(oEndButton);
+
+		// keep references to sub-controls in associations
+		this.setLabel(oGenericMessageLabel);
+		this.setTextArea(oTextArea);
+
+		this.addStyleClass("sapMErrorDialog");
+
+		this.attachAfterClose(function() {
+			self.destroy();
+		});
+
+		this.setState(sap.ui.core.ValueState.Error);
+	};
+
+	/**
+	 * Overridden setter for "message" property.
+	 * Pass message to textarea
+	 * @param {string} sMessage The message that will be displayed in the textarea
+	 * @public
+	 */
+	ErrorDialog.prototype.setMessage = function(sMessage) {
+		var oTextArea = sap.ui.getCore().byId(this.getTextArea());
+		this.setProperty("message", sMessage, true);
+		oTextArea.setValue(sMessage);
+	};
+
+	/**
+	 * Toggle visibility of textarea.
+	 * @private
+	 */
+	ErrorDialog.prototype._toggleTextarea = function() {
+		var bundle = sap.ui.getCore().getLibraryResourceBundle("sap.m"),
+			oTextArea = sap.ui.getCore().byId(this.getTextArea()),
+			oEndButton = this.getEndButton();
+
+		// toggle visibity and button labels
+		if (oTextArea.getVisible() === true) {
+			oTextArea.setVisible(false);
+			oEndButton.setText(bundle.getText("ERRORDIALOG_SHOW"));
+		} else {
+			oTextArea.setVisible(true);
+			oEndButton.setText(bundle.getText("ERRORDIALOG_HIDE"));
+		}
+	};
+
+	return ErrorDialog;
+
+}, /* bExport= */ true);

--- a/src/sap.m/src/sap/m/messagebundle.properties
+++ b/src/sap.m/src/sap/m/messagebundle.properties
@@ -822,3 +822,15 @@ NOTIFICATION_LIST_ITEM_SHOW_MORE=Show more
 
 #XBUT: Button text for collapsing a Notification List Item
 NOTIFICATION_LIST_ITEM_SHOW_LESS=Show less
+
+#XBUT: Text of Show/Hide details button when details are hidden
+ERRORDIALOG_SHOW=Show Details
+
+#XBUT: Text of Show/Hide details button when details are shown
+ERRORDIALOG_HIDE=Hide Details
+
+#YMSG: Text above error details for error dialog
+ERRORDIALOG_GENERICMESSAGE=An error occurred. Please contact your system administrator.
+
+#XTIT: Title text of error dialog
+ERRORDIALOG_TITLE=Error

--- a/src/sap.ui.core/src/sap/ui/core/Configuration.js
+++ b/src/sap.ui.core/src/sap/ui/core/Configuration.js
@@ -122,6 +122,7 @@ sap.ui.define(['jquery.sap.global', '../Device', '../Global', '../base/Object', 
 					"xx-suppressDeactivationOfControllerCode" : { type : "boolean",  defaultValue : false }, //temporarily to suppress the deactivation of controller code in design mode
 					"xx-lesssupport"        : { type : "boolean",  defaultValue : false },
 					"xx-handleValidation"   : { type : "boolean",  defaultValue : false },
+					"xx-enableGlobalErrorHandler" : { type : "boolean",  defaultValue : false },
 					"statistics"            : { type : "boolean",  defaultValue : false }
 			};
 
@@ -1096,6 +1097,24 @@ sap.ui.define(['jquery.sap.global', '../Device', '../Global', '../base/Object', 
 				this._oCore && this._oCore.fireLocalizationChanged(mChanges);
 				delete this.mChanges;
 			}
+		},
+
+		/**
+		 * Flag to turn on global error handling support (window.onerror)
+		 *
+		 * @returns {boolean} enableGlobalErrorHandler mode
+		 * @private
+		 */
+		getEnableGlobalErrorHandler : function() {
+			return this["xx-enableGlobalErrorHandler"];
+		},
+
+		/**
+		 * set Flag to turn on global error handling support (window.onerror)
+		 * @private
+		 */
+		setEnableGlobalErrorHandler : function(bValue) {
+			this["xx-enableGlobalErrorHandler"] = !!bValue;
 		},
 
 		/**

--- a/src/sap.ui.core/src/sap/ui/core/globalErrorHandler.js
+++ b/src/sap.ui.core/src/sap/ui/core/globalErrorHandler.js
@@ -1,0 +1,241 @@
+(function() {
+	"use strict";
+
+// ========================================================================
+// inline resource bundle
+// ========================================================================
+var error_message = {
+	"en-US": "An error occurred. Please contact your system administrator.",
+	"fr": "Une erreur est survenue. Veuillez contacter votre administrateur système.",
+	"it": "Rilevato un errore. Contattare l'amministratore del sistema.",
+	"de": "Es ist ein Fehler aufgetreten. Wenden Sie sich an Ihren Systemadministrator.",
+	"es": "Se produjo un error. Debe ponerse en contacto con el administrador del sistema.",
+	"pl": "Wystąpił błąd. Zwróć się do administratora systemu.",
+	"ru": "Произошла ошибка. Пожалуйста, свяжитесь со своим системным адмнистратором.",
+	"ja": "エラーが発生しました。システム管理者に連絡してください。",
+	"ko": "오류가 발생했습니다. 시스템 관리자에게 문의하십시오.",
+	"zh-CN": "出现错误。请联系您的系统管理员。",
+	"zh-TW": "發生錯誤。請連絡您的系統管理員。",
+	"th": "มีข้อผิดพลาดเกิดขึ้น โปรดติดต่อผู้ดูแลระบบของคุณ",
+	"ar": "حدث خطأ. يرجى الاتصال بمدير نظامك.",
+	"cs": "Došlo k chybě. Obraťte se na správce systému.",
+	"da": "Der er opstået en fejl. Kontakt systemadministratoren.",
+	"el": "Παρουσιάστηκε σφάλμα. Επικοινωνήστε με το διαχειριστή του συστήματος.",
+	"hr": "Došlo je do pogreške. Obratite se administratoru sustava.",
+	"fi": "Tapahtui virhe. Ota yhteyttä järjestelmän ylläpitäjään.",
+	"hu": "Hiba lépett fel. Forduljon a rendszergazdához.",
+	"iw": "התרחשה שגיאה. פנה למנהל המערכת",
+	"nl": "Er is een fout opgetreden. Neem contact op met de systeembeheerder.",
+	"no": "Det oppstod en feil. Ta kontakt med systemadministratoren.",
+	"pt": "Ocorreu um erro. Contacte o administrador do sistema.",
+	"pt-BR": "Ocorreu um erro. Contate o administrador do sistema.",
+	"sk": "Vyskytla sa chyba. Obráťte sa na správcu systému.",
+	"sl": "Prišlo je do napake. Obrnite se na skrbnika sistema.",
+	"sr": "Došlo je do greške. Obratite se administratoru sistema.",
+	"sh": "Došlo je do greške. Obratite se administratoru sistema.",
+	"sv": "Ett fel uppstod. Kontakta systemansvarig.",
+	"tr": "Bir hata oluştu. Lütfen sistem yöneticinizle görüşün.",
+	"uk": "Сталася помилка. Зверніться до системного адміністратора."
+};
+error_message["default"] = error_message["en-US"];
+
+var
+	// original onError function, for chaining
+	fnOnError = window.onerror,
+
+	// parsed error message from window.onError
+	sErrorContent,
+
+	sNativeDialogId = "ErrorDialog_native";
+
+// attempt to use standard jQuery.sap.log,
+// if that fails, just write to console
+function _safeLog(type, sMessage) {
+	try {
+		jQuery.sap.log[type](sMessage);
+	} catch (e) {
+		if (type === "warning") {
+			type = "warn";
+		}
+		// since the framework may not be booted yet, directly use console statement
+		/*eslint-disable */
+		if (console && typeof console.log === "function") {
+			console[type](sMessage);
+		}
+		/*eslint-enable */
+	}
+}
+
+// Create a native js error dialog
+function _createAndOpenNativeDialog() {
+	var
+		// outer height and width (px)
+		iDivHeight = 300, iDivWidth = 275,
+
+		// dom elements
+		domContextNode, domOuterDiv, domTextarea, domCloseButton, domStyleElement,
+
+		// get text based on browser locale
+		sDialogTitle = (function() {
+			var userLang = navigator.language || navigator.userLanguage;
+			return error_message[userLang] || error_message["default"];
+		}());
+
+	// create dom elements that make up the dialog
+	domOuterDiv = document.createElement("div");
+	domOuterDiv.id = sNativeDialogId;
+	domOuterDiv.innerHTML = sDialogTitle;
+
+	domTextarea = document.createElement("textarea");
+	domTextarea.readOnly = true;
+	domTextarea.innerHTML = sErrorContent;
+
+	domCloseButton = document.createElement("button");
+	domCloseButton.appendChild(document.createTextNode("x"));
+	domCloseButton.setAttribute("aria-label", "Close message window");
+
+	// create style node in head tag to style the dialog
+	domStyleElement = document.createElement("STYLE");
+	domStyleElement.appendChild(document.createTextNode("#" + sNativeDialogId + " {" +
+		"z-index: 998;background-color: white;" +
+		"width: " + iDivWidth + "px;height: " + iDivHeight + "px;" +
+		"border: 1px solid black;padding: 15px;" +
+		"margin-top: " + ((iDivHeight / 2) * -1) + "px;" +
+		"margin-left: " + ((iDivWidth / 2) * -1) + "px;" +
+		"position: fixed;top: 50%;left: 50%;" +
+	"}"));
+	domStyleElement.appendChild(document.createTextNode("#" + sNativeDialogId + " textarea {" +
+		"z-index: 999;width: 100%;" +
+		"margin-top: 5px;resize: none;" +
+	"}"));
+	domStyleElement.appendChild(document.createTextNode("#" + sNativeDialogId + " > button {" +
+		"cursor: pointer;position: absolute;" +
+		"top: 0;right: 0;" +
+	"}"));
+
+	document.head.appendChild(domStyleElement);
+
+	// determine parent node of Dialog
+	domContextNode = document.getElementsByTagName("body");
+	if (domContextNode.length === 0) {
+		domContextNode = document.getElementsByTagName("html");
+	}
+
+	// place nodes in dom
+	domContextNode[0].appendChild(domOuterDiv);
+	setTimeout(function() {
+		domOuterDiv.appendChild(domTextarea);
+		domOuterDiv.appendChild(domCloseButton);
+		// set height dynamically
+		domTextarea.style.height = (iDivHeight - 55) + "px";
+	}, 0);
+
+	// close button event handler
+	domCloseButton.addEventListener("click", function() {
+		domOuterDiv.remove();
+	});
+
+    // invoke post-invocation hook
+	if (typeof window.__sap.postGlobalErrorHandlerInvocation === "function") {
+		window.__sap.postGlobalErrorHandlerInvocation(sNativeDialogId);
+	}
+}
+
+// define __sap namespace
+// __sap is used as the namespace for the globalErrorHandler function
+// so it can be accessed since the sap namespace may not yet be defined
+if (window.__sap === undefined) {
+	window.__sap = {};
+	window.__sap.error_message = error_message;
+}
+
+// define globalErrorHandler
+window.__sap.globalErrorHandler = function(oError) {
+	var oErrorDialog;
+
+	// if the error dialog already present, just throw error
+	if (document.getElementById(sNativeDialogId) || document.getElementsByClassName("sapMErrorDialog").length > 0) {
+		throw oError;
+	}
+
+	// attempt to create and open a sap.m.ErrorDialog
+	// if sap dialog fails, render native dialog
+	try {
+		jQuery.sap.require("sap.m.ErrorDialog");
+		oErrorDialog = new sap.m.ErrorDialog({
+			message: sErrorContent
+		});
+		oErrorDialog.attachAfterOpen(function() {
+			if (typeof window.__sap.postGlobalErrorHandlerInvocation === "function") {
+				window.__sap.postGlobalErrorHandlerInvocation(oErrorDialog.getId());
+			}
+		});
+		oErrorDialog.open();
+	} catch (e) {
+		_safeLog("warning", "error while rendering global error dialog");
+		_createAndOpenNativeDialog();
+		throw e;
+	}
+
+	// still have the error dump to console per-usual
+	if (oError !== undefined && oError !== null && typeof oError !== "string") {
+		throw oError;
+	}
+};
+
+// parse default arguments from window.onerror
+window.__sap.parseErrorArgs = function(msg, url, line, col, error) {
+	var sContent = "";
+
+	if (typeof (msg) === "string") {
+		sContent = msg + "\n" + url + "\nline: " + line;
+	}
+	if (col) {
+		sContent += !col ? "" : "\ncol: " + col;
+	}
+	if (error && error.stack) {
+		sContent += "\n" + error.stack;
+	}
+	return sContent;
+};
+
+// chain window.onerror
+window.onerror = function(msg, url, line, col, error) {
+	function isEnabled() {
+		var bEnabled = false;
+		try {
+			bEnabled = sap.ui.getCore().getConfiguration().getEnableGlobalErrorHandler() === true;
+		} catch (e) {
+			_safeLog("warning", "unable to determine if global error handler is enabled.");
+		}
+		return bEnabled;
+	}
+
+	// chain onError
+	if (fnOnError) {
+		fnOnError.apply(this, arguments);
+	}
+
+	// exit if not enabled
+	if (isEnabled() !== true) {
+		return;
+	}
+
+	// IE11 propagates events like image.onerror differently
+	if (typeof msg !== "string") {
+		_safeLog("warning", "image.onerror fired?");
+		return;
+	}
+
+	// parse onerror arguments to generate error message
+	sErrorContent = window.__sap.parseErrorArgs(msg, url, line, col, error);
+
+	// invoke pre-invocation hook
+	if (typeof window.__sap.preGlobalErrorHandlerInvocation === "function") {
+		window.__sap.preGlobalErrorHandlerInvocation(arguments);
+	}
+
+	// invoke global error handler
+	window.__sap.globalErrorHandler.apply(this, [error]);
+};
+}());


### PR DESCRIPTION
Add globalErrorHandler before other JavaScript
content is loaded to catch any error.

A globalErrorHandler.js file is loaded by the grunt build
in concat.js which attaches a listener to window.onerror

If unchecked error occurs during bootup or when
the framework is not available, render a vanillaJS
error dialog. Handle i18n and css inline to keep
self-contained.

Otherwise, render an implementation of sap.m.Popup
with a textarea showing technical details of the error.