### PR TITLE
Update ViewSettingsDialog, unrestrict search from "begins with"

### DIFF
--- a/src/sap.m/src/sap/m/ViewSettingsDialog.js
+++ b/src/sap.m/src/sap/m/ViewSettingsDialog.js
@@ -2189,8 +2189,8 @@ function(jQuery, library, Control, IconPool, Toolbar, CheckBox, SearchField) {
 
 					//update the list items visibility
 					oFilterDetailList.getItems().forEach(function(oItem) {
-						var bStartsWithQuery = oItem.getTitle().toLowerCase().indexOf(sQuery) === 0;
-						oItem.setVisible(bStartsWithQuery);
+						var bQueryMatch = oItem.getTitle().toLowerCase().indexOf(sQuery) !== -1;
+						oItem.setVisible(bQueryMatch);
 					});
 
 					//update Select All checkbox


### PR DESCRIPTION
Being restricted with the search query to anything that "begins with" makes no sense.
Filtering on a name, location, ..., often the end user only remembers a part of it and should be able to find what he or she is looking for in the list of filter values whether or not the partial string is what matches the start of the filter value text.