### PR TITLE
[FIX] sap.m.Wizard: destroySteps typo fixed

### DIFF
--- a/src/sap.m/src/sap/m/Wizard.js
+++ b/src/sap.m/src/sap/m/Wizard.js
@@ -438,7 +438,7 @@ sap.ui.define([
 		Wizard.prototype.destroySteps = function () {
 			this._resetStepCount();
 			this._getProgressNavigator().setStepCount(this._getStepCount());
-			return this.destroyAggregations("steps");
+			return this.destroyAggregation("steps");
 		};
 
 		/**************************************** PRIVATE METHODS ***************************************/


### PR DESCRIPTION
There is a typo in destroySteps method of sap.m.Wizard control.
It's started from this commit: [3a678c58dce9c5e43861d5b00d3c6897d4eba899](https://github.com/xefimx/openui5/commit/3a678c58dce9c5e43861d5b00d3c6897d4eba899)
Author just make the typo in method destroyAggregation(**s**):

```
		Wizard.prototype.destroySteps = function () {
			this._resetStepCount();
			this._getProgressNavigator().setStepCount(this._getStepCount());
			return this.destroyAggregations("steps");
		};
```
So, when we try to bind steps aggregation through factory function, we get an Error (TypeError: this.destroyAggregations is not a function);

Example on JS Bin (you can uncomment 'template' property and comment 'factory', to make Wizard binding work):
[https://jsbin.com/zoqilujiri/edit?html,output](https://jsbin.com/zoqilujiri/edit?html,output)