### PR TITLE
[FEATURE] sap.m.SelectDialog: added CheckBox to select all list's items when MultiSelect mode is enabled

### DIFF
--- a/src/sap.m/src/sap/m/messagebundle.properties
+++ b/src/sap.m/src/sap/m/messagebundle.properties
@@ -337,6 +337,9 @@ FACETFILTERLIST_ARIA_POSITION={0} of {1}
 #YMSG: Message displayed near the list of selection items in the SelectDialg and TableSelectDialog controls. It will be filled with the number of selected items
 TABLESELECTDIALOG_SELECTEDITEMS=Items selected\: {0}
 
+#XTOL: Tooltip for the Select All Checkbox in the SelectDialog
+TABLESELECTDIALOG_SELECT_ALL_ITEMS=Select all
+
 #YMSG: Default placeholder for the input field of a feed
 FEEDINPUT_PLACEHOLDER=Post something here
 

--- a/src/sap.m/src/sap/m/messagebundle_en.properties
+++ b/src/sap.m/src/sap/m/messagebundle_en.properties
@@ -335,6 +335,9 @@ FACETFILTERLIST_ARIA_POSITION={0} of {1}
 #YMSG: Message displayed near the list of selection items in the SelectDialg and TableSelectDialog controls. It will be filled with the number of selected items
 TABLESELECTDIALOG_SELECTEDITEMS=Items selected\: {0}
 
+#XTOL: Tooltip for the Select All Checkbox in the SelectDialog
+TABLESELECTDIALOG_SELECT_ALL_ITEMS=Select all
+
 #YMSG: Default placeholder for the input field of a feed
 FEEDINPUT_PLACEHOLDER=Post something here
 

--- a/src/sap.m/src/sap/m/messagebundle_it.properties
+++ b/src/sap.m/src/sap/m/messagebundle_it.properties
@@ -335,6 +335,9 @@ FACETFILTERLIST_ARIA_POSITION={0} di {1}
 #YMSG: Message displayed near the list of selection items in the SelectDialg and TableSelectDialog controls. It will be filled with the number of selected items
 TABLESELECTDIALOG_SELECTEDITEMS=Elementi selezionati\: {0}
 
+#XTOL: Tooltip for the Select All Checkbox in the SelectDialog
+TABLESELECTDIALOG_SELECT_ALL_ITEMS=Seleziona tutto
+
 #YMSG: Default placeholder for the input field of a feed
 FEEDINPUT_PLACEHOLDER=Pubblica un contenuto qui
 


### PR DESCRIPTION
The CheckBox is only visible when MultiSelect mode is enabled.

The CheckBox behaviour is the same of the List/Table's one:
- When it's selected it will select all visible items.
- If it's selected and you deselect it it will deselect all items.
- If all items are selected and you deselect one, the Select All
checkbox will be deselected.
- If you open the Select Dialog and all the items are pre-selected
(rememberSelections="true") the Select All checkbox will be
auto-selected
- If you select all items of the list the Select All checkbox will be
auto-selected.

I've also added the tooltip translations inside:

- sap/m/messagebundle.properties
- sap/m/messagebundle_en.properties
- sap/m/messagebundle_it.properties