### PR TITLE
[FIX] sap.m.Image background image not rendered for some complex URL

### DIFF
--- a/src/sap.m/src/sap/m/Image.js
+++ b/src/sap.m/src/sap/m/Image.js
@@ -194,7 +194,7 @@ sap.ui.define(['jquery.sap.global', './library', 'sap/ui/core/Control'],
 		// set the src to the real dom node
 		if (this.getMode() === sap.m.ImageMode.Background) {
 			// In Background mode, the src is applied to the output DOM element only when the source image is finally loaded to the client side
-			$DomNode.css("background-image", "url(" + this._oImage.src + ")");
+			$DomNode.css("background-image", "url(\"" + this._oImage.src + "\")");
 		}
 
 		if (!this._isWidthOrHeightSet()) {


### PR DESCRIPTION
We are loading a dynamic image through OData binding. The requested image URL looks like this:
"/destinations/DM_DC_OData/ConversationThumbnails(ModelId='4',ArtifactId='Snapshot1')/$value"
If we bind the same URL to img src, it is working. But when bind to background, it will not render. And we also tested to adding quotes solved this issue.

While looks like it is always safe to adding quotes...
