### PR TITLE
Missing documentation for v2.ODataModel

### DIFF
--- a/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
@@ -4678,6 +4678,7 @@ sap.ui.define([
 	 * @param {function} [mParameters.error] The error callback function
 	 * @param {map} [mParameters.headers] A map of headers
 	 * @param {map} [mParameters.urlParameters] A map of url parameters
+	 * @param {string} [mParameters.eTag] If specified, the If-Match-Header will be set to this Etag.
 	 *
 	 * @return {sap.ui.model.Context} oContext A Context object that point to the new created entry.
 	 * @public

--- a/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
@@ -3689,6 +3689,7 @@ sap.ui.define([
 	 * @param {string} [mParameters.batchGroupId] Deprecated - use groupId instead
 	 * @param {string} [mParameters.groupId] groupId for this request. Requests belonging to the same groupId will be bundled in one batch request.
 	 * @param {string} [mParameters.changeSetId] changeSetId for this request
+	 * @param {map} [mParameters.headers] A map of headers for this request
 	 *
 	 * @return {object} an object which has an <code>abort</code> function to abort the current request.
 	 *

--- a/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
@@ -3625,6 +3625,7 @@ sap.ui.define([
 	 * @param {string} [mParameters.batchGroupId] Deprecated - use groupId instead
 	 * @param {string} [mParameters.groupId] groupId for this request. Requests belonging to the same groupId will be bundled in one batch request.
 	 * @param {string} [mParameters.changeSetId] changeSetId for this request
+	 * @param {string} [mParameters.eTag] If specified, the If-Match-Header will be set to this Etag.
 	 * @return {object} an object which has an <code>abort</code> function to abort the current request.
 	 *
 	 * @public

--- a/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
@@ -3765,6 +3765,7 @@ sap.ui.define([
 	 * @param {string} [mParameters.groupId] groupId for this request. Requests belonging to the same groupId will be bundled in one batch request.
 	 * @param {string} [mParameters.eTag] If the functionImport changes an entity, the eTag for this entity could be passed with this parameter
 	 * @param {string} [mParameters.changeSetId] changeSetId for this request
+	 * @param {map} [mParameters.headers] A map of headers for this request
 	 *
 	 * @return {object} oRequestHandle An object which has a <code>contextCreated</code> function that returns a <code>Promise</code>.
 	 *         This resolves with the created {@link sap.ui.model.Context}.


### PR DESCRIPTION
The v2.ODataModel misses the following documentation of 'standard features':
- `callFunction`: documentation of `mParameters.headers` is missing
- `create`: documentation of `mParameters.eTag` is missing
- `createEntry`: documentation of `mParameters.eTag` is missing
- `remove`: documentation of `mParameters.headers` is missing

The functionality behind this is already implemented, yet, it's not part of the official API.

This PR adds these parts to the official API.
