### PR TITLE
[FEATURE] sap.ui.core.EventBus: Add subscribeOnce method

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/EventBus.js
+++ b/src/sap.ui.core/src/sap/ui/core/EventBus.js
@@ -71,6 +71,41 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/base/Object', 'sap/ui/base/EventProv
 	};
 	
 	/**
+	 * Attaches an one time event handler to the event with the given identifier on the given event channel.
+	 *
+	 * @param {string}
+	 *            [sChannelId] The channel of the event to subscribe to once. If not given, the default channel is used.
+	 *                         The channel <code>"sap.ui"</code> is reserved by the UI5 framework. An application might listen to
+	 *                         events on this channel but is not allowed to publish its own events there.
+	 * @param {string}
+	 *            sEventId The identifier of the event to listen for
+	 * @param {function}
+	 *            fnFunction The handler function to call when the event occurs. This function will be called in the context of the
+	 *                       <code>oListener</code> instance (if present) or on the event bus instance. The channel is provided as first argument of the handler, and
+	 *                       the event identifier is provided as the second argument. The parameter map carried by the event is provided as the third argument (if present).
+	 *                       Handlers must not change the content of this map.
+	 * @param {object}
+	 *            [oListener] The object that wants to be notified when the event occurs (<code>this</code> context within the
+	 *                        handler function). If it is not specified, the handler function is called in the context of the event bus.
+	 * @return {sap.ui.core.EventBus} Returns <code>this</code> to allow method chaining
+	 * @public
+	 */
+	EventBus.prototype.subscribeOnce = function(sChannelId, sEventId, fnFunction, oListener){
+		if (typeof (sEventId) === "function") {
+			oListener = fnFunction;
+			fnFunction = sEventId;
+			sEventId = sChannelId;
+			sChannelId = null;
+		}
+		
+		function fnOnce() {
+			this.unsubscribe(sChannelId, sEventId, fnOnce, undefined); // 'this' is always the control, due to the context 'undefined' in the attach call below
+			fnFunction.apply(oListener || this, arguments);
+		}
+		return this.subscribe(sChannelId, sEventId, fnOnce, undefined); // a listener of 'undefined' enforce a context of 'this' in fnOnce
+	};
+	
+	/**
 	 * Removes a previously subscribed event handler from the event with the given identifier on the given event channel.
 	 *
 	 * The passed parameters must match those used for registration with {@link #subscribe } beforehand!

--- a/src/sap.ui.core/test/sap/ui/core/qunit/EventBus.qunit.html
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/EventBus.qunit.html
@@ -95,6 +95,49 @@
 			ok(!oBus._mChannels[sChannelId], "Unused Channel is cleaned up.");
 		});
 		
+		module("SubscribeOnce");
+		
+		test("Default channel", 4, function(){
+			var sEventId = "Test3";
+			checkNumberOfListeners(oBus._defaultChannel, sEventId, 0);
+			
+			// two listener subscribeOnce to the same event:
+			var fHandler1 = function(){};
+			oBus.subscribeOnce(sEventId, fHandler1);
+			checkNumberOfListeners(oBus._defaultChannel, sEventId, 1);
+			
+			var fHandler2 = function(){};
+			var oObj2 = {};
+			oBus.subscribeOnce(sEventId, fHandler2, oObj2);
+			checkNumberOfListeners(oBus._defaultChannel, sEventId, 2);
+			
+			oBus.publish(sEventId);
+
+			// after publish they should not be registered anymore
+			checkNumberOfListeners(oBus._defaultChannel, sEventId, 0);
+		});
+		
+		test("Custom channel", 4, function(){
+			var sEventId = "Test4";
+			var sChannelId = "TestChannel4";
+			
+			checkNumberOfListeners(oBus._mChannels[sChannelId], sEventId, 0);
+			
+			// two listener subscribeOnce to the same event:
+			var fHandler1 = function(){};
+			oBus.subscribeOnce(sChannelId, sEventId, fHandler1);
+			checkNumberOfListeners(oBus._mChannels[sChannelId], sEventId, 1);
+			
+			var fHandler2 = function(){};
+			var oObj2 = {};
+			oBus.subscribeOnce(sChannelId, sEventId, fHandler2, oObj2);
+			checkNumberOfListeners(oBus._mChannels[sChannelId], sEventId, 2);
+			
+			oBus.publish(sChannelId, sEventId);
+
+			// after publish they should not be registered anymore
+			checkNumberOfListeners(oBus._mChannels[sChannelId], sEventId, 0);
+		});
 		
 		var oObj11, oObj13, oObj21, oObj23, fHandler11, fHandler12, fHandler13, fHandler14, fHandler21, fHandler22, fHandler23, fHandler24;
 		
@@ -183,6 +226,41 @@
 		
 		test("Custom Channel, no Listener, no Data", 4, function() {
 			oBus.publish("CustomChannel", "Test24");
+		});
+		
+		test("Default Channel (one time subscriber)", 5, function() {
+			var sTestEvent = "Event31";
+			var iCount = 0;
+			var that = this;
+			var oObj31 = {id : "Obj31"};
+			oBus.subscribeOnce(sTestEvent, function(sChannelId, sEventId, oData) {
+				iCount++;
+				equal(that, this, "Right scope");
+				equal(sChannelId, null, "Right ChannelId (Default Channel)");
+				equal(sEventId, sTestEvent, "Right EventId");
+				equal(oData, oObj31, "Right parameter object");
+			}, this);
+			oBus.publish(sTestEvent, oObj31);
+			oBus.publish(sTestEvent, oObj31);
+			equal(iCount, 1, "Handler is only called once");
+		});
+		
+		test("Custom Channel (one time subscriber)", 5, function() {
+			var sTestChannel = "Test31";
+			var sTestEvent = "Event31";
+			var iCount = 0;
+			var that = this;
+			var oObj31 = {id : "Obj31"};
+			oBus.subscribeOnce(sTestChannel, sTestEvent, function(sChannelId, sEventId, oData) {
+				iCount++;
+				equal(that, this, "Right scope");
+				equal(sChannelId, sTestChannel, "Right ChannelId");
+				equal(sEventId, sTestEvent, "Right EventId");
+				equal(oData, oObj31, "Right parameter object");
+			}, this);
+			oBus.publish(sTestChannel, sTestEvent, oObj31);
+			oBus.publish(sTestChannel, sTestEvent, oObj31);
+			equal(iCount, 1, "Handler is only called once");
 		});
 	</script>
 		  


### PR DESCRIPTION
The subscribeOnce method enables to add an one time event listener to
the EventBus. In situations where only one notification of an event is
required the subscriber does not have to unsubscribe itself anymore.

Change-Id: I85aabdd6f20bb63b89fa766efa41cee070a0adfc