### PR TITLE
[FIX] MockServer read operation with Edm.Boolean key property

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/util/MockServer.js
+++ b/src/sap.ui.core/src/sap/ui/core/util/MockServer.js
@@ -1871,6 +1871,8 @@ sap.ui
 									sNewValue = sNewValue.replace(/^guid\'|\'$/g, '');
 									break;
 								case "Edm.Boolean":
+									sNewValue = sNewValue === "true";
+									break;
 								case "Edm.Binary":
 								case "Edm.DateTimeOffset":
 								default:

--- a/src/sap.ui.core/test/sap/ui/core/qunit/MockServer.qunit.html
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/MockServer.qunit.html
@@ -134,6 +134,59 @@
 		oMockServer.destroy();
 	});
 
+	test("Test entity read with boolean key property (true)", 4, function() {
+
+		var oMockServer = new sap.ui.core.util.MockServer({
+			rootUri : "/myservice/"
+		});
+		var sMetadataUrl = "testdata/metadata-types.xml";
+		var sMockdataBaseUrl = "testdata/mockdata-types/";
+
+		oMockServer.simulate(sMetadataUrl, {
+			"sMockdataBaseUrl" : sMockdataBaseUrl,
+			"bGenerateMissingMockData" : false
+		});
+		oMockServer.start();
+		ok(oMockServer.isStarted(), "Mock server is started");
+
+		var oResponse = jQuery.sap.sjax({
+			url : "/myservice/BooleanKeyEntitySet(true)",
+			dataType : "json"
+		});
+
+		ok(oResponse.success, "Mock server responded well");
+		equal(oResponse.data.d.Secret, "May the Force be with you.", "The correct entity was loaded");
+		equal(oResponse.statusCode, "200", "Response status is right");
+
+		oMockServer.destroy();
+	});
+
+	test("Test entity read with boolean key property (false)", 4, function() {
+
+		var oMockServer = new sap.ui.core.util.MockServer({
+			rootUri : "/myservice/"
+		});
+		var sMetadataUrl = "testdata/metadata-types.xml";
+		var sMockdataBaseUrl = "testdata/mockdata-types/";
+
+		oMockServer.simulate(sMetadataUrl, {
+			"sMockdataBaseUrl" : sMockdataBaseUrl,
+			"bGenerateMissingMockData" : false
+		});
+		oMockServer.start();
+		ok(oMockServer.isStarted(), "Mock server is started");
+
+		var oResponse = jQuery.sap.sjax({
+			url : "/myservice/BooleanKeyEntitySet(false)",
+			dataType : "json"
+		});
+
+		ok(oResponse.success, "Mock server responded well");
+		equal(oResponse.data.d.Secret, "Only at the end do you realize the power of the Dark Side.", "The correct entity was loaded");
+		equal(oResponse.statusCode, "200", "Response status is right");
+
+		oMockServer.destroy();
+	});
 
 	test("Test URL parameters with ampersand in value", 3, function() {
 

--- a/src/sap.ui.core/test/sap/ui/core/qunit/testdata/metadata-types.xml
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/testdata/metadata-types.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+    <edmx:DataServices m:DataServiceVersion="2.0">
+        <Schema Namespace="MOCK_TYPES_TEST" xml:lang="en" xmlns="http://schemas.microsoft.com/ado/2008/09/edm">
+            <EntityType Name="BooleanKeyEntity" m:HasStream="true">
+                <Key>
+                    <PropertyRef Name="BooleanKey" />
+                </Key>
+                <Property Name="BooleanKey" Type="Edm.Boolean" Nullable="false" />
+                <Property Name="Secret" Type="Edm.String" />
+            </EntityType>
+            <EntityContainer Name="MOCK_TYPES_TEST" m:IsDefaultEntityContainer="true">
+                <EntitySet Name="BooleanKeyEntitySet" EntityType="MOCK_TYPES_TEST.BooleanKeyEntity"  />
+            </EntityContainer>
+            <atom:link rel="self" href="http://testservice:8080/sap/opu/odata/sap/MOCK_TYPES_TEST/$metadata" xmlns:atom="http://www.w3.org/2005/Atom" />
+            <atom:link rel="latest-version" href="http://testservice:8080/sap/opu/odata/sap/MOCK_TYPES_TEST/$metadata" xmlns:atom="http://www.w3.org/2005/Atom" />
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/src/sap.ui.core/test/sap/ui/core/qunit/testdata/mockdata-types/BooleanKeyEntitySet.json
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/testdata/mockdata-types/BooleanKeyEntitySet.json
@@ -1,0 +1,12 @@
+{
+    "d": {
+        "results": [{
+            "BooleanKey": true,
+            "Secret": "May the Force be with you."
+        },
+        {
+            "BooleanKey": false,
+            "Secret": "Only at the end do you realize the power of the Dark Side."
+        }]
+    }
+}


### PR DESCRIPTION
Hi,

this commit would enable the MockServer to work with Edm.Boolean key properties properly.

The attached QUnit test cases did fail before.

Best Regards,
Nils