### PR TITLE
Feature: Expression binding meets Control Binding

### DIFF
--- a/src/sap.ui.core/src/sap/ui/base/ManagedObject.js
+++ b/src/sap.ui.core/src/sap/ui/base/ManagedObject.js
@@ -8,12 +8,12 @@ sap.ui.define([
 		'./BindingParser', './DataType', './EventProvider', './ManagedObjectMetadata',
 		'../model/BindingMode', '../model/CompositeBinding', '../model/Context', '../model/FormatException', '../model/ListBinding',
 		'../model/Model', '../model/ParseException', '../model/TreeBinding', '../model/Type', '../model/ValidateException',
-		'jquery.sap.act', 'jquery.sap.script', 'jquery.sap.strings'
+	'../model/control/ControlModel', 'jquery.sap.act', 'jquery.sap.script', 'jquery.sap.strings'
 	], function(
 		jQuery,
 		BindingParser, DataType, EventProvider, ManagedObjectMetadata,
 		BindingMode, CompositeBinding, Context, FormatException, ListBinding,
-		Model, ParseException, TreeBinding, Type, ValidateException
+		Model, ParseException, TreeBinding, Type, ValidateException, ControlModel
 		/* , jQuerySap2, jQuerySap, jQuerySap1 */) {
 
 	"use strict";
@@ -3602,6 +3602,14 @@ sap.ui.define([
 	 */
 	ManagedObject.prototype.getModel = function(sName) {
 		jQuery.sap.assert(sName === undefined || (typeof sName === "string" && !/^(undefined|null)?$/.test(sName)), "sName must be a string or omitted");
+		// models prefixed with an "@" sign, are control models
+		if (typeof sName === "string" && sName.indexOf("@") === 0) {
+
+			var sId = sName.substring(1);
+			var control = sap.ui.getCore().byId(sId) || sId;
+
+			return new ControlModel(control);
+		}
 		return this.oModels[sName] || this.oPropagatedProperties.oModels[sName];
 	};
 

--- a/src/sap.ui.core/src/sap/ui/core/Control.js
+++ b/src/sap.ui.core/src/sap/ui/core/Control.js
@@ -101,6 +101,14 @@ sap.ui.define(['jquery.sap.global', './CustomStyleClassSupport', './Element', '.
 			Element.apply(this,arguments);
 			this.bOutput = this.getDomRef() != null; // whether this control has already produced output
 
+			// notify, that a control has been instantiated.
+			if (typeof sId === "object" && sId.hasOwnProperty("id")) {
+				sap.ui.getCore().getEventBus().publish("sap.ui.core.Control", "__created", {
+					id: sId.id,
+					control: this
+				});
+			}
+
 			if (this._sapUiCoreLocalBusy_initBusyIndicator) {
 				this._sapUiCoreLocalBusy_initBusyIndicator();
 			}

--- a/src/sap.ui.core/src/sap/ui/model/control/ControlModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/control/ControlModel.js
@@ -42,9 +42,9 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/model/Model', './ControlPropertyBind
 
 				// create fake control
 				oControl = sap.ui.getCore().byId(fakeId);
-				if(!oControl) {
+				if (!oControl) {
 					oControl = new sap.ui.core.Control(fakeId);
-					oControl.getProperty = $.noop;
+					oControl.getProperty = jQuery.noop;
 				}
 				/**
 				 * observer listens for created controls, to replace the fake control, when the

--- a/src/sap.ui.core/src/sap/ui/model/control/ControlModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/control/ControlModel.js
@@ -34,7 +34,51 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/model/Model', './ControlPropertyBind
 	var ControlModel = Model.extend("sap.ui.model.control.ControlModel", /** @lends sap.ui.model.control.ControlModel.prototype */ {
 		
 		constructor : function (oControl) {
-			Model.apply(this, arguments);
+			if (typeof oControl === 'string') {
+				var _this = this;
+				var eventBus = sap.ui.getCore().getEventBus();
+				var fakePrefix = 'FakeControl--';
+                var fakeId = fakePrefix + oControl;
+
+				// create fake control
+				oControl = sap.ui.getCore().byId(fakeId);
+				if(!oControl) {
+					oControl = new sap.ui.core.Control(fakeId);
+					oControl.getProperty = $.noop;
+				}
+				/**
+				 * observer listens for created controls, to replace the fake control, when the
+				 * real control is instantiated
+				 *
+				 * @param {string} channel
+                 * @param {string} event
+                 * @param {{id: string, control: sap.ui.core.Control}} data
+                 */
+				var controlCreatedObserver = function (channel, event, data) {
+					// check if current model is handling the corresponding fake control for the instantiated control
+					if (data.id === _this.oControl.getId().slice(fakePrefix.length) && typeof data.control === 'object') {
+						// destroy fake control, because we dont need it anymore
+						_this.oControl.destroy();
+
+						// assign the new real control instance
+						_this.oControl = data.control;
+
+						// switch existing bindings to new control
+						jQuery.each(_this.aBindings, function (index, binding) {
+							binding.oContext = _this.oControl;
+						});
+
+						// update value with new values from the real control
+						_this.oControl.attachEvent("_change", _this.checkUpdate, _this);
+						_this.checkUpdate();
+
+						// remove listener, because we now have the real control
+						eventBus.unsubscribe('sap.ui.core.Control', '__created', controlCreatedObserver);
+					}
+				};
+				eventBus.subscribe('sap.ui.core.Control', '__created', controlCreatedObserver);
+			}
+			Model.call(this, oControl);
 			this.oControl = oControl;
 			this.oControl.attachEvent("_change", this.checkUpdate, this);
 			this.oElements = [];

--- a/src/sap.ui.core/test/sap/ui/core/qunit/ExpressionParser.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/ExpressionParser.qunit.js
@@ -43,8 +43,9 @@ sap.ui.require([
 	 * @param {string} sTitle - test title
 	 * @param {object[]} aFixtures - the array of test fixtures
 	 * @param {function} [fnInit] - optional initializer function to e.g. set stubs
+	 * @param {function} [fnTearDown] optional tear down function to e.g. destroy stubs
 	 */
-	function checkFixtures(sTitle, aFixtures, fnInit) {
+	function checkFixtures(sTitle, aFixtures, fnInit, fnTearDown) {
 		aFixtures.forEach(function (oFixture) {
 			QUnit.test(sTitle + " : " + oFixture.expression + " --> " + oFixture.result,
 				function (assert) {
@@ -52,6 +53,10 @@ sap.ui.require([
 						fnInit(this); //call initializer with sandbox
 					}
 					check(assert, oFixture.expression, oFixture.result);
+
+					if (fnTearDown) {
+						fnTearDown(this); //call initializer with sandbox
+					}
 				}
 			);
 		});
@@ -603,6 +608,49 @@ sap.ui.require([
 		});
 		assert.strictEqual(oAverageSpy.callCount, 2, "parse start measurment");
 		assert.strictEqual(oEndSpy.callCount, 1, "parse end measurement - end not reached");
+	});
+
+
+	QUnit.module('Control Binding');
+
+	//*********************************************************************************************
+	checkFixtures('Control Binding', [{expression: "{=${@Fixture>text}}", result: "Foo"},
+		{expression: "{=${@Fixture>text} + 'Bar'}", result: "FooBar"}], function () {
+		new sap.ui.core.Title('Fixture', {
+			text: "Foo"
+		});
+	}, function () {
+		sap.ui.getCore().byId('Fixture').destroy();
+	});
+
+	//*********************************************************************************************
+	QUnit.test("Control Binding : Usage with absolute id resolution", function (assert) {
+		var parentView = sap.ui.xmlview("aggregate-control-binding", {
+			viewContent: '<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core">' +
+			'<core:Icon id="Fixture1" color="brown" />' +
+			'<core:Icon id="Fixture2" color="{=${@aggregate-control-binding--Fixture1>color}}" />' +
+			'</mvc:View>'
+		});
+		sap.ui.getCore().applyChanges();
+
+		assert.strictEqual(parentView.byId('Fixture2').getColor(), "brown");
+
+		parentView.destroy();
+	});
+
+	//*********************************************************************************************
+	QUnit.test("Control Binding : Binding with later instantiated controls shall also work", function (assert) {
+		var parentView = sap.ui.xmlview("aggregate-control-binding", {
+			viewContent: '<mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core">' +
+			'<core:Icon id="Fixture2" color="{=${@aggregate-control-binding--Fixture1>color}}" />' +
+			'<core:Icon id="Fixture1" color="brown" />' +
+			'</mvc:View>'
+		});
+		sap.ui.getCore().applyChanges();
+
+		assert.strictEqual(parentView.byId('Fixture2').getColor(), "brown");
+
+		parentView.destroy();
 	});
 
 });


### PR DESCRIPTION
Add possibility to bind one controls property to another controls property.

For example it is now possible to bind the pressed state of a ToggleButton to the enabled property of some form controls.
Therefor I added a new prefix @ for bindings, to mark a binding as a control binding. I have chosen the @ sign because it is mostly used within the same view to refer at other controls.
The Binding Path is therefor produced like that: {=${@ControlId>Property}}.
For example `<Input enabled='{=${@MyToggleButtonId>pressed}}'></Input>`

Currently id resolution is done by sap.ui.getCore().byId call and therefor only possible by setting an absolute id.
But if you like the feature and think about taking it over to one of your next releases, I can also try to implement a relative solution.

Some tests to show the behavior:
http://localhost:8080/testsuite/test-resources/sap/ui/core/qunit/ExpressionParser.qunit.html?sap-ui-debug=true&sap-ui-language=de-DE&sap-ui-theme=sap_bluecrystal&sap-ui-accessibility=true&sap-ui-jqueryversion=1.11.1&module=Control%20Binding

**A live demo of the feature may be found on jsfiddle: http://jsfiddle.net/hijolan/shcoqpue/170/**
