### PR TITLE
[FIX] ViewSettingsCustomItem customControl content does not bind to any model

### DIFF
--- a/src/sap.m/src/sap/m/ViewSettingsDialog.js
+++ b/src/sap.m/src/sap/m/ViewSettingsDialog.js
@@ -1004,6 +1004,8 @@ function(jQuery, library, Control, IconPool, Toolbar, CheckBox, SearchField) {
 				}).attachPress(this._onCancel, this)
 			}).addStyleClass("sapMVSD");
 
+			this.addDependent(this._dialog);
+
 			// CSN# 3696452/2013: ESC key should also cancel dialog, not only close
 			// it
 			var fnDialogEscape = this._dialog.onsapescape;


### PR DESCRIPTION
[FIX] sap.m.ViewSettingsCustomItem: Does not propagate models correctly to it's aggregation customControl

- the sap.m.Dialog used inside of sap.m.ViewSettingsDialog is now a dependent of the sap.m.ViewSettingsDialog instance and thereby inherits and propagates all the models correctly

Fixes https://github.com/SAP/openui5/issues/1068
Fixes https://github.com/SAP/openui5/issues/1071