### PR TITLE
Fix return value documentation of Element.clone

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/Element.js
+++ b/src/sap.ui.core/src/sap/ui/core/Element.js
@@ -870,11 +870,11 @@ sap.ui.define(['jquery.sap.global', '../base/Object', '../base/ManagedObject', '
 	/**
 	 * Create a clone of this Element.
 	 *
-	 * Calls <code>ManagedObject#clone</code> and additionally clones event delegates.
+	 * Calls {@link sap.ui.base.ManagedObject#clone} and additionally clones event delegates.
 	 *
 	 * @param {string} [sIdSuffix] Suffix to be appended to the cloned element ID
 	 * @param {string[]} [aLocalIds] Array of local IDs within the cloned hierarchy (internally used)
-	 * @return {sap.ui.base.ManagedObject} reference to the newly created clone
+	 * @return {sap.ui.core.Element} reference to the newly created clone
 	 * @protected
 	 */
 	Element.prototype.clone = function(sIdSuffix, aLocalIds){


### PR DESCRIPTION
Cloning an Element should also return an Element, right?

Also links the ManagedObject clone method.