### PR TITLE
[FIX] sap.ui.core.UIComponent: Document return value of createContent

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/UIComponent.js
+++ b/src/sap.ui.core/src/sap/ui/core/UIComponent.js
@@ -479,6 +479,7 @@ sap.ui.define(['jquery.sap.global', '../base/ManagedObject', './Component', './l
 	 * This method has to be overwritten in the implementation of the component
 	 * if the root view is not declared in the component metadata.
 	 *
+	 * @return {sap.ui.core.mvc.View} instance of the view specified in the metadata or in the descriptor file
 	 * @public
 	 */
 	UIComponent.prototype.createContent = function() {


### PR DESCRIPTION
Additionally, shouldn't the method be declared `protected` as it is ["not for use by applications, but might be used even outside the same class"](https://github.com/SAP/openui5/blob/master/docs/guidelines.md)?