### PR TITLE
[FIX] validate string prior to using bindingParser

### DIFF
--- a/src/sap.ui.core/src/sap/ui/base/ManagedObject.js
+++ b/src/sap.ui.core/src/sap/ui/base/ManagedObject.js
@@ -2365,7 +2365,7 @@ sap.ui.define([
 		}
 
 		// property:"{path}" or "\{path\}"
-		if (typeof oValue === "string") {
+		if (typeof oValue === "string" && /{.+}/.test(oValue) === true) {
 			// either returns a binding info or an unescaped string or undefined - depending on binding syntax
 			return ManagedObject.bindingParser(oValue, oScope, true);
 		}

--- a/src/sap.ui.core/test/sap/ui/core/qunit/BindingParser.qunit.html
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/BindingParser.qunit.html
@@ -806,6 +806,13 @@
 		strictEqual(oIcon.getColor(), "1", "one time binding -> value unchanged");
 	});
 
+	test("Instantiate control with incomplete syntax", function(){
+		var oControl = new TestControl({
+			text: "{foo"
+		});
+		equal(oControl.getText(), "{foo", "text property set correctly");
+	});
+
 	</script>
 
 	<title>QUnit tests: Data binding Calculated Fields</title>


### PR DESCRIPTION
Strings that are passed to `ManagedObject.bindingParser` should have both
an opening and closing curly bracket (`{` and `}`).

This prevents a run-time `SyntaxError` from being thrown by
`BindingParser.complexParser`.

Fixes #1061
