### PR TITLE
[FEATURE] New Explored examples for TreeTable with OData

### DIFF
--- a/src/sap.ui.table/test/sap/ui/table/demokit/docuindex.json
+++ b/src/sap.ui.table/test/sap/ui/table/demokit/docuindex.json
@@ -34,7 +34,9 @@
 				"category": "List",
 				"since": "1.36",
 				"samples": [
-			  	    "sap.ui.table.sample.TreeTable.JSONTreeBinding"
+			  	    "sap.ui.table.sample.TreeTable.JSONTreeBinding",
+					"sap.ui.table.sample.TreeTable.BasicODataTreeBinding",
+					"sap.ui.table.sample.TreeTable.ODataAnnotationsTreeBinding"
 				]
 		  	}
 		],
@@ -87,6 +89,14 @@
 			  "id": "sap.ui.table.sample.TreeTable.JSONTreeBinding",
 			  "name": "JSONTreeBinding",
 			  "description": "Basic example showing how a TreeTable can be build by using a JSONModel"
+		  	},{
+				"id": "sap.ui.table.sample.TreeTable.BasicODataTreeBinding",
+				"name": "Basic OData TreeBinding",
+				"description": "Illustrates how to bind to data from an OData model without using $metadata annotations or navigation properties. Instead, treeAnnotationProperties is filled for the TreeBinding."
+			},{
+				"id": "sap.ui.table.sample.TreeTable.ODataAnnotationsTreeBinding",
+				"name": "OData Annotations TreeBinding",
+				"description": "Illustrates how to bind to data from an OData model using $metadata annotations."
 			}
 		]
 	}

--- a/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/BasicODataTreeBinding/Component.js
+++ b/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/BasicODataTreeBinding/Component.js
@@ -1,0 +1,50 @@
+sap.ui.define([
+    "sap/ui/core/UIComponent",
+    "sap/ui/model/odata/v2/ODataModel",
+    "sap/ui/table/sample/TreeTable/BasicODataTreeBinding/localService/mockserver"
+], function (UIComponent, ODataModel, mockserver) {
+    "use strict";
+
+    return  UIComponent.extend("sap.ui.table.sample.TreeTable.BasicODataTreeBinding.Component", {
+        metadata: {
+            rootView: "sap.ui.table.sample.TreeTable.BasicODataTreeBinding.View",
+            dependencies: {
+                libs: [
+                    "sap.ui.table",
+                    "sap.ui.unified",
+                    "sap.m"
+                ]
+            },
+            config: {
+                sample: {
+                    stretch: true,
+                    files: [
+                        "localService/mockdata/Nodes.json",
+                        "localService/metadata.xml",
+                        "localService/mockserver.js",
+                        "Component.js",
+                        "Controller.controller.js",
+                        "View.view.xml"
+                    ]
+                }
+            }
+        },
+        init : function (){
+            // call the init function of the parent
+			UIComponent.prototype.init.apply(this, arguments);
+
+            var sODataServiceUrl = "/here/goes/your/odata/service/url/";
+
+            // init our mock server
+            mockserver.init(sODataServiceUrl);
+
+            // set model on component
+            this.setModel(
+                new ODataModel(sODataServiceUrl, {
+                    json : true,
+                    useBatch : true
+                })
+            );
+        }
+    });
+});

--- a/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/BasicODataTreeBinding/Controller.controller.js
+++ b/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/BasicODataTreeBinding/Controller.controller.js
@@ -1,0 +1,14 @@
+sap.ui.define([
+    "sap/ui/core/mvc/Controller"
+], function(Controller) {
+    "use strict";
+
+    return Controller.extend("sap.ui.table.sample.TreeTable.BasicODataTreeBinding.Controller", {
+
+        onInit : function () {
+            //nothing to do for us
+        }
+
+    });
+
+});

