### PR TITLE
[FIX] CompositeBinding: correct update order of partial bindings

### DIFF
--- a/src/sap.ui.core/src/sap/ui/base/ManagedObject.js
+++ b/src/sap.ui.core/src/sap/ui/base/ManagedObject.js
@@ -3168,7 +3168,7 @@ sap.ui.define([
 			if (aParts && aParts.length > 1) {
 				// composite binding: invalid when for any part the model has the same name (or updateall) and when the model instance for that part differs
 				for (i = 0; i < aParts.length; i++) {
-					if ( (bUpdateAll || aParts[i].model == sModelName) && !oBindingInfo.binding.aBindings[i].updateRequired(that.getModel(aParts[i].model)) ) {
+					if ( (bUpdateAll || aParts[i].model == sModelName) && !oBindingInfo.binding.updateRequired(that.getModel(aParts[i].model), i) ) {
 						return true;
 					}
 				}
@@ -3380,18 +3380,14 @@ sap.ui.define([
 				// update context in existing bindings
 				jQuery.each(this.mBindingInfos, function(sName, oBindingInfo) {
 					var oBinding = oBindingInfo.binding;
-					var aParts = oBindingInfo.parts,
-						i;
+					var aParts = oBindingInfo.parts;
 					if (!oBinding) {
 						return;
 					}
 					if (aParts && aParts.length > 1) {
 						// composite binding: update required  when a part use the model with the same name
-						for (i = 0; i < aParts.length; i++) {
-							if ( aParts[i].model == sModelName ) {
-								oBinding.aBindings[i].setContext(that.getBindingContext(aParts[i].model));
-							}
-						}
+						// provide the model for the context to update only the relevant parts
+						oBinding.setContext(that.getBindingContext(sModelName), oModel);
 					} else if (oBindingInfo.factory) {
 						// list binding: update required when the model has the same name (or updateall)
 						if ( oBindingInfo.model == sModelName) {

--- a/src/sap.ui.core/test/sap/ui/core/qunit/BindingParser.qunit.html
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/BindingParser.qunit.html
@@ -659,6 +659,51 @@
 		oModel.setProperty("/blue", true);
 		strictEqual(oIcon.getColor(), "*red*", "one time binding -> value unchanged");
 	});
+	
+	test("Expression binding: two one time bindings inside composite binding", function () {
+		var oModel = new sap.ui.model.json.JSONModel({color1: 'blue', color2: 'red'}),
+			oIcon = new sap.ui.core.Icon({models : oModel});
+		
+		oIcon.bindProperty("color", parse("*{:= ${/color1}}{:= ${/color2}}*"));
+		strictEqual(oIcon.getColor(), "*bluered*");
+		
+		oModel.setData({color1: 'black', color2: 'green'});
+		strictEqual(oIcon.getColor(), "*bluered*");
+	});
+	
+	test("Expression binding: one time binding inside composite binding with two models", function () {
+		var oModel1 = new sap.ui.model.json.JSONModel({color1: 'red'}),
+			oModel2 = new sap.ui.model.json.JSONModel({color2: 'blue'});
+			oIcon = new sap.ui.core.Icon();
+			
+		oIcon.setModel(oModel1, "model1");
+		
+		oIcon.bindProperty("color", parse("*{:= ${model1>/color1}}{= ${model2>/color2}}*"));
+		strictEqual(oIcon.getColor(), "");
+		
+		oModel1.setProperty("/color1", 'green');
+		strictEqual(oIcon.getColor(), "", "model2 not set yet");
+		
+		oIcon.setModel(oModel2, "model2");
+		strictEqual(oIcon.getColor(), "*greenblue*", "binding resolved for the first time");
+		
+		oModel1.setProperty("/color1", 'black');
+		strictEqual(oIcon.getColor(), "*greenblue*", "one time binding => value unchanged");
+		
+		oModel2.setProperty("/color2", 'white');
+		strictEqual(oIcon.getColor(), "*greenwhite*", "one time binding => only second binding resolved");
+	});
+	
+	test("Expression binding: binding order dependent expression", function () {
+		var oModel = new sap.ui.model.json.JSONModel(),
+			oIcon = new sap.ui.core.Icon({models : oModel});
+
+		oIcon.bindProperty("color", parse("{= ${/colors} ? ${/colors/color1} : 'none' }"));
+		strictEqual(oIcon.getColor(), "none");
+		
+		oModel.setData({colors: { color1: 'blue', color2: 'red'}});
+		strictEqual(oIcon.getColor(), "blue");
+	});
 
 	test("jQuery.proxy(..., oEnv.oContext)", function () {
 		var sBinding = "{path : '/', formatter : '.foo'}",

--- a/src/sap.ui.core/test/sap/ui/core/qunit/CalculatedFields.qunit.html
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/CalculatedFields.qunit.html
@@ -180,6 +180,35 @@
 		
 	});
 	
+	test("Composite Binding tests with formatter", function(){
+		setup();
+	
+		var fnFormatter = function(bDataIsAvailable, sName, sValue) {
+			if(bDataIsAvailable) {
+				return sName.length + ' (' + sValue + ')';
+			}
+			return 'Not available';
+		}
+	
+		oTxt.bindValue({
+			formatter: fnFormatter,
+			parts: [
+				{path: '/data'},
+				{path: '/data/text'},
+				{path: "/data/value", type: new sap.ui.model.type.Float()}
+			]
+		});
+		
+		var sValue = oTxt.getValue();
+		ok(sValue);
+		equals(sValue, "Not available");
+		
+		var oModel = sap.ui.getCore().getModel();
+		oModel.setData({ data: { text: "hello", value: 5 }});
+		sValue = oTxt.getValue();
+		equals(sValue, "5 (5)");
+	});
+	
 	test("Calculated fields model tests wrong path", function(){
 		setup();
 		oTxt.bindValue({

--- a/src/sap.ui.core/test/sap/ui/core/qunit/CompositeBinding.qunit.html
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/CompositeBinding.qunit.html
@@ -1,0 +1,344 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<!-- Initialization -->
+	<link rel="stylesheet" href="../../../../../resources/sap/ui/thirdparty/qunit.css" type="text/css" media="screen" />
+	<script type="text/javascript" src="../../../../../resources/sap/ui/thirdparty/qunit.js"></script>
+	<script type="text/javascript" src="../../../../../resources/sap/ui/qunit/qunit-junit.js"></script>
+	<script id="sap-ui-bootstrap" 
+		type="text/javascript"
+		src="../../../../../resources/sap-ui-core.js"
+		data-sap-ui-theme="sap_bluecrystal"
+		data-sap-ui-noConflict="true"
+		data-sap-ui-libs="sap.ui.commons"	
+		>
+	</script>
+	<script type="text/javascript" src="../../../../../resources/sap/ui/qunit/QUnitUtils.js"></script>
+	
+    <script language="javascript">
+
+	var oModel,
+		oModel2,
+		bindingInfo,
+		oTxt,
+		parse = sap.ui.base.ManagedObject.bindingParser;
+
+	function setup(){
+		
+		if (oTxt) {
+			oTxt.destroy();
+		}
+		
+		var testData = {
+	  		"data": {
+				"text": "Hello",
+				"value": 7
+			},
+			"data2": {
+				"text": "World!",
+				"value": 42
+			}
+		};
+		
+		var testData2 = {
+				"values":
+					[
+					 {"value" : 10},
+					 {"value" : 20},
+					 {"value" : 30}
+				]	
+		}
+		
+		bindingInfo = {
+			formatter: function(text, value) { return text + ': ' + value},
+			parts: ['/data/text', '/data/value']
+		};
+		
+		oModel = new sap.ui.model.json.JSONModel();
+		oModel.setData(testData);
+		oModel2 = new sap.ui.model.json.JSONModel();
+		oModel2.setData(testData2);
+
+		oTxt = new sap.ui.commons.TextField();
+		oTxt.placeAt("txt");
+	};
+
+	test("Test missing model", function(){
+		setup();
+		
+		oTxt.bindValue(bindingInfo);
+		
+		sValue = oTxt.getValue();
+		equals(sValue, '', 'no model set');
+		
+		oTxt.setModel(oModel);
+		sValue = oTxt.getValue();
+		equals(sValue, 'Hello: 7');
+	});
+	
+	test("Test missing context", function(){
+		setup();
+		
+		bindingInfo = {
+			formatter: function(text, value) { return text + ': ' + value},
+			parts: ['text', 'value']
+		};
+		
+		oTxt.bindValue(bindingInfo);
+		
+		sValue = oTxt.getValue();
+		equals(sValue, '', 'no context set');
+		
+		oTxt.bindElement('/data');
+		sValue = oTxt.getValue();
+		equals(sValue, '', 'no model set');
+		
+		oTxt.setModel(oModel);
+		sValue = oTxt.getValue();
+		equals(sValue, 'Hello: 7');
+	});
+	
+	test("Test adding/removing context with two models", function(){
+		setup();
+		
+		bindingInfo = {
+			formatter: function(text, value) { return text + ': ' + value},
+			parts: ['text', 'model2>value']
+		};
+		
+		oTxt.bindValue(bindingInfo);
+		
+		sValue = oTxt.getValue();
+		equals(sValue, '', 'no context set');
+		
+		oTxt.bindElement('/data');
+		sValue = oTxt.getValue();
+		equals(sValue, '', 'no model set');
+		
+		oTxt.setModel(oModel);
+		sValue = oTxt.getValue();
+		equals(sValue, '', 'second context and model missing');
+		
+		oTxt.bindElement('model2>/values/0');
+		sValue = oTxt.getValue();
+		equals(sValue, '', 'second model not set');
+		
+		oTxt.setModel(oModel2, 'model2')
+		sValue = oTxt.getValue();
+		equals(sValue, 'Hello: 10');
+		
+		oTxt.unbindElement();
+		sValue = oTxt.getValue();
+		equals(sValue, 'null: 10', 'unbound first model');
+		
+		oTxt.bindElement('/data2');
+		sValue = oTxt.getValue();
+		equals(sValue, 'World!: 10');
+	});
+	
+	test("Test changing models", function(){
+		setup();
+		
+		var oModel3 = new sap.ui.model.json.JSONModel();
+		oModel3.setData({ data: { text: 'new', value: 77 }});
+		
+		oTxt.setModel(oModel);
+		oTxt.setModel(oModel2, 'model2');
+		
+		bindingInfo = {
+			formatter: function(text, value) { return text + ': ' + value},
+			parts: ['text', 'model2>value']
+		};
+		
+		oTxt.bindValue(bindingInfo);
+		sValue = oTxt.getValue();
+		equals(sValue, 'null: null', 'no context set');
+		
+		oTxt.bindElement('/data');
+		oTxt.bindElement('model2>/values/1');
+		sValue = oTxt.getValue();
+		equals(sValue, 'Hello: 20');
+		
+		oTxt.setModel(null);
+		sValue = oTxt.getValue();
+		equals(sValue, 'Hello: 20');
+		
+		oTxt.setModel(oModel3);
+		sValue = oTxt.getValue();
+		equals(sValue, 'new: 20');
+	});
+	
+	test("Test changing models and contexts (bind/unbind)", function(){
+		setup();
+		
+		var oModel3 = new sap.ui.model.json.JSONModel();
+		oModel3.setData({ data: { text: 'new', value: 77 }});
+		
+		oTxt.setModel(oModel);
+		oTxt.setModel(oModel2, 'model2');
+		
+		bindingInfo = {
+			formatter: function(text, value) { return text + ': ' + value},
+			parts: ['text', 'model2>value']
+		};
+		
+		oTxt.bindValue(bindingInfo);
+		oTxt.bindElement('/data');
+		oTxt.bindElement('model2>/values/1');
+		sValue = oTxt.getValue();
+		equals(sValue, 'Hello: 20');
+		
+		oTxt.setModel(null);
+		oTxt.setModel(null, 'model2');
+		sValue = oTxt.getValue();
+		equals(sValue, 'Hello: 20', 'missing models: binding cannot be resolved');
+		
+		oTxt.unbindElement('model2');
+		sValue = oTxt.getValue();
+		equals(sValue, 'Hello: 20', 'missing models: binding cannot be resolved');
+		
+		oTxt.bindElement('model3>/fake');
+		oTxt.bindElement('model2>/values/0');
+		sValue = oTxt.getValue();
+		equals(sValue, 'Hello: 20', 'missing models: binding cannot be resolved');
+		
+		oModel2.setProperty('/values/0/value', 22);
+		
+		oTxt.setModel(oModel3);
+		oTxt.setModel(oModel2, 'model2');
+		sValue = oTxt.getValue();
+		equals(sValue, 'new: 22');
+	});
+
+	test("Continuos OneTime Binding test with several model and binding updates", function() {
+		setup();
+
+		var fnFormatter = function(bDataIsAvailable, sName, sValue) {
+			if(bDataIsAvailable) {
+				return sName + ' (' + sName.length + '): ' + sValue;
+			}
+			return 'Not available';
+		}
+
+		oTxt.setModel(oModel);
+		oTxt.setModel(oModel2, "model2");
+
+		oTxt.bindValue({
+			formatter: fnFormatter,
+			parts: [
+				{path: '/data'},
+				{path: '/data/text', mode: sap.ui.model.BindingMode.OneTime},
+				{path: '/data/value', type: new sap.ui.model.type.Float()}
+			]
+		});
+		
+		var sValue = oTxt.getValue();
+		equals(sValue, 'Hello (5): 7');
+		
+		oModel.setProperty('/data/text', 'ab');
+		sValue = oTxt.getValue();
+		equals(sValue, 'Hello (5): 7', 'OneTime binding is not updated');
+		
+		oModel.setData({ data: { text: 'abc', value: 0 }});
+		sValue = oTxt.getValue();
+		equals(sValue, 'Hello (5): 0', 'OneTime binding is still not updated');
+		
+		oTxt.bindValue({
+			formatter: fnFormatter,
+			parts: [
+				{path: 'text'},
+				{path: 'text', mode: sap.ui.model.BindingMode.OneTime},
+				{path: 'value', type: new sap.ui.model.type.Float()}
+			]
+		});
+		
+		sValue = oTxt.getValue();
+		equals(sValue, 'Not available', 'binding cannot be resolved without context');
+		
+		oTxt.bindElement('/data');
+		sValue = oTxt.getValue();
+		equals(sValue, 'abc (3): 0', 'initial values applied');
+		
+		oModel.setProperty('/data2', { text: 'abcd', value: 11 });
+		oTxt.bindElement('/data2');
+		sValue = oTxt.getValue();
+		equals(sValue, 'abc (3): 11', 'One Time binding is not updated on context change');
+		
+		oTxt.bindValue({
+			formatter: fnFormatter,
+			parts: [
+				{path: 'text'},
+				{path: 'text', mode: sap.ui.model.BindingMode.OneTime},
+				{path: 'model2>value', type: new sap.ui.model.type.Float(), mode: sap.ui.model.BindingMode.OneTime}
+			]
+		});
+		
+		sValue = oTxt.getValue();
+		equals(sValue, 'abcd (4): null', 'relative binding on model2 cannot be resolved yet');
+		
+		oTxt.bindElement('model2>/values/0');
+		sValue = oTxt.getValue();
+		equals(sValue, 'abcd (4): 10');
+		
+		oModel.setProperty('/data2/text', 'abcde')
+		oModel2.setProperty('/values/0/value', 8)
+		sValue = oTxt.getValue();
+		equals(sValue, 'abcd (4): 10', 'no value change due OneTime bindings');
+		
+		oTxt.bindValue({
+			formatter: fnFormatter,
+			parts: [
+				{path: '/data2'},
+				{path: '/data2/text'},
+				{path: 'model2>/values/0/value', type: new sap.ui.model.type.Float(), mode: sap.ui.model.BindingMode.OneTime}
+			]
+		});
+		
+		sValue = oTxt.getValue();
+		equals(sValue, 'abcde (5): 8');
+		
+		oModel2.setProperty('/values/0/value', 9);
+		sValue = oTxt.getValue();
+		equals(sValue, 'abcde (5): 8', 'One time binding for second value');
+		
+		oModel.setProperty('/data2/text', 'abcdef');
+		sValue = oTxt.getValue();
+		equals(sValue, 'abcdef (6): 8');
+		
+		oTxt.bindValue({
+			formatter: fnFormatter,
+			parts: [
+				{path: '/data2'},
+				{path: 'model3>/value'},
+				{path: 'model2>/values/0/value', type: new sap.ui.model.type.Float(), mode: sap.ui.model.BindingMode.OneTime}
+			]
+		});
+		
+		sValue = oTxt.getValue();
+		equals(sValue, 'abcdef (6): 8', 'binding cannot be resolved yet, the old value remains');
+		
+		var oModel3 = new sap.ui.model.json.JSONModel();
+		oModel3.setData({ value: '1234567890' });
+		oTxt.setModel(oModel3, 'model3');
+		sValue = oTxt.getValue();
+		equals(sValue, '1234567890 (10): 9', 'initial values applied');
+	});
+			
+	</script>
+  
+</head>
+<body>
+	<h1 id="qunit-header">QUnit tests: Composite Bindings</h1>
+	<h2 id="qunit-banner"></h2>
+ 	<h2 id="qunit-userAgent"></h2>
+	<div id="qunit-testrunner-toolbar"></div>
+	<ol id="qunit-tests"></ol>
+	<br>
+	<div id="uiArea1"></div>
+	<div id="txt"></div>
+	<br/>
+	
+	<!-- For details see Trac Ticket 1238 -->
+</body>
+</html>

--- a/src/sap.ui.core/test/sap/ui/core/qunit/testsuites/testsuite.databinding.qunit.html
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/testsuites/testsuite.databinding.qunit.html
@@ -51,6 +51,7 @@
 			suite.addTestPage(contextPath + "/test-resources/sap/ui/core/qunit/ODataMessages.qunit.html");
 			suite.addTestPage(contextPath + "/test-resources/sap/ui/core/qunit/V2ODataModelDataState.qunit.html");
 			suite.addTestPage(contextPath + "/test-resources/sap/ui/core/qunit/DataState.qunit.html");
+			suite.addTestPage(contextPath + "/test-resources/sap/ui/core/qunit/CompositeBinding.qunit.html");
 			return suite;
 		}
 		  


### PR DESCRIPTION
- this was caused by hiding the CompositeBinding itself but exposing the
  partial bindings to the model, therefore partial bindings were not managed by
  their CompositeBinding only
- with this fix the access to CompositeBinding parts is now restricted, they
  are not accessed directly but only through calls on CompositeBinding
- the CompositeBinding itself is added to the binding collection of a model if
  any part of it is bound to the model. All actions on a partial binding
  (e.g. update check, context change, ...)  are/should be    handled only by the
  CompositeBinding they are part of.

Fixes https://github.com/SAP/openui5/issues/642
