### PR TITLE
[FIX] sap.ui.unified.FileUploader: Hand cursor displayed for disabled button

### DIFF
--- a/src/sap.ui.unified/src/sap/ui/unified/themes/base/FileUploader.less
+++ b/src/sap.ui.unified/src/sap/ui/unified/themes/base/FileUploader.less
@@ -61,6 +61,10 @@
 	font-size: 500px; /* to make the field high enough for most themes; for themes with very large fonts this needs to be increased further */
 	width: 5000px;
 }
+.sapUiFupInputMask > input[disabled],
+.sapUiFupInputMask > input:disabled {
+	cursor: default;
+}
 
 html[data-sap-ui-browser^="ie"] .sapUiFup > form input {
 	display: block;


### PR DESCRIPTION
- this was caused by the sapUiFupInputMask overlaying the actual button sap.m.Button triggering an upload

- now the cursor of the actual <input type="file"/> will be set back to 'default' if disabled

- uses element selector as well as pseudo class to fix IE7/8

Fixes https://github.com/SAP/openui5/issues/1050