### PR TITLE
[FIX] sap.ui.table.Table: allow tab navigation in action mode

### DIFF
--- a/src/sap.ui.table/src/sap/ui/table/Table.js
+++ b/src/sap.ui.table/src/sap/ui/table/Table.js
@@ -4703,18 +4703,15 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/Control', 'sap/ui/core/ResizeHa
 	 *   <li>Navigation Mode:
 	 *      <ul>
 	 *          <li>If focus is on header: jump to the next focusable control before the table</li>
-	 *          <li>If focus in on content: jump to header for the current column</li>
+	 *          <li>If focus is on content: jump to header for the current column</li>
 	 *      </ul>
-	 *   <li>Action Mode: switch back to navigation mode</li>
+	 *   <li>Action Mode: do nothing, the browser moves focus</li>
 	 * </ul>
 	 * @private
 	 */
 	Table.prototype.onsaptabprevious = function(oEvent) {
 		var $this = this.$();
-		if (this._bActionMode) {
-			this._leaveActionMode();
-			oEvent.preventDefault();
-		} else {
+		if (!this._bActionMode) {
 			var oIN = this._oItemNavigation;
 			var bNoData = this.$().hasClass("sapUiTableEmpty");
 			var oSapUiTableCCnt = $this.find('.sapUiTableCCnt')[0];
@@ -4744,18 +4741,15 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/Control', 'sap/ui/core/ResizeHa
 	 *   <li>Navigation Mode:
 	 *      <ul>
 	 *          <li>If focus is on header: jump to the first data column of the focused column header</li>
-	 *          <li>If focus in on content: jump to the next focusable control after the table</li>
+	 *          <li>If focus is on content: jump to the next focusable control after the table</li>
 	 *      </ul>
-	 *   <li>Action Mode: switch back to navigation mode</li>
+	 *   <li>Action Mode: do nothing, the browser moves focus</li>
 	 * </ul>
 	 * @private
 	 */
 	Table.prototype.onsaptabnext = function(oEvent) {
 		var $this = this.$();
-		if (this._bActionMode) {
-			this._leaveActionMode();
-			oEvent.preventDefault();
-		} else {
+		if (!this._bActionMode) {
 			var oIN = this._oItemNavigation;
 			var bContainsColHdrCnt = jQuery.contains($this.find('.sapUiTableColHdrCnt')[0], oEvent.target);
 			var bNoData = this.$().hasClass("sapUiTableEmpty");


### PR DESCRIPTION
According to the documentation of `_enterActionMode`, "In the action mode the user can navigate through the interactive controls of the table by using the TAB & SHIFT-TAB."
Currently, `onsaptabnext` and `onsaptabprevious` are implemented and documented to return to navigation mode instead.

It is not clearly defined which solution is the intended behavior. To resolve this conflict, I suggest removing the code in the tab handlers to allow the native focus cycling to focus the next/previous control.