### PR TITLE
Add MessageManager explored examples (from UI5Con 2017)

### DIFF
--- a/src/sap.ui.core/test/sap/ui/core/demokit/docuindex.json
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/docuindex.json
@@ -136,6 +136,17 @@
 				]
 			},
 			{
+				"id": "sap.ui.core.message.MessageManager",
+				"name": "Message Manager",
+				"category": "Display",
+				"since": "1.30",
+				"samples": [
+					"sap.ui.core.sample.MessageManager.BasicMessages",
+					"sap.ui.core.sample.MessageManager.BasicODataMessages",
+					"sap.ui.core.sample.MessageManager.ODataBackendMessagesComp"
+				]
+			},
+			{
 				"id" : "sap.ui.test.gherkin",
 				"name" : "Gherkin",
 				"category" : "Testing",
@@ -609,6 +620,21 @@
 				"id": "sap.ui.core.sample.matcher.LabelFor",
 				"name": "Label For Matcher",
 				"description": "The LabelFor matcher searches for given control associated with labelFor property."
+			},
+			{
+				"id": "sap.ui.core.sample.MessageManager.BasicMessages",
+				"name": "Basic Messages",
+				"description": "Shows how to create messages on the frontend and display them afterwards. This can be used for form validation on the frontend."
+			},
+			{
+				"id": "sap.ui.core.sample.MessageManager.BasicODataMessages",
+				"name": "Basic OData Messages",
+				"description": "Uses the MockServer to simulate an OData response containing different types of server side messages (error, warning, info, success)."
+			},
+			{
+				"id": "sap.ui.core.sample.MessageManager.ODataBackendMessagesComp",
+				"name": "OData Messages Component",
+				"description": "Shows how to handle OData responses containing server side messages in component based apps. Also illustrates how the sap-message header works."
 			},
 			{
 				"id": "sap.ui.core.sample.OpaStartup.iStartMyUIComponent",

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicMessages/Component.js
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicMessages/Component.js
@@ -1,0 +1,30 @@
+sap.ui.define([
+    "sap/ui/core/UIComponent"
+], function (UIComponent) {
+    "use strict";
+
+    return UIComponent.extend("sap.ui.core.sample.MessageManager.BasicMessages.Component", {
+        metadata: {
+            rootView: "sap.ui.core.sample.MessageManager.BasicMessages.View",
+            dependencies: {
+                libs: [
+                    "sap.m",
+                    "sap.ui.layout",
+                    "sap.ui.unified"
+                ]
+            },
+
+            config: {
+                sample: {
+                    stretch: true,
+                    files: [
+                        "Controller.controller.js",
+                        "MessagePopover.fragment.xml",
+                        "View.view.xml"
+                    ]
+                }
+            }
+        }
+    });
+
+});

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicMessages/Controller.controller.js
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicMessages/Controller.controller.js
@@ -1,0 +1,111 @@
+sap.ui.define([
+    "sap/ui/core/mvc/Controller",
+    "sap/ui/model/json/JSONModel",
+    "sap/ui/model/BindingMode",
+    "sap/ui/core/message/Message",
+    "sap/ui/core/MessageType",
+    "sap/ui/core/ValueState",
+    "sap/m/MessageToast"
+], function(Controller, JSONModel, BindingMode, Message, MessageType, ValueState, MessageToast) {
+    "use strict";
+
+    return Controller.extend("sap.ui.core.sample.MessageManager.BasicMessages.Controller", {
+
+        onInit : function () {
+            var oMessageManager, oModel, oView;
+
+            oView = this.getView();
+
+            // set message model
+            oMessageManager = sap.ui.getCore().getMessageManager();
+            oView.setModel(oMessageManager.getMessageModel(), "message");
+
+            // activate automatic message generation for controls
+            //oMessageManager.registerObject(oView.byId("mandatoryInput"), true);
+            //oMessageManager.registerObject(oView.byId("date"), true);
+            //oMessageManager.registerObject(oView.byId("int"), true);
+
+            // or just do it for the whole view
+            oMessageManager.registerObject(oView, true);
+
+            // create a default model with somde demo data
+            oModel = new JSONModel({
+                MandatoryInputValue: "",
+                DateValue: null,
+                IntegerValue: undefined,
+                Dummy: ""
+            });
+            oModel.setDefaultBindingMode(BindingMode.TwoWay);
+            oView.setModel(oModel);
+
+        },
+
+        onMessagePopoverPress : function (oEvent) {
+            this._getMessagePopover().openBy(oEvent.getSource());
+        },
+
+        onSuccessPress : function(){
+            var oMessage = new Message({
+                message: "My generated success message",
+                type: MessageType.Success,
+                target: "/Dummy",
+                processor: this.getView().getModel()
+            });
+            sap.ui.getCore().getMessageManager().addMessages(oMessage);
+        },
+
+        onErrorPress : function(){
+            var oMessage = new Message({
+                message: "My generated error message",
+                type: MessageType.Error,
+                target: "/Dummy",
+                processor: this.getView().getModel()
+            });
+            sap.ui.getCore().getMessageManager().addMessages(oMessage);
+        },
+
+        onWarningPress : function(){
+            var oMessage = new Message({
+                message: "My generated warning message",
+                type: MessageType.Warning,
+                target: "/Dummy",
+                processor: this.getView().getModel()
+            });
+            sap.ui.getCore().getMessageManager().addMessages(oMessage);
+        },
+
+        onInfoPress : function(){
+            var oMessage = new Message({
+                message: "My generated info message",
+                type: MessageType.Information,
+                target: "/Dummy",
+                processor: this.getView().getModel()
+            });
+            sap.ui.getCore().getMessageManager().addMessages(oMessage);
+        },
+
+        onValueStatePress : function(){
+            var oInput = this.getView().byId("valuesStateOnly");
+            oInput.setValueState(ValueState.Error);
+            oInput.setValueStateText("My ValueState text for Error");
+        },
+
+        onClearPress : function(){
+            // does not remove the manually set ValueStateText we set in onValueStatePress():
+            sap.ui.getCore().getMessageManager().removeAllMessages();
+        },
+
+        //################ Private APIs ###################
+
+        _getMessagePopover : function () {
+            // create popover lazily (singleton)
+            if (!this._oMessagePopover) {
+                this._oMessagePopover = sap.ui.xmlfragment(this.getView().getId(),"sap.ui.core.sample.MessageManager.BasicODataMessages.MessagePopover", this);
+                this.getView().addDependent(this._oMessagePopover);
+            }
+            return this._oMessagePopover;
+        }
+
+    });
+
+});

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicMessages/MessagePopover.fragment.xml
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicMessages/MessagePopover.fragment.xml
@@ -1,0 +1,13 @@
+<core:FragmentDefinition
+    xmlns="sap.m"
+    xmlns:core="sap.ui.core">
+    <MessagePopover
+        items="{message>/}"
+        initiallyExpanded="true">
+        <MessagePopoverItem
+            type="{message>type}"
+            title="{message>message}"
+            subtitle="{message>additionalText}"
+            description="{message>description}"/>
+    </MessagePopover>
+</core:FragmentDefinition>

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicMessages/View.view.xml
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicMessages/View.view.xml
@@ -1,0 +1,136 @@
+<mvc:View
+    controllerName="sap.ui.core.sample.MessageManager.BasicMessages.Controller"
+    xmlns="sap.m"
+    xmlns:core="sap.ui.core"
+    xmlns:mvc="sap.ui.core.mvc"
+	xmlns:f="sap.ui.layout.form"
+    height="100%"
+    displayBlock="true">
+
+    <Page
+        id="page"
+        showHeader="false"
+        class="sapUiContentPadding">
+        <content>
+            <f:Form
+                id="form"
+                editable="true"
+                title="UI Messages">
+                <f:layout>
+                    <f:ResponsiveGridLayout />
+                </f:layout>
+                <f:formContainers>
+                    <f:FormContainer
+                        id="formContainer"
+                        title="Fields">
+
+                        <f:FormElement>
+                            <f:label>
+                                <Label
+                                    text="String\{3,10\}"
+                                    required="true"/>
+                            </f:label>
+                            <f:fields>
+                                <Input
+                                    id="mandatoryInput"
+                                    value="{
+                                        path: '/MandatoryInputValue',
+                                        type: 'sap.ui.model.type.String',
+                                        constraints: {
+                                            minLength: 3,
+                                            maxLength: 10
+                                        }
+                                    }"/>
+                            </f:fields>
+                        </f:FormElement>
+
+                        <f:FormElement>
+                            <f:label>
+                                <Label text="DatePicker"/>
+                            </f:label>
+                            <f:fields>
+                                <DatePicker
+                                    id="date"
+                                    value="{
+                                        path:'/DateValue',
+                                        type:'sap.ui.model.type.Date',
+                                        formatOptions: {
+                                            style: 'short',
+                                            strictParsing: true
+                                        },
+                                        constraints: { }
+                                    }" />
+                            </f:fields>
+                        </f:FormElement>
+
+                        <f:FormElement>
+                            <f:label>
+                                <Label text="Integer 0-100"/>
+                            </f:label>
+                            <f:fields>
+                                <Input
+                                    id="int"
+                                    value="{
+                                        path: '/IntegerValue',
+                                        type:'sap.ui.model.type.Integer',
+                                        constraints: {
+                                            minimum: 0,
+                                            maximum: 100
+                                        }
+                                    }"/>
+                            </f:fields>
+                        </f:FormElement>
+
+                        <f:FormElement>
+                            <f:label>
+                                <Label text="Message Buttons"/>
+                            </f:label>
+                            <f:fields>
+                                <Input
+                                    id="dummy"
+                                    value="{/Dummy}"/>
+                            </f:fields>
+                        </f:FormElement>
+
+                        <f:FormElement>
+                            <f:label>
+                                <Label text="ValueState Only"/>
+                            </f:label>
+                            <f:fields>
+                                <Input
+                                    id="valuesStateOnly"
+                                    value="{/ValueStateOnly}"/>
+                            </f:fields>
+                        </f:FormElement>
+
+                    </f:FormContainer>
+                </f:formContainers>
+            </f:Form>
+        </content>
+
+        <footer>
+            <Toolbar
+                id="otbFooter">
+
+                <Button
+                    icon="sap-icon://alert"
+                    text="{= ${message>/}.length }"
+                    visible="{= ${message>/}.length > 0 }"
+                    type="Emphasized"
+                    press="onMessagePopoverPress" />
+
+                <ToolbarSpacer/>
+
+                <Button type="Accept" text="Success" press="onSuccessPress"/>
+                <Button type="Reject" text="Error" press="onErrorPress"/>
+                <Button text="Warning" press="onWarningPress"/>
+                <Button text="Info" press="onInfoPress"/>
+                <Button text="ValueState" press="onValueStatePress"/>
+                <Button text="Clear" press="onClearPress"/>
+
+            </Toolbar>
+        </footer>
+
+    </Page>
+
+</mvc:View>

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/Component.js
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/Component.js
@@ -1,0 +1,33 @@
+sap.ui.define([
+    "sap/ui/core/UIComponent"
+], function (UIComponent) {
+    "use strict";
+
+    return UIComponent.extend("sap.ui.core.sample.MessageManager.BasicODataMessages.Component", {
+        metadata: {
+            rootView: "sap.ui.core.sample.MessageManager.BasicODataMessages.View",
+            dependencies: {
+                libs: [
+					"sap.m",
+                    "sap.ui.layout"
+                ]
+            },
+
+            config: {
+                sample: {
+                    stretch: true,
+                    files: [
+                        "localService/mockdata/Employees.json",
+                        "localService/response/ODataErrorResponse.json",
+                        "localService/metadata.xml",
+                        "localService/mockserver.xml",
+                        "Controller.controller.js",
+                        "MessagePopover.fragment.xml",
+                        "View.view.xml"
+                    ]
+                }
+            }
+        }
+    });
+
+});

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/Controller.controller.js
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/Controller.controller.js
@@ -1,0 +1,66 @@
+sap.ui.define([
+    "sap/ui/core/mvc/Controller",
+    "sap/ui/model/odata/v2/ODataModel",
+    "sap/ui/core/sample/MessageManager/BasicODataMessages/localService/mockserver"
+], function(Controller, ODataModel, mockserver) {
+    "use strict";
+
+    return Controller.extend("sap.ui.core.sample.MessageManager.BasicODataMessages.Controller", {
+
+        onInit : function () {
+
+            var sODataServiceUrl, oMessageManager;
+
+            // set message model
+            oMessageManager = sap.ui.getCore().getMessageManager();
+            this.getView().setModel(oMessageManager.getMessageModel(), "message");
+
+            // activate automatic message generation for complete view
+            oMessageManager.registerObject(this.getView(), true);
+
+            sODataServiceUrl = "/here/goes/your/odata/service/url/";
+
+            // init our mock server
+            mockserver.init(sODataServiceUrl);
+
+            // Northwind service
+            this.getView().setModel(
+                new ODataModel(sODataServiceUrl, {
+                    json : true,
+                    useBatch : true,
+                    defaultBindingMode : "TwoWay"
+                })
+            );
+
+            this.getView().bindElement("/Employees(1)");
+
+        },
+
+        onMessagePopoverPress : function (oEvent) {
+            this._getMessagePopover().openBy(oEvent.getSource());
+        },
+
+        onDelete : function (oEvent) {
+            var sPath = this.getView().getBindingContext().getPath();
+            this.getView().getModel().remove(sPath);
+        },
+
+        onClearPress : function(){
+            sap.ui.getCore().getMessageManager().removeAllMessages();
+        },
+
+        //################ Private APIs ###################
+
+        _getMessagePopover : function () {
+            // create popover lazily (singleton)
+            if (!this._oMessagePopover) {
+                // create popover lazily (singleton)
+                this._oMessagePopover = sap.ui.xmlfragment(this.getView().getId(), "sap.ui.core.sample.MessageManager.BasicODataMessages.MessagePopover", this);
+                this.getView().addDependent(this._oMessagePopover);
+            }
+            return this._oMessagePopover;
+        }
+
+    });
+
+});

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/MessagePopover.fragment.xml
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/MessagePopover.fragment.xml
@@ -1,0 +1,13 @@
+<core:FragmentDefinition
+    xmlns="sap.m"
+    xmlns:core="sap.ui.core">
+    <MessagePopover
+        items="{message>/}"
+        initiallyExpanded="true">
+        <MessagePopoverItem
+            type="{message>type}"
+            title="{message>message}"
+            subtitle="{message>additionalText}"
+            description="{message>description}"/>
+    </MessagePopover>
+</core:FragmentDefinition>

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/View.view.xml
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/View.view.xml
@@ -1,0 +1,58 @@
+<mvc:View
+    controllerName="sap.ui.core.sample.MessageManager.BasicODataMessages.Controller"
+    xmlns="sap.m"
+    xmlns:core="sap.ui.core"
+    xmlns:mvc="sap.ui.core.mvc"
+    xmlns:l="sap.ui.layout"
+	xmlns:f="sap.ui.layout.form"
+    height="100%">
+
+    <Page
+        showHeader="false">
+        <content>
+            <VBox class="sapUiSmallMargin">
+        		<f:SimpleForm id="SimpleFormToolbar"
+        			editable="true"
+        			layout="ResponsiveGridLayout" >
+        			<f:content>
+
+        				<Label text="First Name" />
+        				<Input value="{FirstName}" />
+
+                        <Label text="Last Name" />
+        				<Input value="{LastName}" />
+
+                        <Label text="ZIP Code/City" />
+        				<Input value="{PostalCode}">
+        					<layoutData>
+        						<l:GridData span="L3 M4 S4" />
+        					</layoutData>
+        				</Input>
+        				<Input value="{City}" />
+
+        			</f:content>
+        		</f:SimpleForm>
+        	</VBox>
+        </content>
+
+        <footer>
+            <OverflowToolbar id="otbFooter">
+                <Button
+                    icon="sap-icon://alert"
+                    text="{=${message>/}.length}"
+                    visible="{=${message>/}.length > 0}"
+                    type="Emphasized"
+                    press="onMessagePopoverPress">
+                </Button>
+
+                <ToolbarSpacer/>
+
+                <Button text="Delete" press="onDelete" type="Reject"/>
+                <Button text="Clear" press="onClearPress"/>
+
+            </OverflowToolbar>
+        </footer>
+
+    </Page>
+
+</mvc:View>

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/localService/metadata.xml
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/localService/metadata.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx">
+	<edmx:DataServices xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" m:DataServiceVersion="1.0">
+		<Schema Namespace="DemoModel" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns="http://schemas.microsoft.com/ado/2008/09/edm">
+
+			<EntityType Name="Employee">
+				<Key>
+					<PropertyRef Name="EmployeeID" />
+				</Key>
+				<Property Name="EmployeeID" Type="Edm.Int32" Nullable="false" p8:StoreGeneratedPattern="Identity" xmlns:p8="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
+				<Property Name="LastName" Type="Edm.String" Nullable="false" MaxLength="20" Unicode="true" FixedLength="false"/>
+				<Property Name="FirstName" Type="Edm.String" Nullable="false" MaxLength="10" Unicode="true" FixedLength="false"/>
+				<Property Name="Address" Type="Edm.String" Nullable="true" MaxLength="60" Unicode="true" FixedLength="false" />
+				<Property Name="City" Type="Edm.String" Nullable="true" MaxLength="15" Unicode="true" FixedLength="false" />
+				<Property Name="Region" Type="Edm.String" Nullable="true" MaxLength="15" Unicode="true" FixedLength="false" />
+				<Property Name="PostalCode" Type="Edm.String" Nullable="true" MaxLength="10" Unicode="true" FixedLength="false"/>
+				<Property Name="Country" Type="Edm.String" Nullable="true" MaxLength="15" Unicode="true" FixedLength="false" />
+				<Property Name="HomePhone" Type="Edm.String" Nullable="true" MaxLength="24" Unicode="true" FixedLength="false" />
+				<Property Name="ManagerID" Type="Edm.Int32" Nullable="true" />
+			</EntityType>
+
+			<EntityContainer Name="DemoEntities" p7:LazyLoadingEnabled="true" m:IsDefaultEntityContainer="true" xmlns:p7="http://schemas.microsoft.com/ado/2009/02/edm/annotation">
+				<EntitySet Name="Employees" EntityType="DemoModel.Employee" />
+			</EntityContainer>
+
+		</Schema>
+	</edmx:DataServices>
+</edmx:Edmx>

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/localService/mockdata/Employees.json
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/localService/mockdata/Employees.json
@@ -1,0 +1,110 @@
+[
+	{
+		"EmployeeID": 1,
+		"LastName": "Davolio",
+		"FirstName": "Nancy",
+		"Address": "507 - 20th Ave. E. Apt. 2A",
+		"City": "Seattle",
+		"Region": "WA",
+		"PostalCode": "98122",
+		"Country": "USA",
+		"HomePhone": "(206) 555-9857",
+		"ManagerID": null
+	},
+	{
+		"EmployeeID": 2,
+		"LastName": "Fuller",
+		"FirstName": "Andrew",
+		"Address": "908 W. Capital Way",
+		"City": "Tacoma",
+		"Region": "WA",
+		"PostalCode": "98401",
+		"Country": "USA",
+		"HomePhone": "(206) 555-9482",
+		"ManagerID": 1
+	},
+	{
+		"EmployeeID": 3,
+		"LastName": "Leverling",
+		"FirstName": "Janet",
+		"Address": "722 Moss Bay Blvd.",
+		"City": "Kirkland",
+		"Region": "WA",
+		"PostalCode": "98033",
+		"Country": "USA",
+		"HomePhone": "(206) 555-3412",
+		"ManagerID": 1
+	},
+	{
+		"EmployeeID": 4,
+		"LastName": "Peacock",
+		"FirstName": "Margaret",
+		"Address": "4110 Old Redmond Rd.",
+		"City": "Redmond",
+		"Region": "WA",
+		"PostalCode": "98052",
+		"Country": "USA",
+		"HomePhone": "(206) 555-8122",
+		"ManagerID": 1
+	},
+	{
+		"EmployeeID": 5,
+		"LastName": "Buchanan",
+		"FirstName": "Steven",
+		"Address": "14 Garrett Hill",
+		"City": "London",
+		"Region": null,
+		"PostalCode": "SW1 8JR",
+		"Country": "UK",
+		"HomePhone": "(71) 555-4848",
+		"ManagerID": 4
+	},
+	{
+		"EmployeeID": 6,
+		"LastName": "Suyama",
+		"FirstName": "Michael",
+		"Address": "Coventry House Miner Rd.",
+		"City": "London",
+		"Region": null,
+		"PostalCode": "EC2 7JR",
+		"Country": "UK",
+		"HomePhone": "(71) 555-7773",
+		"ManagerID": 4
+	},
+	{
+		"EmployeeID": 7,
+		"LastName": "King",
+		"FirstName": "Robert",
+		"Address": "Edgeham Hollow Winchester Way",
+		"City": "London",
+		"Region": null,
+		"PostalCode": "RG1 9SP",
+		"Country": "UK",
+		"HomePhone": "(71) 555-5598",
+		"ManagerID": 4
+	},
+	{
+		"EmployeeID": 8,
+		"LastName": "Callahan",
+		"FirstName": "Laura",
+		"Address": "4726 - 11th Ave. N.E.",
+		"City": "Seattle",
+		"Region": "WA",
+		"PostalCode": "98105",
+		"Country": "USA",
+		"HomePhone": "(206) 555-1189",
+		"ManagerID": 7
+	},
+	{
+		"EmployeeID": 9,
+		"LastName": "Dodsworth",
+		"FirstName": "Anne",
+		"Address": "7 Houndstooth Rd.",
+		"City": "London",
+		"Region": null,
+		"PostalCode": "WG2 7LT",
+		"Country": "UK",
+		"HomePhone": "(71) 555-4444",
+		"ManagerID": null
+	}
+]

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/localService/mockserver.js
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/localService/mockserver.js
@@ -1,0 +1,58 @@
+sap.ui.define([
+	"sap/ui/core/util/MockServer"
+], function (MockServer) {
+	"use strict";
+
+	return {
+
+		init: function (sODataServiceUrl) {
+
+			var oMockServer, sLocalServicePath, aRequests, oErrorResponse;
+
+			// create
+			oMockServer = new MockServer({
+				rootUri: sODataServiceUrl
+			});
+
+			// configure
+			MockServer.config({
+				autoRespond: true,
+				autoRespondAfter: 1000
+			});
+
+			sLocalServicePath = jQuery.sap.getModulePath("sap.ui.core.sample.MessageManager.BasicODataMessages.localService");
+
+			// simulate
+			oMockServer.simulate(sLocalServicePath + "/metadata.xml", {
+				sMockdataBaseUrl : sLocalServicePath + "/mockdata",
+				bGenerateMissingMockData: false
+			});
+
+			// mock server error:
+			aRequests = oMockServer.getRequests();
+
+			// JSON response containing the OData error(s)
+			oErrorResponse = jQuery.sap.syncGetJSON(sLocalServicePath + "/response/ODataErrorResponse.json").data;
+
+			// mock all DELETE requests for Employees with the error response/message from above
+			aRequests.forEach(function(aRequest) {
+				if (aRequest.method === "DELETE" && aRequest.path.toString().indexOf("Employees") > -1) {
+                    this._fnResponse(500, oErrorResponse, aRequest);
+                }
+			}.bind(this));
+
+			// start
+			oMockServer.start();
+		},
+
+		// helper function
+		_fnResponse : function(iErrCode, oBody, aRequest) {
+			aRequest.response = function(oXhr, sUrlParams) {
+				oXhr.respond(iErrCode, {
+					"Content-Type": "application/json"
+				}, JSON.stringify(oBody));
+			};
+		}
+	};
+
+});

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/localService/response/ODataErrorResponse.json
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/BasicODataMessages/localService/response/ODataErrorResponse.json
@@ -1,0 +1,55 @@
+{
+    "error":{
+        "code":"ErrorCode-0",
+        "message":{
+            "lang":"en",
+            "value":"Leading Message - Exception raised without specific error"
+        },
+        "innererror":{
+            "transactionid":"566E06A5AC200A50E10080000A0F87DB",
+            "timestamp":"20160310120625.4547750",
+            "Error_Resolution":{
+                "SAP_Transaction":"Run transaction /IWFND/ERROR_LOG on SAP NW Gateway hub system and search for entries with the timestamp above for more details",
+                "SAP_Note":"See SAP Note 1797736 for error analysis (https://service.sap.com/sap/support/notes/1797736)",
+                "Batch_SAP_Note":"See SAP Note 1869434 for details about working with $batch (https://service.sap.com/sap/support/notes/1869434)"
+            },
+            "errordetails":[
+                {
+                    "code":"ErrorCode-1",
+                    "message":"Exception raised without specific error 1",
+                    "propertyref":"",
+                    "severity":"error",
+                    "target":""
+                },
+                {
+                    "code":"ErrorCode-2",
+                    "message":"Server does not like this zip code",
+                    "propertyref":"/Employees(1)/PostalCode",
+                    "severity":"error",
+                    "target":""
+                },
+                {
+                    "code":"SuccessCode-1",
+                    "message":"My success message for first name",
+                    "propertyref":"",
+                    "severity":"success",
+                    "target":"/Employees(1)/FirstName"
+                },
+                {
+                    "code":"WarningCode-1",
+                    "message":"My warning message for last name",
+                    "propertyref":"LastName",
+                    "severity":"warning",
+                    "target":"/Employees(1)"
+                },
+                {
+                    "code":"InfoCode-1",
+                    "message":"My information message",
+                    "propertyref":"",
+                    "severity":"info",
+                    "target":""
+                }
+            ]
+        }
+    }
+}

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/Component.js
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/Component.js
@@ -1,0 +1,42 @@
+sap.ui.define([
+	"sap/ui/core/UIComponent"
+],
+function (UIComponent) {
+	"use strict";
+
+	return UIComponent.extend("sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.Component", {
+		metadata: {
+			config: {
+				dependencies: {
+					libs: [
+						"sap.m"
+					]
+				},
+				sample: {
+					iframe: "webapp/index.html",
+					stretch: true,
+					files: [
+						"webapp/controller/App.controller.js",
+						"webapp/controller/BaseController.js",
+						"webapp/controller/Employee.controller.js",
+						"webapp/controller/NotFound.controller.js",
+						"webapp/fragment/MessagePopover.fragment.xml",
+						"webapp/i18n/i18n.properties",
+						"webapp/localService/mockdata/Employees_3.json",
+						"webapp/localService/mockdata/Employees.json",
+						"webapp/response/ODataErrorResponseTemplate.json",
+						"webapp/response/SAP-Message-Header.json",
+						"webapp/localService/metadata.xml",
+						"webapp/localService/mockserver.js",
+						"webapp/view/App.view.xml",
+						"webapp/view/Employee.view.xml",
+						"webapp/view/NotFound.view.xml",
+						"webapp/Component.js",
+						"webapp/index.html",
+						"webapp/manifest.json"
+					]
+				}
+			}
+		}
+	});
+});

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/Component.js
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/Component.js
@@ -1,0 +1,25 @@
+sap.ui.define([
+	"sap/ui/core/UIComponent"
+], function (UIComponent) {
+	"use strict";
+
+	return UIComponent.extend("sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.Component", {
+
+		metadata: {
+			manifest: "json"
+		},
+
+		init: function () {
+			// call the init function of the parent
+			UIComponent.prototype.init.apply(this, arguments);
+
+			// set message model
+			this.setModel(sap.ui.getCore().getMessageManager().getMessageModel(), "message");
+
+			// create the views based on the url/hash
+			this.getRouter().initialize();
+		}
+
+	});
+
+});

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/controller/App.controller.js
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/controller/App.controller.js
@@ -1,0 +1,14 @@
+sap.ui.define([
+	"sap/ui/core/mvc/Controller"
+], function (Controller) {
+	"use strict";
+
+	return Controller.extend("sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.controller.App", {
+
+		onInit: function () {
+
+		}
+
+	});
+
+});

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/controller/BaseController.js
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/controller/BaseController.js
@@ -1,0 +1,43 @@
+sap.ui.define([
+	"sap/ui/core/mvc/Controller",
+	"sap/ui/core/routing/History"
+], function (Controller, History) {
+	"use strict";
+
+	return Controller.extend("sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.controller.BaseController", {
+
+		getRouter : function () {
+			return sap.ui.core.UIComponent.getRouterFor(this);
+		},
+
+		onNavBack: function (oEvent) {
+			var oHistory, sPreviousHash;
+
+			oHistory = History.getInstance();
+			sPreviousHash = oHistory.getPreviousHash();
+
+			if (sPreviousHash !== undefined) {
+				window.history.go(-1);
+			} else {
+				this.getRouter().navTo("appHome", {}, true /*no history*/);
+			}
+		},
+
+		onMessagePopoverPress : function (oEvent) {
+			this._getMessagePopover().openBy(oEvent.getSource());
+		},
+
+		//################ Private APIs ###################
+
+		_getMessagePopover : function () {
+			// create popover lazily
+			if (!this._oMessagePopover) {
+				this._oMessagePopover = sap.ui.xmlfragment(this.getView().getId(), "sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.fragment.MessagePopover", this);
+				this.getView().addDependent(this._oMessagePopover);
+			}
+			return this._oMessagePopover;
+		}
+
+	});
+
+});

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/controller/Employee.controller.js
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/controller/Employee.controller.js
@@ -1,0 +1,75 @@
+sap.ui.define([
+	"sap/ui/core/sample/MessageManager/ODataBackendMessagesComp/controller/BaseController",
+	"sap/ui/model/json/JSONModel",
+	"sap/m/MessageToast",
+	"sap/ui/model/Binding"
+], function (BaseController, JSONModel, MessageToast, Binding) {
+	"use strict";
+
+	return BaseController.extend("sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.controller.Employee", {
+
+		onInit: function () {
+
+			//create a view model
+			var oViewModel = new JSONModel({
+				busy : false,
+				dirty : false
+			});
+			oViewModel.setDefaultBindingMode("TwoWay");
+			this.getView().setModel(oViewModel, "view");
+
+			this.getRouter().getRoute("employee").attachMatched(this._onRouteMatched, this);
+		},
+
+		_onRouteMatched : function (oEvent){
+			var oViewModel;
+
+			oViewModel = this.getView().getModel("view");
+
+			this.getView().bindElement({
+				path : "/Employees(3)",		//hard coded in this demo
+				events : {
+					change: function(){
+						var oBinding, oElementBinding, oModel;
+
+						oElementBinding	= this.getView().getElementBinding();
+						if (oElementBinding && !oElementBinding.getBoundContext()) {
+							MessageToast.show("No data - do something here...");
+						} else {
+							oModel = this.getView().getModel();
+							oBinding = new Binding(oModel, oElementBinding.getPath(), oElementBinding.getBoundContext());
+							oBinding.attachChange(function(oEvent) {
+								if (oModel.hasPendingChanges()){
+									oViewModel.setProperty("/dirty", true);
+								}else {
+									oViewModel.setProperty("/dirty", false);
+								}
+							});
+						}
+					}.bind(this),
+					dataRequested: function (oEvent) {
+						oViewModel.setProperty("/busy", true);
+					},
+					dataReceived: function (oEvent) {
+						oViewModel.setProperty("/busy", false);
+					}
+				}
+			});
+		},
+
+		onCheckHasPendingChanges : function (oEvent) {
+			MessageToast.show("Has Pending Changes: " + this.getView().getModel().hasPendingChanges());
+		},
+
+		onRevertChanges : function (oEvent) {
+			this.getView().getModel().resetChanges();
+			sap.ui.getCore().getMessageManager().removeAllMessages();
+		},
+
+		onSave : function (oEvent) {
+			this.getView().getModel().submitChanges();
+		}
+
+	});
+
+});

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/controller/NotFound.controller.js
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/controller/NotFound.controller.js
@@ -1,0 +1,33 @@
+sap.ui.define([
+	"sap/ui/core/sample/MessageManager/ODataBackendMessagesComp/controller/BaseController"
+], function (BaseController) {
+	"use strict";
+
+	return BaseController.extend("sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.controller.NotFound", {
+
+		onInit: function () {
+			var oRouter, oTarget;
+
+			oRouter = this.getRouter();
+			oTarget = oRouter.getTarget("notFound");
+			oTarget.attachDisplay(function (oEvent) {
+				this._oData = oEvent.getParameter("data");	// store the data
+			}, this);
+		},
+
+		// override the parent's onNavBack (inherited from BaseController)
+		onNavBack : function (oEvent){
+			// in some cases we could display a certain target when the back button is pressed
+			if (this._oData && this._oData.fromTarget) {
+				this.getRouter().getTargets().display(this._oData.fromTarget);
+				delete this._oData.fromTarget;
+				return;
+			}
+
+			// call the parent's onNavBack
+			BaseController.prototype.onNavBack.apply(this, arguments);
+		}
+
+	});
+
+});

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/fragment/MessagePopover.fragment.xml
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/fragment/MessagePopover.fragment.xml
@@ -1,0 +1,13 @@
+<core:FragmentDefinition
+    xmlns="sap.m"
+    xmlns:core="sap.ui.core">
+    <MessagePopover
+        items="{message>/}"
+        initiallyExpanded="true">
+        <MessagePopoverItem
+            type="{message>type}"
+            title="{message>message}"
+            subtitle="{message>additionalText}"
+            description="{message>description}"/>
+    </MessagePopover>
+</core:FragmentDefinition>

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/i18n/i18n.properties
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/i18n/i18n.properties
@@ -1,0 +1,5 @@
+# App Descriptor
+appTitle=SAPUI5 Message Manager Example
+appDescription=A simple app that illustrates how to use the messages concept in UI5
+
+homePageTitle=Home

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/index.html
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta charset="utf-8">
+		<title>SAPUI5 Messages</title>
+		<script
+				id="sap-ui-bootstrap"
+				src="../../../../../../../../../resources/sap-ui-core.js"
+				data-sap-ui-theme="sap_belize"
+				data-sap-ui-libs="sap.m"
+				data-sap-ui-bindingSyntax="complex"
+				data-sap-ui-compatVersion="edge"
+				data-sap-ui-preload="async"
+				data-sap-ui-resourceroots='{
+					"sap.ui.core.sample.MessageManager.ODataBackendMessagesComp": "./"
+				}'>
+		</script>
+
+		<script>
+
+			sap.ui.getCore().attachInit(function () {
+				sap.ui.require([
+					"sap/ui/core/sample/MessageManager/ODataBackendMessagesComp/localService/mockserver",
+					"sap/m/Shell",
+					"sap/ui/core/ComponentContainer"
+				], function (mockserver, Shell, ComponentContainer) {
+					mockserver.init();
+					new Shell({
+						app: new ComponentContainer({
+							name: "sap.ui.core.sample.MessageManager.ODataBackendMessagesComp",
+							height: "100%"
+						})
+					}).placeAt("content");
+				});
+			});
+
+		</script>
+
+	</head>
+	<body class="sapUiBody" id="content">
+	</body>
+</html>

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/localService/metadata.xml
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/localService/metadata.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx">
+	<edmx:DataServices xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" m:DataServiceVersion="1.0">
+		<Schema Namespace="EmployeesModel" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns="http://schemas.microsoft.com/ado/2008/09/edm">
+
+			<EntityType Name="Employee">
+				<Key>
+					<PropertyRef Name="EmployeeID" />
+				</Key>
+				<Property Name="EmployeeID" Type="Edm.Int32" Nullable="false" p8:StoreGeneratedPattern="Identity" xmlns:p8="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
+				<Property Name="LastName" Type="Edm.String" Nullable="false" MaxLength="20" Unicode="true" FixedLength="false" />
+				<Property Name="FirstName" Type="Edm.String" Nullable="false" MaxLength="10" Unicode="true" FixedLength="false" />
+				<Property Name="BirthDate" Type="Edm.DateTime" Nullable="true"/>
+				<Property Name="HireDate" Type="Edm.DateTime" Nullable="true"/>
+				<Property Name="Address" Type="Edm.String" Nullable="true" MaxLength="60" Unicode="true" FixedLength="false" />
+				<Property Name="City" Type="Edm.String" Nullable="true" MaxLength="15" Unicode="true" FixedLength="false" />
+				<Property Name="Region" Type="Edm.String" Nullable="true" MaxLength="15" Unicode="true" FixedLength="false" />
+				<Property Name="PostalCode" Type="Edm.String" Nullable="true" MaxLength="10" Unicode="true" FixedLength="false" />
+				<Property Name="Country" Type="Edm.String" Nullable="true" MaxLength="15" Unicode="true" FixedLength="false" />
+				<Property Name="HomePhone" Type="Edm.String" Nullable="true" MaxLength="24" Unicode="true" FixedLength="false" />
+			</EntityType>
+
+			<EntityContainer Name="NavigationEntities" p7:LazyLoadingEnabled="true" m:IsDefaultEntityContainer="true" xmlns:p7="http://schemas.microsoft.com/ado/2009/02/edm/annotation">
+
+				<EntitySet Name="Employees" EntityType="EmployeesModel.Employee" />
+
+			</EntityContainer>
+
+		</Schema>
+	</edmx:DataServices>
+</edmx:Edmx>

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/localService/mockdata/Employees.json
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/localService/mockdata/Employees.json
@@ -1,0 +1,15 @@
+[
+	{
+		"EmployeeID": 3,
+		"LastName": "Leverling",
+		"FirstName": "Janet",
+		"Address": "722 Moss Bay Blvd.",
+		"BirthDate": "/Date(-200102400000)/",
+		"HireDate": "/Date(702086400000)/",
+		"City": "Kirkland",
+		"Region": "WA",
+		"PostalCode": "98033",
+		"Country": "USA",
+		"HomePhone": "(206) 555-3412"
+	}
+]

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/localService/mockdata/Employees_3.json
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/localService/mockdata/Employees_3.json
@@ -1,0 +1,20 @@
+{
+	"d":{
+		"EmployeeID":3,
+		"LastName":"Leverling",
+		"FirstName":"Janet",
+		"Address":"722 Moss Bay Blvd.",
+		"BirthDate":"/Date(-200102400000)/",
+		"HireDate":"/Date(702086400000)/",
+		"City":"Kirkland",
+		"Region":"WA",
+		"PostalCode":"98033",
+		"Country":"USA",
+		"HomePhone":"(206) 555-3412",
+		"__metadata":{
+			"id":"/here/goes/your/serviceUrl/Employees(3)",
+			"type":"EmployeesModel.Employee",
+			"uri":"/here/goes/your/serviceUrl/Employees(3)"
+		}
+	}
+}

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/localService/mockserver.js
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/localService/mockserver.js
@@ -1,0 +1,121 @@
+sap.ui.define([
+	"sap/ui/core/util/MockServer"
+], function (MockServer) {
+	"use strict";
+
+	return {
+
+		init: function () {
+
+			var sODataServiceUrl = "/here/goes/your/serviceUrl/";
+
+			var oMockServer = new MockServer({
+				rootUri: sODataServiceUrl
+			});
+
+			var sLocalServicePath = jQuery.sap.getModulePath("sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.localService");
+
+			// configure mock server with a delay
+			MockServer.config({
+				autoRespond: true,
+				autoRespondAfter: 1000
+			});
+
+			oMockServer.simulate(sLocalServicePath + "/metadata.xml", {
+				sMockdataBaseUrl: sLocalServicePath + "/mockdata",
+				bGenerateMissingMockData: true
+			});
+
+			// ##########################################
+			// # Begin Simulate Responses
+			// ##########################################
+
+			// JSON response containing the OData error(s)
+			var oErrorResponseTemplate = jQuery.sap.syncGetJSON(sLocalServicePath + "/response/ODataErrorResponseTemplate.json").data;
+
+			// sap-message header data
+			var oSapMessageHeaderValue = jQuery.sap.syncGetJSON(sLocalServicePath + "/response/SAP-Message-Header.json").data;
+
+			// pre-fetch the mockdata
+			//var aEmployees = jQuery.sap.syncGetJSON(sLocalServicePath + "/mockdata/Employees.json").data;
+			var oEmployee = jQuery.sap.syncGetJSON(sLocalServicePath + "/mockdata/Employees_3.json").data;
+
+			var aRequests = oMockServer.getRequests();
+
+			var fnValidateUpdateEntity = function(oEmployee){
+				var aErrors = [];
+				// simulate some dummy backend validation
+				if (!oEmployee.FirstName) {
+					aErrors.push({
+						code:"EmptyFirstName",
+						message:"First name mustn't be empty",
+						propertyref:"",
+						severity:"error",
+						target:"/Employees(3)/FirstName"
+					});
+				}
+				if (!oEmployee.LastName) {
+					aErrors.push({
+						code:"EmptyLastName",
+						message:"Last name mustn't be empty",
+						propertyref:"",
+						severity:"error",
+						target:"/Employees(3)/LastName"
+					});
+				}
+				return aErrors;
+			};
+
+			var fnUpdateEntityResponse = function(aRequest) {
+				aRequest.response = function(oXhr) {
+					var oData = JSON.parse(oXhr.requestBody);
+					var aErrors = fnValidateUpdateEntity(oData);
+
+					if (aErrors.length) {
+						oErrorResponseTemplate.error.innererror.errordetails = aErrors;
+						oXhr.respond(500, {
+							"Content-Type": "application/json"
+						}, JSON.stringify(oErrorResponseTemplate));
+
+					} else {
+						// update mock data
+						oEmployee.d.FirstName = oData.FirstName;
+						oEmployee.d.LastName  = oData.LastName;
+						oEmployee.d.BirthDate = oData.BirthDate;
+						oEmployee.d.HireDate  = oData.HireDate;
+
+						// now send the ok response
+						oXhr.respond(200, {
+							"Content-Type": "application/json",
+							"sap-message": JSON.stringify(oSapMessageHeaderValue)
+						}, JSON.stringify(oEmployee));
+					}
+				};
+			};
+
+			var fnGetEntityResponse = function(aRequest) {
+				aRequest.response = function(oXhr) {
+					oXhr.respond(200, {
+						"Content-Type": "application/json"
+					}, JSON.stringify(oEmployee));
+				};
+			};
+
+			aRequests.forEach(function(aRequest) {
+				if (aRequest.method === "GET" && aRequest.path.toString().indexOf("Employees") > -1) {
+					//we simply return always the first entry
+					fnGetEntityResponse(aRequest);
+				}else if (aRequest.method === "PUT" && aRequest.path.toString().indexOf("Employees") > -1){
+					fnUpdateEntityResponse(aRequest);
+				}
+			});
+
+			// ##########################################
+			// # End Simulate Responses
+			// ##########################################
+
+			oMockServer.start();
+		}
+	};
+
+});

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/localService/response/ODataErrorResponseTemplate.json
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/localService/response/ODataErrorResponseTemplate.json
@@ -1,0 +1,15 @@
+{
+    "error":{
+        "code":"BusinessError-123",
+        "message":{
+            "lang":"en",
+            "value":"Employee was not updated"
+        },
+        "innererror":{
+            "transactionid":"566E06A5AC200A50E10080000A0F87DB",
+            "timestamp":"20160310120625.4547750",
+            "Error_Resolution":{ },
+            "errordetails":[ ]
+        }
+    }
+}

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/localService/response/SAP-Message-Header.json
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/localService/response/SAP-Message-Header.json
@@ -1,0 +1,26 @@
+{
+	"code":"MYCODE/111",
+	"message":"Data was successfully saved",
+	"severity":"success",
+	"target":"",
+	"details":[
+		{
+			"code":"MYCODE/222",
+			"message":"My success detail",
+			"target":"",
+			"severity":"success"
+		},
+		{
+			"code":"MYCODE/333",
+			"message":"Nice first name",
+			"target":"FirstName",
+			"severity":"info"
+		},
+		{
+			"code":"MYCODE/333",
+			"message":"Think about changing your last name",
+			"target":"LastName",
+			"severity":"warning"
+		}
+	]
+}

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/manifest.json
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/manifest.json
@@ -1,0 +1,95 @@
+{
+	"_version": "1.1.0",
+	"sap.app": {
+		"_version": "1.1.0",
+		"id": "sap.ui.core.sample.MessageManager.ODataBackendMessagesComp",
+		"type": "application",
+		"i18n": "i18n/i18n.properties",
+		"title": "{{appTitle}}",
+		"description": "{{appDescription}}",
+		"applicationVersion": {
+			"version": "1.0.0"
+		},
+		"ach": "CA-UI5-DOC",
+		"dataSources": {
+			"employeeRemote": {
+				"uri": "/here/goes/your/serviceUrl/",
+				"type": "OData",
+				"settings": {
+					"odataVersion": "2.0",
+					"localUri" : "localService/metadata.xml"
+				}
+			}
+		}
+	},
+	"sap.ui": {
+		"_version": "1.1.0",
+		"technology": "UI5",
+		"deviceTypes": {
+			"desktop": true,
+			"tablet": true,
+			"phone": true
+		},
+		"supportedThemes": ["sap_belize"]
+  	},
+	"sap.ui5": {
+		"_version": "1.1.0",
+		"rootView": "sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.view.App",
+		"handleValidation"  : true,
+		"dependencies": {
+			"minUI5Version": "1.30",
+			"libs": {
+				"sap.m": { },
+				"sap.ui.layout": { },
+				"sap.ui.unified": { }
+			}
+		},
+		"models": {
+			"i18n": {
+				"type": "sap.ui.model.resource.ResourceModel",
+				"settings": {
+					"bundleName": "sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.i18n.i18n"
+				}
+			},
+			"": {
+				"dataSource": "employeeRemote",
+				"settings" : {
+					"json": true,
+					"useBatch": false,
+					"defaultBindingMode": "TwoWay",
+					"defaultUpdateMethod" : "Put",
+					"skipMetadataAnnotationParsing" : true,
+					"disableHeadRequestForToken" : true
+				}
+			}
+		},
+		"routing": {
+			"config": {
+				"routerClass": "sap.m.routing.Router",
+				"viewType": "XML",
+				"viewPath": "sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.view",
+				"controlId": "app",
+				"controlAggregation": "pages",
+				"transition": "slide",
+				"bypassed": {
+					"target": "notFound"
+				}
+			},
+			"routes": [{
+				"pattern": "",
+				"name": "employee",
+				"target": "employee"
+			}],
+			"targets": {
+				"employee": {
+					"viewName": "Employee",
+					"viewLevel" : 1
+				},
+				"notFound": {
+					"viewName": "NotFound",
+					"transition": "show"
+				}
+			}
+		}
+	}
+}

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/view/App.view.xml
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/view/App.view.xml
@@ -1,0 +1,9 @@
+<mvc:View
+	controllerName="sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.controller.App"
+	xmlns="sap.m"
+	xmlns:mvc="sap.ui.core.mvc"
+	displayBlock="true">
+	<App id="app">
+		<pages /> <!-- filled via routing -->
+	</App>
+</mvc:View>

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/view/Employee.view.xml
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/view/Employee.view.xml
@@ -1,0 +1,72 @@
+<mvc:View
+	controllerName="sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.controller.Employee"
+	xmlns="sap.m"
+	xmlns:mvc="sap.ui.core.mvc"
+	xmlns:f="sap.ui.layout.form"
+	displayBlock="true">
+	<Page title="Employee">
+		<content>
+			<f:SimpleForm
+				id="form"
+				busy="{view>/busy}"
+				minWidth="1024"
+				maxContainerCols="2"
+				editable="true"
+				layout="ResponsiveGridLayout"
+				labelSpanL="3" labelSpanM="3"
+				emptySpanL="4" emptySpanM="4"
+				columnsL="1" columnsM="1">
+
+				<f:content>
+
+					<Label text="First Name" required="true"/>
+					<Input value="{FirstName}" required="true"/>
+
+					<Label text="Last Name" required="true"/>
+					<Input value="{LastName}"/>
+
+					<Label text="Birthday"/>
+					<DatePicker
+						value="{
+							path:'BirthDate',
+							type: 'sap.ui.model.type.Date',
+							formatOptions: {
+								style: 'medium',
+								strictParsing: true
+							}
+						}"/>
+
+					<Label text="Hire Date" />
+					<DatePicker
+						value="{
+							path:'HireDate',
+							type:'sap.ui.model.type.Date',
+							formatOptions: {
+								style: 'medium',
+								strictParsing: true
+							}
+						}"/>
+				</f:content>
+			</f:SimpleForm>
+
+		</content>
+		<footer>
+			<OverflowToolbar
+				id="otbFooter">
+				<Button
+					icon="sap-icon://alert"
+					text="{=${message>/}.length}"
+					visible="{=${message>/}.length > 0}"
+					type="Emphasized"
+					press="onMessagePopoverPress"/>
+
+				<ToolbarSpacer/>
+
+				<Button text="Save" type="Accept" enabled="{view>/dirty}" press="onSave"/>
+				<Button text="Revert Changes" type="Reject" press="onRevertChanges"/>
+				<Button text="Has pending changes" press="onCheckHasPendingChanges"/>
+
+			</OverflowToolbar>
+		</footer>
+	</Page>
+</mvc:View>

--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/view/NotFound.view.xml
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/MessageManager/ODataBackendMessagesComp/webapp/view/NotFound.view.xml
@@ -1,0 +1,11 @@
+<mvc:View
+	controllerName="sap.ui.core.sample.MessageManager.ODataBackendMessagesComp.controller.NotFound"
+	xmlns="sap.m"
+	xmlns:mvc="sap.ui.core.mvc">
+	<MessagePage
+		title="{i18n>NotFound}"
+		text="{i18n>NotFound.text}"
+		description="{i18n>NotFound.description}"
+		showNavButton="true"
+		navButtonPress="onNavBack"/>
+</mvc:View>


### PR DESCRIPTION
The following examples from the UI5Con 2017 March event are added to
the Explored App:

- Basic Messages: Shows how to create messages on the frontend and
display them afterwards. This can be used for form validation on the
frontend.

- Basic OData Messages: Uses the MockServer to simulate an OData
response containing different types of server side messages (error,
warning, info, success).

- OData Messages Component: Shows how to handle OData responses
containing server side messages in component based apps. Also
llustrates how the sap-message header works.