### PR TITLE
Update: DateFormat.js for weekInYear

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/format/DateFormat.js
+++ b/src/sap.ui.core/src/sap/ui/core/format/DateFormat.js
@@ -413,6 +413,16 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/LocaleData', 'sap/ui/core/date/
 					if (oDate.getWeek) {
 						sWeek += oDate.getWeek();
 					}
+					else{
+						//define getWeek function
+						Date.prototype.getWeek = function () {
+						    var d = new Date(+this);
+						    d.setHours(0, 0, 0);
+						    d.setDate(d.getDate() + 4 - (d.getDay() || 7));
+						    return Math.ceil((((d - new Date(d.getFullYear(), 0, 1)) / 8.64e7) + 1) / 7);
+						};
+						sWeek += oDate.getWeek();
+					}
 					aBuffer.push(jQuery.sap.padLeft(sWeek, "0", oPart.iDigits));
 					break;
 				case "hour0_23":


### PR DESCRIPTION
pattern "w" will not work since getWeek is not defined.
http://stackoverflow.com/questions/31315940/how-to-select-a-calendar-week-in-sapui5/31333741

Working solution http://jsbin.com/biraxisaxa/3/edit?html,output