### PR TITLE
Spelling correction in docs at sap.ui.model/Filter.js

### DIFF
--- a/src/sap.ui.core/src/sap/ui/model/Filter.js
+++ b/src/sap.ui.core/src/sap/ui/model/Filter.js
@@ -52,7 +52,7 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/base/Object', './FilterOperator', 's
 	 * @param {function} oFilterInfo.test function which is used to filter the items which should return a boolean value to indicate whether the current item is preserved
 	 * @param {sap.ui.model.FilterOperator} oFilterInfo.operator operator used for the filter
 	 * @param {object} oFilterInfo.value1 first value to use for filter
-	 * @param {object} [oFilterInfo.value2=null] fecond value to use for filter
+	 * @param {object} [oFilterInfo.value2=null] second value to use for filter
 	 * @param {array} oFilterInfo.filters array of filters on which logical conjunction is applied
 	 * @param {boolean} oFilterInfo.and indicates whether an "and" logical conjunction is applied on the filters. If it's set to false, an "or" conjunction is applied
 	 * @public


### PR DESCRIPTION
Hi Team,

I observed a minor spelling mistake in docs (where second is spelled as fecond) at https://openui5.hana.ondemand.com/#docs/api/symbols/sap.ui.model.Filter.html

I believe it is a auto-generated documentation from
https://github.com/SAP/openui5/blob/master/src/sap.ui.core/src/sap/ui/model/Filter.js

I have made the necessary typo fix. I have initiated CLA process using https://cla-assistant.io/
Please let me know if there is any other thing needed from my end.

Regards,
Prabhat 