### PR TITLE
Added documentation for "is" prefix for functions

### DIFF
--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -10,7 +10,7 @@ When a file is consistently not following these rules and adhering to the rules 
 1.  [JavaScript Coding Guidelines](#javascript-coding-guidelines)
     *  [Code Formatting](#code-formatting)
     *  [Naming Conventions](#naming-conventions)
-    	*  [Static and Additional Prototype Functions](#naming-functions)
+    	*  [Static and Additional Prototype Functions](#Static and Additional Prototype Functions)
     *  [Creating Classes](#creating-classes)
     *  [Documentation (JSDoc)](#documentation-jsdoc)
 1.  [UI5 Control Development Guidelines](#ui5-control-development-guidelines)
@@ -121,7 +121,7 @@ But do NOT use hungarian notation for API method parameters: the documentation w
 | `sap-ui-TraceWindowRoot` | ID of the `TraceWindowRoot`                        |
 | `sap-ui-xmldata`         | ID of the `XML Data Island`                        |
 
-#### Static and Prototype Functions
+#### Static and Additional Prototype Functions
 Besides the *fn*-prefix for anonymous function a function that returns a boolean value should be prefixed with *is*. For example <code>isOpen</code>.<br>
 This isn't necessary for functions that are created through the metadata for a control due to a boolean property, but for static functions and functions that are attached to the prototype like <code>Control.prototype.isOpen = function()</code>.
 

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -10,6 +10,7 @@ When a file is consistently not following these rules and adhering to the rules 
 1.  [JavaScript Coding Guidelines](#javascript-coding-guidelines)
     *  [Code Formatting](#code-formatting)
     *  [Naming Conventions](#naming-conventions)
+    	*  [Static and Additional Prototype Functions](#naming-functions)
     *  [Creating Classes](#creating-classes)
     *  [Documentation (JSDoc)](#documentation-jsdoc)
 1.  [UI5 Control Development Guidelines](#ui5-control-development-guidelines)
@@ -119,6 +120,10 @@ But do NOT use hungarian notation for API method parameters: the documentation w
 | `sap-ui-static`          | ID of the static popup area of UI5                 |
 | `sap-ui-TraceWindowRoot` | ID of the `TraceWindowRoot`                        |
 | `sap-ui-xmldata`         | ID of the `XML Data Island`                        |
+
+#### Static and Prototype Functions
+Besides the *fn*-prefix for anonymous function a function that returns a boolean value should be prefixed with *is*. For example <code>isOpen</code>.<br>
+This isn't necessary for functions that are created through the metadata for a control due to a boolean property, but for static functions and functions that are attached to the prototype like <code>Control.prototype.isOpen = function()</code>.
 
 ### Creating Classes
 


### PR DESCRIPTION
If a function is added additionally to a control/class that returns a boolean value, the function should be prefixed with "is"