--- a/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/BasicODataTreeBinding/View.view.xml
+++ b/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/BasicODataTreeBinding/View.view.xml
@@ -1,0 +1,55 @@
+<mvc:View
+    controllerName="sap.ui.table.sample.TreeTable.BasicODataTreeBinding.Controller"
+    xmlns="sap.ui.table"
+    xmlns:m="sap.m"
+    xmlns:mvc="sap.ui.core.mvc">
+
+    <TreeTable
+        id="treeTable"
+        selectionMode="Single"
+        enableColumnReordering="false"
+        expandFirstLevel="false"
+        rows="{
+            path : '/Nodes',
+            parameters : {
+                countMode: 'Inline',
+                treeAnnotationProperties : {
+                    hierarchyLevelFor : 'HierarchyLevel',
+                    hierarchyNodeFor : 'NodeID',
+                    hierarchyParentNodeFor : 'ParentNodeID',
+                    hierarchyDrillStateFor : 'DrillState'
+                }
+            }
+        }">
+
+        <columns>
+
+            <Column label="Description">
+                <template>
+                    <m:Text text="{Description}"/>
+                </template>
+            </Column>
+
+            <Column label="HierarchyLevel">
+                <template>
+                    <m:Text text="{HierarchyLevel}"/>
+                </template>
+            </Column>
+
+            <Column label="NodeID">
+                <template>
+                    <m:Text text="{NodeID}"/>
+                </template>
+            </Column>
+
+            <Column label="ParentNodeID">
+                <template>
+                    <m:Text text="{ParentNodeID}"/>
+                </template>
+            </Column>
+
+        </columns>
+
+    </TreeTable>
+
+</mvc:View>

--- a/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/BasicODataTreeBinding/localService/metadata.xml
+++ b/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/BasicODataTreeBinding/localService/metadata.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<edmx:Edmx Version="1.0"
+	xmlns="http://schemas.microsoft.com/ado/2008/09/edm"
+	xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx"
+	xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"
+	xmlns:edmanno="http://schemas.microsoft.com/ado/2009/02/edm/annotation">
+
+	<edmx:DataServices m:DataServiceVersion="2.0">
+		<Schema Namespace="DemoModel" xml:lang="en">
+
+			<EntityType Name="Node">
+				<Key>
+					<PropertyRef Name="NodeID" />
+				</Key>
+				<Property Name="NodeID" Type="Edm.Int32" Nullable="false" edmanno:StoreGeneratedPattern="Identity" />
+				<Property Name="HierarchyLevel" Type="Edm.Int32" Nullable="false" />
+				<Property Name="Description" Type="Edm.String" Nullable="false" MaxLength="40" Unicode="true" FixedLength="false" />
+				<Property Name="ParentNodeID" Type="Edm.Int32" Nullable="true" />
+				<Property Name="DrillState" Type="Edm.String" Nullable="false" MaxLength="10" Unicode="true" FixedLength="false" />
+			</EntityType>
+
+			<EntityContainer Name="DemoEntities" edmanno:LazyLoadingEnabled="true" m:IsDefaultEntityContainer="true">
+				<EntitySet Name="Nodes" EntityType="DemoModel.Node" />
+			</EntityContainer>
+
+		</Schema>
+	</edmx:DataServices>
+</edmx:Edmx>

