### PR TITLE
[FEATURE] sap.m.ViewSettingsDialog: search entire title

### DIFF
--- a/src/sap.m/src/sap/m/ViewSettingsDialog.js
+++ b/src/sap.m/src/sap/m/ViewSettingsDialog.js
@@ -2176,8 +2176,8 @@ function(jQuery, library, Control, IconPool, Toolbar, CheckBox, SearchField) {
 
 					//update the list items visibility
 					oFilterDetailList.getItems().forEach(function(oItem) {
-						var bStartsWithQuery = oItem.getTitle().toLowerCase().indexOf(sQuery) === 0;
-						oItem.setVisible(bStartsWithQuery);
+						var bContainsQuery = oItem.getTitle().toLowerCase().indexOf(sQuery) > -1;
+						oItem.setVisible(bContainsQuery);
 					});
 
 					//update Select All checkbox


### PR DESCRIPTION
Actually on search in ViewSettingsDialog it is checked if the title begins with the search query. Please extend this search behaviour to browse the entire title for the given query.