### PR TITLE
Default aggregation for sap.m.ActionSheet 

### DIFF
--- a/src/sap.m/src/sap/m/ActionSheet.js
+++ b/src/sap.m/src/sap/m/ActionSheet.js
@@ -70,6 +70,7 @@ sap.ui.define(['jquery.sap.global', './Dialog', './Popover', './library', 'sap/u
 			*/
 			_invisibleAriaTexts: {type : "sap.ui.core.InvisibleText", multiple : true, visibility : "hidden"}
 		},
+		defaultAggregation : "buttons",
 		events : {
 
 			/**


### PR DESCRIPTION
Some controls got a defaultAggregation, some don't. Why?