### PR TITLE
workaround on Windows Mobile to disable bouncing / overscroll

### DIFF
--- a/src/sap.m/src/sap/m/themes/base/Page.less
+++ b/src/sap.m/src/sap/m/themes/base/Page.less
@@ -67,6 +67,26 @@ html[data-sap-ui-os^="iOS7"][data-sap-ui-browser^="msf"]:not(.sap-tablet){
 	}
 }
 
+/*
+* workaround on Windows Mobile to disable bouncing / overscroll
+*/
+html[data-sap-ui-os^="winphone"][data-sap-ui-browser^="ie"] {
+	height: 100%;
+	width: 100%;
+	margin: 0;
+	-ms-scroll-translation: vertical-to-horizontal;
+	overflow: hidden;
+
+	body {
+		height: 100%;
+		width: 100%;
+		margin: 0;
+		-ms-scroll-translation: vertical-to-horizontal;
+		-ms-content-zooming: none;
+	}
+}
+
+
 /* ============================================= */
 /* CSS for displaying the Footer/Header controls at the correct position */
 /* ============================================= */


### PR DESCRIPTION
On Windows Mobile you can pull down the UI5 application and it will bounce back. This looks ugly and does not behave like a native app. This change will fix the bouncing on Windows 10 Mobile. I got it from the WinJS templates.