### PR TITLE
MockServer - Refresh metadata on setting entity data

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/util/MockServer.js
+++ b/src/sap.ui.core/src/sap/ui/core/util/MockServer.js
@@ -289,6 +289,7 @@ sap.ui
 			MockServer.prototype.setEntitySetData = function(sEntitySetName, aData) {
 				if (this._oMockdata && this._oMockdata.hasOwnProperty(sEntitySetName)) {
 					this._oMockdata[sEntitySetName] = aData;
+					this._enhanceWithMetadata(this._mEntitySets[sEntitySetName], aData);
 				} else {
 					jQuery.sap.log.error("Unrecognized EntitySet name: " + sEntitySetName);
 				}

--- a/src/sap.ui.core/test/sap/ui/core/qunit/MockServer.qunit.html
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/MockServer.qunit.html
@@ -1706,6 +1706,70 @@
 
 	});
 
+	QUnit.test("test set adds required metadata to entity", function(assert) {
+		var oMockServer = new sap.ui.core.util.MockServer({
+			rootUri : "/myservice/"
+		});
+		var sMetadataUrl = "testdata/rmtsampleflight/metadata.xml";
+		oMockServer.simulate(sMetadataUrl, "testdata/rmtsampleflight/");
+
+		oMockServer.start();
+		assert.ok(oMockServer.isStarted(), "Mock server is started");
+
+		var aFlights = [{
+			CURRENCY: "EUR",
+			PAYMENTSUM: "0.00",
+			PLANETYPE: "A330-300",
+			PRICE: "4050.00",
+			SEATSMAX: 320,
+			SEATSMAX_B: 20,
+			SEATSMAX_F: 0,
+			SEATSOCC: 2,
+			SEATSOCC_B: 1,
+			SEATSOCC_F: 0,
+			carrid: "AF",
+			connid: "0900",
+			fldate: "/Date(1040601600000)/"
+		}];
+
+		oMockServer.setEntitySetData("FlightCollection", aFlights);
+
+		oResponse = jQuery.sap.sjax({
+			url : "/myservice/FlightCollection",
+			dataType : "json"
+		});
+
+		assert.equal(oResponse.data.d.results.length, 1, "one new flight exists");
+
+		var sId = "/myservice/FlightCollection(carrid='AF',connid='0900',fldate=datetime'2002-12-23T00%3A00%3A00')";
+
+		assert.deepEqual(oResponse.data.d.results[0].__metadata, {
+			id: sId,
+			type: "RMTSAMPLEFLIGHT.Flight",
+			uri: sId
+		}, "Metadata has been set correctly");
+
+		assert.deepEqual(oResponse.data.d.results[0].FlightCarrier, {
+			__deferred: {
+				uri: sId + "/FlightCarrier"
+			}
+		}, "FlightCarrier navigation is set from metadata");
+
+		assert.deepEqual(oResponse.data.d.results[0].flightBookings, {
+			__deferred: {
+				uri: sId + "/flightBookings"
+			}
+		}, "flightBookings navigation is set from metadata");
+
+		assert.deepEqual(oResponse.data.d.results[0].flightbooking, {
+			__deferred: {
+				uri: sId + "/flightbooking"
+			}
+		}, "flightbooking navigation is set from metadata");
+
+		oMockServer.destroy();
+    });
+
 	QUnit.test("test deep insert!", function(assert) {
 		var oMockServer = new sap.ui.core.util.MockServer({
 			rootUri : "/myservice/"


### PR DESCRIPTION
When we edit the entity set data, for example in response to a mocked function import, the metadata gets out of sync. especially if you add new entities.

The _enhanceWithMetadata function is added to setEntitySetData in order to refresh the __metadata properties of the changed entities.

Any comments or criticisms welcome.

Oli
