### PR TITLE
Sane default for non-existant compare function

### DIFF
--- a/src/sap.ui.core/src/sap/ui/model/FilterProcessor.js
+++ b/src/sap.ui.core/src/sap/ui/model/FilterProcessor.js
@@ -209,7 +209,7 @@ sap.ui.define(['jquery.sap.global'],
 				};
 				break;
 			default:
-				oFilter.fnTest = function(value) { return true; };
+				oFilter.fnTest = function(value) { return false; };
 		}
 		return oFilter.fnTest;
 	};


### PR DESCRIPTION
If you can't compare two values, they are not equal. This is
also in sync with the behaviour of
FilterProcessor._resolveMultiFilter
for undefined Paths and Values.