### PR TITLE
[FIX] sap.m.Popover: sync Compact Mode with opening Control

### DIFF
--- a/src/sap.m/src/sap/m/Popover.js
+++ b/src/sap.m/src/sap/m/Popover.js
@@ -604,6 +604,9 @@ sap.ui.define(['jquery.sap.global', './Bar', './Button', './InstanceManager', '.
 				sTheme = sap.ui.getCore().getConfiguration().getTheme(),
 				oParentDomRef, iPlacePos, bThemeBelize;
 
+            // bug fix issue 1012: https://github.com/SAP/openui5/issues/1012
+            jQuery.sap.syncStyleClass('sapUiSizeCompact', oControl, this);
+
 			// Determines if the Popover will be rendered in a compact mode
 			bThemeBelize = sTheme === "sap_belize" || sTheme === "sap_belize_plus";
 			this._bSizeCompact = sap.m._bSizeCompact || !!document.querySelector('body.sapUiSizeCompact') || this.hasStyleClass("sapUiSizeCompact");


### PR DESCRIPTION
- from 1.36.10 to 1.36.11 definition for compact mode was changed for popover and the use case that opening MultiComboBox or ComboBox is in compactMode was not treated anymore

Fixes https://github.com/SAP/openui5/issues/1012