### PR TITLE
Fixes https://github.com/SAP/openui5/issues/439 

### DIFF
--- a/src/sap.ui.core/src/sap/ui/model/ClientListBinding.js
+++ b/src/sap.ui.core/src/sap/ui/model/ClientListBinding.js
@@ -118,7 +118,8 @@ sap.ui.define(['jquery.sap.global', './ChangeReason', './Filter', './FilterType'
 	 * @see sap.ui.model.ListBinding.prototype.sort
 	 */
 	ClientListBinding.prototype.sort = function(aSorters){
-		if (!aSorters) {
+		var aIndicesOld = this.aIndices.slice();
+        if (!aSorters) {
 			this.aSorters = null;
 			this.updateIndices();
 			this.applyFilter();
@@ -132,7 +133,9 @@ sap.ui.define(['jquery.sap.global', './ChangeReason', './Filter', './FilterType'
 		
 		this.bIgnoreSuspend = true;
 		
-		this._fireChange({reason: ChangeReason.Sort});
+		this._fireChange({reason: ChangeReason.Sort,
+                          aIndicesOld: aIndicesOld,
+                          aIndicesNew: this.aIndices.slice() });
 		// TODO remove this if the sorter event gets removed which is deprecated
 		this._fireSort({sorter: aSorters});
 		this.bIgnoreSuspend = false;
@@ -172,7 +175,8 @@ sap.ui.define(['jquery.sap.global', './ChangeReason', './Filter', './FilterType'
 	 * @public
 	 */
 	ClientListBinding.prototype.filter = function(aFilters, sFilterType){
-		this.updateIndices();
+		var aIndicesOld = this.aIndices.slice();
+        this.updateIndices();
 		if (aFilters instanceof Filter) {
 			aFilters = [aFilters];
 		}
@@ -197,7 +201,9 @@ sap.ui.define(['jquery.sap.global', './ChangeReason', './Filter', './FilterType'
 		
 		this.bIgnoreSuspend = true;
 		
-		this._fireChange({reason: ChangeReason.Filter});
+		this._fireChange({reason: ChangeReason.Filter,
+                          aIndicesOld: aIndicesOld,
+                          aIndicesNew: this.aIndices.slice() });
 		// TODO remove this if the filter event gets removed which is deprecated
 		if (sFilterType == FilterType.Application) {
 			this._fireFilter({filters: this.aApplicationFilters});

--- a/src/sap.ui.core/src/sap/ui/model/SelectionModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/SelectionModel.js
@@ -328,6 +328,50 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/base/EventProvider'],
 		this._update(aSelectedIndices, iLeadIndex, aChangedRowIndices);
 		return this;
 	};
+    
+    /**
+     *Restores the selected indices after a sort or filter operation. 
+     * @param {Array} aIndicesOld indices before sort operation
+     * @param {Array} aIndicesNew indices after sort operation
+     * @return {sap.ui.model.SelectionModel} <code>this</code> to allow method chaining
+	 * @public
+    */
+    SelectionModel.prototype.restoreSelection = function(aIndicesOld, aIndicesNew) { 
+         var findNewIndex = function( iSelIndexOld ) {
+            if (iSelIndexOld >= aIndicesOld.length){ return -1; }
+                
+            var iObj = aIndicesOld[iSelIndexOld];
+            var found = false;
+            var i = 0;
+            while(found === false && i < aIndicesNew.length){
+                if(aIndicesNew[i] === iObj) {
+                    found = true;
+                } else {
+                    i++;
+                }
+            }
+            return (found === true) ? i : -1; 
+        }  
+        
+        aIndicesOld = aIndicesOld || [];
+        aIndicesNew = aIndicesNew || [];
+         
+        var aSelectedIndicesNew = [];
+        var iLeadIndexNew = -1;
+        
+        for(var i = 0; i < this.aSelectedIndices.length; i++) {
+            var selectedIndexNew = findNewIndex( this.aSelectedIndices[i] );
+            if( selectedIndexNew !== -1 ) {
+               aSelectedIndicesNew.push( selectedIndexNew ); 
+               if( this.aSelectedIndices[i] === this.iLeadIndex ) {
+                 iLeadIndexNew = selectedIndexNew;
+               }
+            }
+        }
+        
+        this._update(aSelectedIndicesNew.sort(this.fnSort), iLeadIndexNew, [] );
+        return this;        
+    };
 	
 	/**
 	 * Slices a the indices between the two indices from the selection.

--- a/src/sap.ui.table/src/sap/ui/table/Table.js
+++ b/src/sap.ui.table/src/sap/ui/table/Table.js
@@ -82,6 +82,11 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/Control', 'sap/ui/core/Interval
 			 * how the selection can be extended. It may also influence the visual appearance.
 			 */
 			selectionMode : {type : "sap.ui.table.SelectionMode", group : "Behavior", defaultValue : sap.ui.table.SelectionMode.Multi},
+            
+            /**
+			 * Flag whether selected columns will be restored after a sort or filter operation
+			 */
+			selectionRestoration : {type : "boolean", group : "Behavior", defaultValue : false},
 
 			/**
 			 * Selection behavior of the Table. This property defines whether the row selector is displayed and whether the row, the row selector or both
@@ -1116,7 +1121,13 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/Control', 'sap/ui/core/Interval
 	Table.prototype._onBindingChange = function(oEvent) {
 		var sReason = typeof (oEvent) === "object" ? oEvent.getParameter("reason") : oEvent;
 		if (sReason === "sort" || sReason === "filter") {
-			this.clearSelection();
+            if(this.getSelectionRestoration() === true) {
+                var aIndicesOld = typeof (oEvent) === "object" ? oEvent.getParameter("aIndicesOld") : [];
+                var aIndicesNew = typeof (oEvent) === "object" ? oEvent.getParameter("aIndicesNew") : [];     
+			    this._oSelection.restoreSelection(aIndicesOld, aIndicesNew);
+            } else {
+                this.clearSelection();
+            }
 			this.setFirstVisibleRow(0);
 		}
 	};

--- a/src/sap.ui.table/test/sap/ui/table/Table.html
+++ b/src/sap.ui.table/test/sap/ui/table/Table.html
@@ -276,7 +276,8 @@
 	aData[100].lastName = "Multi\nLine";
 
 	var oTable = new sap.ui.table.Table("table", {
-		firstVisibleRow: 5
+		firstVisibleRow: 5,
+        selectionRestoration: true
 	});
 
 	oTable.setTitle("Title of the Table");


### PR DESCRIPTION
I hereby declare to agree to the OpenUI5 Individual Contributor License Agreement.

This fix allows to keep the selected rows of a table selected after a sort or filter operation.
The idea is to restore the selected indices in the selection model by comparing how the indices of the ClientListBinding changed.

The new behaviour can be turned on using the boolean property "selectionRestoration".
 