### PR TITLE
[INTERNAL][FIX] Travis CI: Switch to node v4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
+  - "4.2"
 
 before_script:
-  - npm install -g eslint
   - npm install -g grunt-cli
 
 branches:


### PR DESCRIPTION
- Switch to node LTS release 4.2
- Remove unused global dependency "eslint". ESlint will be called
within grunt (grunt-eslint task).