### PR TITLE
[FIX] sap.ui.table.Table: If no visible columns, show "no data" message

### DIFF
--- a/src/sap.ui.table/src/sap/ui/table/Table.js
+++ b/src/sap.ui.table/src/sap/ui/table/Table.js
@@ -1004,6 +1004,8 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/Control', 'sap/ui/core/ResizeHa
 		if (this.getBinding("rows")) {
 			this.fireEvent("_rowsUpdated");
 		}
+
+		this._updateNoData();
 	};
 
 	Table.prototype.invalidate = function() {
@@ -2331,9 +2333,9 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/Control', 'sap/ui/core/ResizeHa
 	 * @private
 	 */
 	Table.prototype._updateNoData = function() {
-		// no data?
+		// no data or no visible cols?
 		if (this.getShowNoData()) {
-			this.$().toggleClass("sapUiTableEmpty", !this._hasData());
+			this.$().toggleClass("sapUiTableEmpty", (!this._hasData() || this._getVisibleColumnCount() === 0));
 		}
 	};
 

--- a/src/sap.ui.table/test/sap/ui/table/qunit/Table.qunit.html
+++ b/src/sap.ui.table/test/sap/ui/table/qunit/Table.qunit.html
@@ -1361,6 +1361,31 @@
 		sap.ui.getCore().applyChanges();
 	});
 
+	module("NoData", {
+		setup: function() {
+			createTable();
+		},
+		teardown: destroyTable
+	});
+
+	asyncTest("Empty message shows if no data", function(assert) {
+		assert.ok(!oTable.$().find(".sapUiTableCtrlEmpty").is(':visible'), "empty message shown");
+		oTable.getModel().setData([]);
+		setTimeout(function() {
+			assert.ok(oTable.$().find(".sapUiTableCtrlEmpty").is(':visible'), "empty message not shown");
+			QUnit.start();
+		}, 0);
+	});
+
+	asyncTest("Empty message shows if no columns", function(assert) {
+		assert.ok(!oTable.$().find(".sapUiTableCtrlEmpty").is(':visible'), "empty message shown");
+		oTable.removeAllColumns();
+		setTimeout(function() {
+			assert.ok(oTable.$().find(".sapUiTableCtrlEmpty").is(':visible'), "empty message not shown");
+			QUnit.start();
+		}, 0);
+	});
+
 	</script>
 </head>
 <body class="sapUiBody">


### PR DESCRIPTION
- Add logic to _updateNoData() to account if no visible columns are present.
- Invoke _updateNoData after rendering to cover when columns are removed dynamically

Fixes https://github.com/SAP/openui5/issues/904