--- a/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/BasicODataTreeBinding/localService/mockdata/Nodes.json
+++ b/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/BasicODataTreeBinding/localService/mockdata/Nodes.json
@@ -1,0 +1,114 @@
+[
+	{
+		"NodeID": 1,
+		"HierarchyLevel": 0,
+		"Description": "1",
+		"ParentNodeID": null,
+		"DrillState": "expanded"
+	},
+	{
+		"NodeID": 2,
+		"HierarchyLevel": 0,
+		"Description": "2",
+		"ParentNodeID": null,
+		"DrillState": "expanded"
+	},
+	{
+		"NodeID": 3,
+		"HierarchyLevel": 0,
+		"Description": "3",
+		"ParentNodeID": null,
+		"DrillState": "expanded"
+	},
+	{
+		"NodeID": 4,
+		"HierarchyLevel": 1,
+		"Description": "1.1",
+		"ParentNodeID": 1,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 5,
+		"HierarchyLevel": 1,
+		"Description": "1.2",
+		"ParentNodeID": 1,
+		"DrillState": "expanded"
+	},
+	{
+		"NodeID": 6,
+		"HierarchyLevel": 2,
+		"Description": "1.2.1",
+		"ParentNodeID": 5,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 7,
+		"HierarchyLevel": 2,
+		"Description": "1.2.2",
+		"ParentNodeID": 5,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 8,
+		"HierarchyLevel": 1,
+		"Description": "2.1",
+		"ParentNodeID": 2,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 9,
+		"HierarchyLevel": 1,
+		"Description": "2.2",
+		"ParentNodeID": 2,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 10,
+		"HierarchyLevel": 1,
+		"Description": "2.3",
+		"ParentNodeID": 2,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 11,
+		"HierarchyLevel": 1,
+		"Description": "3.1",
+		"ParentNodeID": 3,
+		"DrillState": "expanded"
+	},
+	{
+		"NodeID": 12,
+		"HierarchyLevel": 2,
+		"Description": "3.1.1",
+		"ParentNodeID": 11,
+		"DrillState": "expanded"
+	},
+	{
+		"NodeID": 13,
+		"HierarchyLevel": 3,
+		"Description": "3.1.1.1",
+		"ParentNodeID": 12,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 14,
+		"HierarchyLevel": 3,
+		"Description": "3.1.1.2",
+		"ParentNodeID": 12,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 15,
+		"HierarchyLevel": 3,
+		"Description": "3.1.1.3",
+		"ParentNodeID": 12,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 16,
+		"HierarchyLevel": 3,
+		"Description": "3.1.1.4",
+		"ParentNodeID": 12,
+		"DrillState": "leaf"
+	}
+]

--- a/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/BasicODataTreeBinding/localService/mockserver.js
+++ b/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/BasicODataTreeBinding/localService/mockserver.js
@@ -1,0 +1,36 @@
+sap.ui.define([
+	"sap/ui/core/util/MockServer"
+], function (MockServer) {
+	"use strict";
+
+	return {
+
+		init: function (sODataServiceUrl) {
+			var oMockServer, sLocalServicePath, aRequests, oErrorResponse, fnResponse;
+
+			// create
+			oMockServer = new MockServer({
+				rootUri: sODataServiceUrl
+			});
+
+			// configure
+			MockServer.config({
+				autoRespond: true,
+				autoRespondAfter: 1000
+			});
+
+			sLocalServicePath = jQuery.sap.getModulePath("sap.ui.table.sample.TreeTable.BasicODataTreeBinding.localService");
+
+			// simulate
+			oMockServer.simulate(sLocalServicePath + "/metadata.xml", {
+				sMockdataBaseUrl : sLocalServicePath + "/mockdata",
+				bGenerateMissingMockData: false
+			});
+
+			// start
+			oMockServer.start();
+		}
+
+	};
+
+});

--- a/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/ODataAnnotationsTreeBinding/Component.js
+++ b/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/ODataAnnotationsTreeBinding/Component.js
@@ -1,0 +1,49 @@
+sap.ui.define([
+    "sap/ui/core/UIComponent",
+    "sap/ui/model/odata/v2/ODataModel",
+    "sap/ui/table/sample/TreeTable/ODataAnnotationsTreeBinding/localService/mockserver"
+], function (UIComponent, ODataModel, mockserver) {
+    "use strict";
+
+    return  UIComponent.extend("sap.ui.table.sample.TreeTable.ODataAnnotationsTreeBinding.Component", {
+        metadata: {
+            rootView: "sap.ui.table.sample.TreeTable.ODataAnnotationsTreeBinding.View",
+            dependencies: {
+                libs: [
+                    "sap.ui.table",
+                    "sap.ui.unified",
+                    "sap.m"
+                ]
+            },
+            config: {
+                sample: {
+                    stretch: true,
+                    files: [
+                        "localService/mockdata/Nodes.json",
+                        "localService/metadata.xml",
+                        "localService/mockserver.js",
+                        "Component.js",
+                        "View.view.xml"
+                    ]
+                }
+            }
+        },
+        init : function (){
+            // call the init function of the parent
+			UIComponent.prototype.init.apply(this, arguments);
+
+            var sODataServiceUrl = "/here/goes/your/odata/service/url/";
+
+            // init our mock server
+            mockserver.init(sODataServiceUrl);
+
+            // set model on component
+            this.setModel(
+                new ODataModel(sODataServiceUrl, {
+                    json : true,
+                    useBatch : true
+                })
+            );
+        }
+    });
+});

