### PR TITLE
JSONModel can auto-create "missing" objects

### DIFF
--- a/src/sap.ui.core/test/sap/ui/core/qunit/component/Models.qunit.html
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/component/Models.qunit.html
@@ -1386,6 +1386,22 @@
 			}.bind(this));
 		});
 
+		QUnit.module("JSONModel", { });
+
+		QUnit.test("setProperty creates missing structure", function(assert) {
+			var oModel = new sap.ui.model.json.JSONModel({
+				data: {}
+			});
+
+			oModel.setProperty("/something/missing", "test");
+			assert.equal(oModel.getProperty("/something/missing"), "test");
+
+			oModel.setProperty("/data/missing/property", 42);
+			assert.equal(oModel.getProperty("/data/missing/property"), 42);
+
+			oModel.setProperty("/data/missing/level/property", 42);
+			assert.equal(oModel.getProperty("/data/missing/level/property"), 42);
+		});
 	});
 
 	</script>


### PR DESCRIPTION
This change allows the JSONModel to create missing nodes to you can setProperty("/any/path/here", x) without requiring the user to define the object structure { any: { path : { }}} first.

When you create a JSONModel with an empty object and try to set a property like "/one/two" it just fails silently and does nothing but returning false. 
```js
var oModel = new JSONModel({ });
oModel.setProperty("/one/two", 42);
// oModel.getProperty("/one/two") === undefined
```

While one could check for the return value here, this isn't available for bindings. 

This isn't really what I'd expect to happen. I feel like there should be either 
  a) a warning that the model wasn't able to set the property or
  b) the model should create the missing object itself (this PR). 

I'm not sure if the current behavior is intended but if it is not, heres a PR to fix that ;)

**Breaking change:**  As far as I can see this should not break any existing code but if someone wrote code that expects the old behavior it would break now. 

`setProperty` could still return false if the last found node in `_getObject` isn't an object. In that case theres also a `jQuery.sap.log.warn`. 