### PR TITLE
[FIX] ObjectPageHeader context switch with no sections 

### DIFF
--- a/src/sap.uxap/src/sap/uxap/ObjectPageLayout.js
+++ b/src/sap.uxap/src/sap/uxap/ObjectPageLayout.js
@@ -350,7 +350,7 @@ sap.ui.define([
 		this._applyUxRules();
 
 		// If we are on the first true rendering : first time we render the page with section and blocks
-		if ((this.getSections().length == 0 || !jQuery.isEmptyObject(this._oSectionInfo)) && this._bFirstRendering) {
+		if ((this.getSections().length === 0 || !jQuery.isEmptyObject(this._oSectionInfo)) && this._bFirstRendering) {
 			this._preloadSectionsOnBeforeFirstRendering();
 			this._bFirstRendering = false;
 		}

--- a/src/sap.uxap/src/sap/uxap/ObjectPageLayout.js
+++ b/src/sap.uxap/src/sap/uxap/ObjectPageLayout.js
@@ -350,7 +350,7 @@ sap.ui.define([
 		this._applyUxRules();
 
 		// If we are on the first true rendering : first time we render the page with section and blocks
-		if ((this.getSections().length == 0 ||!jQuery.isEmptyObject(this._oSectionInfo)) && this._bFirstRendering) {
+		if ((this.getSections().length == 0 || !jQuery.isEmptyObject(this._oSectionInfo)) && this._bFirstRendering) {
 			this._preloadSectionsOnBeforeFirstRendering();
 			this._bFirstRendering = false;
 		}

--- a/src/sap.uxap/src/sap/uxap/ObjectPageLayout.js
+++ b/src/sap.uxap/src/sap/uxap/ObjectPageLayout.js
@@ -350,7 +350,7 @@ sap.ui.define([
 		this._applyUxRules();
 
 		// If we are on the first true rendering : first time we render the page with section and blocks
-		if (!jQuery.isEmptyObject(this._oSectionInfo) && this._bFirstRendering) {
+		if ((this.getSections().length == 0 ||!jQuery.isEmptyObject(this._oSectionInfo)) && this._bFirstRendering) {
 			this._preloadSectionsOnBeforeFirstRendering();
 			this._bFirstRendering = false;
 		}

--- a/src/sap.uxap/test/sap/uxap/qunit/ObjectPageHeaderSwitchContext.qunit.html
+++ b/src/sap.uxap/test/sap/uxap/qunit/ObjectPageHeaderSwitchContext.qunit.html
@@ -20,7 +20,7 @@
 	<script src="./js/ObjectPageHeaderSwitchContext.qunit.js"></script>
 </head>
 <body id="body" class="sapUiBody">
-<h1 id="qunit-header">aat_UxAP_ObjectPageHeader</h1>
+<h1 id="qunit-header">UxAP_ObjectPageHeader_Switch_Context</h1>
 
 <div id="qunit"></div>
 <div id="content"></div>

--- a/src/sap.uxap/test/sap/uxap/qunit/ObjectPageHeaderSwitchContext.qunit.html
+++ b/src/sap.uxap/test/sap/uxap/qunit/ObjectPageHeaderSwitchContext.qunit.html
@@ -1,0 +1,29 @@
+<html>
+<head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta charset="utf-8">
+
+	<script src="../shared-config.js"></script>
+	<script id="sap-ui-bootstrap"
+			src="../../../../resources/sap-ui-core.js"
+			data-sap-ui-xx-bindingSyntax="complex"
+			data-sap-ui-libs="sap.m, sap.uxap">
+	</script>
+
+	<link rel="stylesheet" href="../../../../resources/sap/ui/thirdparty/qunit.css" type="text/css" media="screen">
+	<script src="../../../../resources/sap/ui/thirdparty/qunit.js"></script>
+	<script src="../../../../resources/sap/ui/qunit/QUnitUtils.js"></script>
+	<script src="../../../../resources/sap/ui/qunit/qunit-coverage.js"></script>
+	<script src="../../../../resources/sap/ui/thirdparty/sinon.js"></script>
+	<script src="../../../../resources/sap/ui/thirdparty/sinon-qunit.js"></script>
+	<script src="./js/js-coverage-filter.js"></script>
+	<script src="./js/ObjectPageHeaderSwitchContext.qunit.js"></script>
+</head>
+<body id="body" class="sapUiBody">
+<h1 id="qunit-header">aat_UxAP_ObjectPageHeader</h1>
+
+<div id="qunit"></div>
+<div id="content"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/src/sap.uxap/test/sap/uxap/qunit/js/ObjectPageHeaderSwitchContext.qunit.js
+++ b/src/sap.uxap/test/sap/uxap/qunit/js/ObjectPageHeaderSwitchContext.qunit.js
@@ -1,0 +1,90 @@
+(function ($, QUnit) {
+	"use strict";
+	sinon.config.useFakeTimers = true;
+	QUnit.module("set context (and rebind) with property 'showTitleInHeaderContent' doesn't work", {
+		beforeEach : function() {
+			this.oPageLayout = new sap.uxap.ObjectPageLayout({
+				id:"ObjectPageLayout",
+				showTitleInHeaderContent:true,
+				headerTitle: [
+					new sap.uxap.ObjectPageHeader({
+						id:"header",
+						objectImageURI:"{src}",
+						objectTitle:"{name}",
+						objectSubtitle:"{group}",
+						isObjectIconAlwaysVisible:false,
+						isObjectTitleAlwaysVisible:false,
+						isObjectSubtitleAlwaysVisible:false,
+						isActionAreaAlwaysVisible:false,
+					})
+				]
+			}).placeAt('qunit-fixture');
+
+			// test data
+			var oMock = [
+				{
+					src: '../qunit/img/imageID_273624.png',
+					name: 'Denise Smith',
+					group: 'Junior Developer'
+				},
+				{
+					src: '../qunit/img/imageID_275314.png',
+					name: 'Denise Smith-Jones',
+					group: 'Senior Developer'
+				}
+			];
+
+			// didn't set context for properties objectImageURI, objectTitle, objectSubtitle
+			this.oJSONModel = new sap.ui.model.json.JSONModel(oMock);
+			this.oPageLayout.setModel(this.oJSONModel);
+
+			this.oPageLayout.bindObject('/0');
+
+			this.clock = sinon.clock.create();
+
+			sap.ui.getCore().applyChanges();
+		},
+		afterEach : function() {
+			this.oPageLayout.destroy();
+			this.oPageLayout = null;
+		}
+	});
+	QUnit.test("Rebind properties objectImageURI, objectTitle, objectSubtitle", function(assert) {
+		sap.ui.getCore().applyChanges();
+		this.clock.tick(1000);
+
+		// check if all right
+		// objectImageURI
+		assert.equal(this.oPageLayout.$().find("#ObjectPageLayout-opwrapper .sapUxAPObjectPageHeaderContentImageContainer > img").attr('src'),
+			this.oJSONModel.getProperty('/0/src'),
+			"objectImageURI successfully inited");
+		// objectTitle
+		assert.equal(this.oPageLayout.$().find("#ObjectPageLayout-opwrapper #header-innerTitle").text(),
+			this.oJSONModel.getProperty('/0/name'),
+			"objectTitle successfully inited");
+		// objectSubtitle
+		assert.equal(this.oPageLayout.$().find("#ObjectPageLayout-opwrapper #header-subtitle").text(),
+			this.oJSONModel.getProperty('/0/group'),
+			"objectSubtitle successfully inited");
+
+
+		// rebind
+		this.oPageLayout.bindObject('/1');
+		sap.ui.getCore().applyChanges();
+		this.clock.tick(1000);
+
+		assert.equal(this.oPageLayout.$().find("#ObjectPageLayout-opwrapper .sapUxAPObjectPageHeaderContentImageContainer > img").attr('src'),
+			this.oJSONModel.getProperty('/1/src'),
+			"objectImageURI successfully changed");
+		// objectTitle
+		assert.equal(this.oPageLayout.$().find("#ObjectPageLayout-opwrapper #header-innerTitle").text(),
+			this.oJSONModel.getProperty('/1/name'),
+			"objectTitle successfully changed");
+		// objectSubtitle
+		assert.equal(this.oPageLayout.$().find("#ObjectPageLayout-opwrapper #header-subtitle").text(),
+			this.oJSONModel.getProperty('/1/group'),
+			"objectSubtitle successfully changed");
+
+
+	});
+}(jQuery, QUnit));


### PR DESCRIPTION
When we use `sap.uxap.ObjectPageHeader` with `showTitleInHeaderContent = true` and empty sections aggregaton, there is incorrect update of ObjectPageHeader fields after context change. 
So I put additional check for emptiness of sections.

Exmple: 
[https://jsbin.com/sasizut/edit?html,output](https://jsbin.com/sasizut/edit?html,output)
You can uncomment sections, to check correct update.