--- a/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/ODataAnnotationsTreeBinding/View.view.xml
+++ b/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/ODataAnnotationsTreeBinding/View.view.xml
@@ -1,0 +1,48 @@
+<mvc:View
+    xmlns="sap.ui.table"
+    xmlns:m="sap.m"
+    xmlns:mvc="sap.ui.core.mvc">
+
+    <TreeTable
+        id="treeTable"
+        selectionMode="Single"
+        enableColumnReordering="false"
+        expandFirstLevel="false"
+        rows="{
+            path : '/Nodes',
+            parameters : {
+                countMode: 'Inline'
+            }
+        }">
+
+        <columns>
+
+            <Column label="Description">
+                <template>
+                    <m:Text text="{Description}"/>
+                </template>
+            </Column>
+
+            <Column label="HierarchyLevel">
+                <template>
+                    <m:Text text="{HierarchyLevel}"/>
+                </template>
+            </Column>
+
+            <Column label="NodeID">
+                <template>
+                    <m:Text text="{NodeID}"/>
+                </template>
+            </Column>
+
+            <Column label="ParentNodeID">
+                <template>
+                    <m:Text text="{ParentNodeID}"/>
+                </template>
+            </Column>
+
+        </columns>
+
+    </TreeTable>
+
+</mvc:View>

--- a/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/ODataAnnotationsTreeBinding/localService/metadata.xml
+++ b/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/ODataAnnotationsTreeBinding/localService/metadata.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<edmx:Edmx Version="1.0"
+	xmlns="http://schemas.microsoft.com/ado/2008/09/edm"
+	xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx"
+	xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"
+	xmlns:edmanno="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+	xmlns:sap="http://www.sap.com/Protocols/SAPData">
+
+	<edmx:DataServices m:DataServiceVersion="2.0">
+		<Schema Namespace="DemoModel" xml:lang="en" sap:schema-version="1">
+
+			<EntityType Name="Node">
+				<Key>
+					<PropertyRef Name="NodeID" />
+				</Key>
+				<Property Name="NodeID" Type="Edm.Int32" Nullable="false" edmanno:StoreGeneratedPattern="Identity" sap:hierarchy-node-for="NodeID"/>
+				<Property Name="HierarchyLevel" Type="Edm.Int32" Nullable="false" sap:hierarchy-level-for="NodeID"/>
+				<Property Name="Description" Type="Edm.String" Nullable="false" MaxLength="40" Unicode="true" FixedLength="false" />
+				<Property Name="ParentNodeID" Type="Edm.Int32" Nullable="true" sap:hierarchy-parent-node-for="NodeID"/>
+				<Property Name="DrillState" Type="Edm.String" Nullable="false" MaxLength="10" Unicode="true" FixedLength="false" sap:hierarchy-drill-state-for="NodeID" />
+			</EntityType>
+
+			<EntityContainer Name="DemoEntities" edmanno:LazyLoadingEnabled="true" m:IsDefaultEntityContainer="true">
+				<EntitySet Name="Nodes" EntityType="DemoModel.Node" />
+			</EntityContainer>
+
+		</Schema>
+	</edmx:DataServices>
+</edmx:Edmx>

