### PR TITLE
[FIX] changed Meteor-UI5 link on related projects page

### DIFF
--- a/OpenUI5RelatedProjects.json
+++ b/OpenUI5RelatedProjects.json
@@ -20,7 +20,7 @@
 		"Meteor-UI5": {
 			"name": "Meteor-UI5",
 			"decription": "Meteor-UI5 is a collection of packages that brings together two powerful open source JavaScript web frameworks: Meteor and OpenUI5.",
-			"githubLink": "https://github.com/propellerlabsio/meteor-ui5",
+			"githubLink": "https://github.com/propellerlabsio/meteor-ui5-website",
 			"documentationLink": "https://meteor-ui5.propellerlabs.com/",
 			"owner": "proehlen",
 			"license": "Apache 2.0",


### PR DESCRIPTION
- Change the url to Meteor-UI5 GitHub repository