### PR TITLE
Set editorconfig tab_width to improve GitHub display

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ charset = utf-8
 [*.{css,html,java,js,json,less,txt}]
 trim_trailing_whitespace = true
 end_of_line = lf
+tab_width = 4
 
 [pom.xml]
 trim_trailing_whitespace = true


### PR DESCRIPTION
GitHub can use the `.editorconfig` file to [adapt the code display](https://twitter.com/editorconfig/status/610836234676535296) when viewing the repository online.

Adding `tab_width = 4` makes reading the code in the browser much more pleasant:
_Before:_
![2016-10-24_11-01-43](https://cloud.githubusercontent.com/assets/2564094/19639593/600b3a90-99d9-11e6-9fd4-e2baf871abeb.png)

_After:_
![2016-10-24_11-02-19](https://cloud.githubusercontent.com/assets/2564094/19639600/6615d558-99d9-11e6-84a5-af3f501f6112.png)
