### PR TITLE
Fix for issue # 1282

### DIFF
--- a/src/sap.m/src/sap/m/Page.js
+++ b/src/sap.m/src/sap/m/Page.js
@@ -234,7 +234,7 @@ sap.ui.define(["jquery.sap.global", "./library", "sap/ui/core/Control", "sap/ui/
 		};
 
     Page.prototype.onAfterRendering = function () {
-		  jQuery.sap.delayedCall(10, this, this._adjustFooterPadding);
+      jQuery.sap.delayedCall(10, this, this._adjustFooterPadding);
       jQuery.sap.delayedCall(10, this, this._adjustFooterWidth);
     };
 
@@ -400,7 +400,7 @@ sap.ui.define(["jquery.sap.global", "./library", "sap/ui/core/Control", "sap/ui/
 		};
 
 		Page.prototype._adjustFooterPadding = function() {
-				if(!this.getShowFooter() || !this.getFooter() || !sap.ui.Device.browser.safari) {
+				if (!this.getShowFooter() || !this.getFooter() || !sap.ui.Device.browser.safari) {
 					return;
 				}
 				var $footer = jQuery(this.getDomRef()).find(".sapMPageFooter").last();

--- a/src/sap.m/src/sap/m/Page.js
+++ b/src/sap.m/src/sap/m/Page.js
@@ -233,9 +233,10 @@ sap.ui.define(["jquery.sap.global", "./library", "sap/ui/core/Control", "sap/ui/
 			}
 		};
 
-        Page.prototype.onAfterRendering = function () {
-            jQuery.sap.delayedCall(10, this, this._adjustFooterWidth);
-        };
+    Page.prototype.onAfterRendering = function () {
+		  jQuery.sap.delayedCall(10, this, this._adjustFooterPadding);
+      jQuery.sap.delayedCall(10, this, this._adjustFooterWidth);
+    };
 
 		/**
 		 * Called when the control is destroyed.
@@ -396,6 +397,14 @@ sap.ui.define(["jquery.sap.global", "./library", "sap/ui/core/Control", "sap/ui/
 
 			this.setProperty("icon", sIconSrc, true);
 			return this;
+		};
+
+		Page.prototype._adjustFooterPadding = function() {
+				if(!this.getShowFooter() || !this.getFooter() || !sap.ui.Device.browser.safari) {
+					return;
+				}
+				var $footer = jQuery(this.getDomRef()).find(".sapMPageFooter").last();
+				$footer.css("padding-bottom","3rem"); /*TO DO: need to change 3REM to appropriate value based on screen */
 		};
 
 		Page.prototype._adjustFooterWidth = function () {


### PR DESCRIPTION
Issue is that safari is not interpreting the CSS correctly on footer; more specifically on class "sapMPageFooter." By adding padding-bottom it will push up the footer and will then display correctly.
We can adjust the CSS through the onAfterRendering function in Page.js in sap.m namespace. However, currently it is hardcoded to 3REM. I will need some input on how to specify the padding dynamically.