### PR TITLE
Updated separatorChar to ',' from ';'

### DIFF
--- a/src/sap.m/test/sap/m/demokit/sample/TableExport/Table.controller.js
+++ b/src/sap.m/test/sap/m/demokit/sample/TableExport/Table.controller.js
@@ -26,7 +26,7 @@ sap.ui.define([
 
 				// Type that will be used to generate the content. Own ExportType's can be created to support other formats
 				exportType : new ExportTypeCSV({
-					separatorChar : ";"
+					separatorChar : ","
 				}),
 
 				// Pass in the model created above


### PR DESCRIPTION
Standards (https://www.ietf.org/rfc/rfc4180.txt) define comma (,) as separator. Still CSV is 'Comma Separated Values'