--- a/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/ODataAnnotationsTreeBinding/localService/mockdata/Nodes.json
+++ b/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/ODataAnnotationsTreeBinding/localService/mockdata/Nodes.json
@@ -1,0 +1,114 @@
+[
+	{
+		"NodeID": 1,
+		"HierarchyLevel": 0,
+		"Description": "1",
+		"ParentNodeID": null,
+		"DrillState": "expanded"
+	},
+	{
+		"NodeID": 2,
+		"HierarchyLevel": 0,
+		"Description": "2",
+		"ParentNodeID": null,
+		"DrillState": "expanded"
+	},
+	{
+		"NodeID": 3,
+		"HierarchyLevel": 0,
+		"Description": "3",
+		"ParentNodeID": null,
+		"DrillState": "expanded"
+	},
+	{
+		"NodeID": 4,
+		"HierarchyLevel": 1,
+		"Description": "1.1",
+		"ParentNodeID": 1,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 5,
+		"HierarchyLevel": 1,
+		"Description": "1.2",
+		"ParentNodeID": 1,
+		"DrillState": "expanded"
+	},
+	{
+		"NodeID": 6,
+		"HierarchyLevel": 2,
+		"Description": "1.2.1",
+		"ParentNodeID": 5,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 7,
+		"HierarchyLevel": 2,
+		"Description": "1.2.2",
+		"ParentNodeID": 5,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 8,
+		"HierarchyLevel": 1,
+		"Description": "2.1",
+		"ParentNodeID": 2,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 9,
+		"HierarchyLevel": 1,
+		"Description": "2.2",
+		"ParentNodeID": 2,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 10,
+		"HierarchyLevel": 1,
+		"Description": "2.3",
+		"ParentNodeID": 2,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 11,
+		"HierarchyLevel": 1,
+		"Description": "3.1",
+		"ParentNodeID": 3,
+		"DrillState": "expanded"
+	},
+	{
+		"NodeID": 12,
+		"HierarchyLevel": 2,
+		"Description": "3.1.1",
+		"ParentNodeID": 11,
+		"DrillState": "expanded"
+	},
+	{
+		"NodeID": 13,
+		"HierarchyLevel": 3,
+		"Description": "3.1.1.1",
+		"ParentNodeID": 12,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 14,
+		"HierarchyLevel": 3,
+		"Description": "3.1.1.2",
+		"ParentNodeID": 12,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 15,
+		"HierarchyLevel": 3,
+		"Description": "3.1.1.3",
+		"ParentNodeID": 12,
+		"DrillState": "leaf"
+	},
+	{
+		"NodeID": 16,
+		"HierarchyLevel": 3,
+		"Description": "3.1.1.4",
+		"ParentNodeID": 12,
+		"DrillState": "leaf"
+	}
+]

--- a/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/ODataAnnotationsTreeBinding/localService/mockserver.js
+++ b/src/sap.ui.table/test/sap/ui/table/demokit/sample/TreeTable/ODataAnnotationsTreeBinding/localService/mockserver.js
@@ -1,0 +1,36 @@
+sap.ui.define([
+	"sap/ui/core/util/MockServer"
+], function (MockServer) {
+	"use strict";
+
+	return {
+
+		init: function (sODataServiceUrl) {
+			var oMockServer, sLocalServicePath, aRequests, oErrorResponse, fnResponse;
+
+			// create
+			oMockServer = new MockServer({
+				rootUri: sODataServiceUrl
+			});
+
+			// configure
+			MockServer.config({
+				autoRespond: true,
+				autoRespondAfter: 1000
+			});
+
+			sLocalServicePath = jQuery.sap.getModulePath("sap.ui.table.sample.TreeTable.ODataAnnotationsTreeBinding.localService");
+
+			// simulate
+			oMockServer.simulate(sLocalServicePath + "/metadata.xml", {
+				sMockdataBaseUrl : sLocalServicePath + "/mockdata",
+				bGenerateMissingMockData: false
+			});
+
+			// start
+			oMockServer.start();
+		}
+
+	};
+
+});


### PR DESCRIPTION
"Hacking the Explored App" TreeTable examples from UI5con 2016

With an OData model, several requests for each node must be sent in
order to expand them. If batch-requests are enabled it will be one
batch for each auto-expand-level but the batch requests will contain
sub-requests for every single hierarchy node.