### PR TITLE
Make SorterProcessor's default comparator public

### DIFF
--- a/src/sap.ui.core/src/sap/ui/model/Sorter.js
+++ b/src/sap.ui.core/src/sap/ui/model/Sorter.js
@@ -78,6 +78,36 @@ sap.ui.define(['sap/ui/base/Object'],
 
 	});
 
+	/**
+	 * Default function used for comparing two values, accounting for null-ness and type.
+	 * This function is public for re-use in custom comparator functions.
+	 * @param {number|string} a sort value 1
+	 * @param {number|string} b sort value 2
+	 * @return {number} a value representing the result of the comparision. (0 for equal, 1 if a is greater, -1 if b is greater)
+	 * @public
+	 */
+	Sorter.defaultComparator = function(a, b) {
+		if (a == b) {
+			return 0;
+		}
+		if (b == null) {
+			return -1;
+		}
+		if (a == null) {
+			return 1;
+		}
+		if (typeof a == "string" && typeof b == "string") {
+			return a.localeCompare(b);
+		}
+		if (a < b) {
+			return -1;
+		}
+		if (a > b) {
+			return 1;
+		}
+		return 0;
+	};
+
 	return Sorter;
 
 });

--- a/src/sap.ui.core/src/sap/ui/model/SorterProcessor.js
+++ b/src/sap.ui.core/src/sap/ui/model/SorterProcessor.js
@@ -2,8 +2,8 @@
  * ${copyright}
  */
 
-sap.ui.define(['jquery.sap.global'],
-	function(jQuery) {
+sap.ui.define(['jquery.sap.global', './Sorter'],
+	function(jQuery, Sorter) {
 	"use strict";
 
 	/**
@@ -34,34 +34,12 @@ sap.ui.define(['jquery.sap.global'],
 			return aData;
 		}
 
-		function fnCompare(a, b) {
-			if (a == b) {
-				return 0;
-			}
-			if (b == null) {
-				return -1;
-			}
-			if (a == null) {
-				return 1;
-			}
-			if (typeof a == "string" && typeof b == "string") {
-				return a.localeCompare(b);
-			}
-			if (a < b) {
-				return -1;
-			}
-			if (a > b) {
-				return 1;
-			}
-			return 0;
-		}
-
 		for (var j = 0; j < aSorters.length; j++) {
 			oSorter = aSorters[j];
 			aCompareFunctions[j] = oSorter.fnCompare;
 
 			if (!aCompareFunctions[j]) {
-				aCompareFunctions[j] = fnCompare;
+				aCompareFunctions[j] = Sorter.defaultComparator;
 			}
 			/*eslint-disable no-loop-func */
 			jQuery.each(aData, function(i, vRef) {


### PR DESCRIPTION
For applications that define custom sorting comparator
functions it is useful to be able to invoke the default
comparator function that SorterProcessor uses internally.

Move this function to be a static to sap.ui.model.Sorter