### PR TITLE
[FEATURE] sap.ui.qunit.qunit-coverage: Apply blanket includes

### DIFF
--- a/src/sap.ui.core/src/sap/ui/qunit/qunit-coverage.js
+++ b/src/sap.ui.core/src/sap/ui/qunit/qunit-coverage.js
@@ -65,10 +65,10 @@
 				if (jQuery && jQuery.sap) {
 					jQuery.sap.require._hook = function(sScript, sModuleName) {
 						// manage includes and excludes with blanket utils
-						var bFiltered = window.blanket.utils.matchPatternAttribute(sModuleName, window.blanket.options("filter"));
-						bFiltered &= !window.blanket.utils.matchPatternAttribute(sModuleName, window.blanket.options("anti-filter"));
+						var bFiltered = !window.blanket.utils.matchPatternAttribute(sModuleName, window.blanket.options("antifilter"));
+						bFiltered &= window.blanket.utils.matchPatternAttribute(sModuleName, window.blanket.options("filter"));
 						// avoid duplicate instrumentation on server and client-side
-						if (sScript.indexOf("window['sap-ui-qunit-coverage'] = 'server';") !== 0) {
+						if (bFiltered && sScript.indexOf("window['sap-ui-qunit-coverage'] = 'server';") !== 0) {
 							window.blanket.instrument({
 								inputFile: sScript,
 								inputFileName: sModuleName,

--- a/src/sap.ui.core/src/sap/ui/qunit/qunit-coverage.js
+++ b/src/sap.ui.core/src/sap/ui/qunit/qunit-coverage.js
@@ -64,7 +64,9 @@
 
 				if (jQuery && jQuery.sap) {
 					jQuery.sap.require._hook = function(sScript, sModuleName) {
-						// TODO: manage includes/excludes? (usage of regex)
+						// manage includes and excludes with blanket utils
+						var bFiltered = window.blanket.utils.matchPatternAttribute(sModuleName, window.blanket.options("filter"));
+						bFiltered &= !window.blanket.utils.matchPatternAttribute(sModuleName, window.blanket.options("anti-filter"));
 						// avoid duplicate instrumentation on server and client-side
 						if (sScript.indexOf("window['sap-ui-qunit-coverage'] = 'server';") !== 0) {
 							window.blanket.instrument({


### PR DESCRIPTION
When our team wrote some QUnit tests for our custom control library, we always saw code coverage for all used controls, including the OpenUI5 library controls.

In order to only see the coverage of our controls, I changed the coverage module and added the following line to the test html:
```js
blanket.options("filter", "my/custom/lib");
```