### PR TITLE
[FEATURE] sap.m.TimePicker: added startValue Property

### DIFF
--- a/src/sap.m/src/sap/m/TimePicker.js
+++ b/src/sap.m/src/sap/m/TimePicker.js
@@ -150,7 +150,14 @@ sap.ui.define(['jquery.sap.global', './InputBase', './MaskInput', './MaskInputRu
 					 * The seconds slider is populated only by multiples of the step.
 					 * @since 1.40
 					 */
-					secondsStep: {type: "int", group: "Misc", defaultValue: 1}
+					secondsStep: {type: "int", group: "Misc", defaultValue: 1},
+
+					/**
+					 * Sets the default start value for the slider.
+					 * The start value overrides the current slider value and will
+					 * always be displayed when the slider is opened.
+					 */
+					startValue: {type: "string", group : "Data", defaultValue : null }
 				},
 				aggregations: {
 					/**
@@ -308,7 +315,15 @@ sap.ui.define(['jquery.sap.global', './InputBase', './MaskInput', './MaskInputRu
 			/* Set the timevalues of the picker here to prevent user from seeing it */
 			var oSliders = this._getSliders();
 
-			oSliders.setTimeValues(this.getDateValue());
+			var startValue = this.getStartValue();
+
+			if (startValue) {
+				var oDate = this._parseValue(startValue);
+				oSliders.setTimeValues(oDate);
+			} else {
+				oSliders.setTimeValues(this.getDateValue());
+			}
+
 			oSliders.collapseAll();
 
 			/* Mark input as active */

--- a/src/sap.m/test/sap/m/TimePicker.html
+++ b/src/sap.m/test/sap/m/TimePicker.html
@@ -97,6 +97,13 @@
 				displayFormat: "ah:mm:ss",
 				valueFormat: "HH:mm:ss",
 				value: "13:22:52"
+			},
+			{
+				value: "13:15:52",
+				startValue: "01:12:52"
+			},
+			{
+				startValue: "15:33:02"
 			}
 		];
 


### PR DESCRIPTION
The TimePicker element defaults to the current time when the
popup is opened and no initial value is set. There is currently
no options to override this behavior.

The TimePicker now has an additional property to allow developers
to pick a default value to be displayed in the slider popup.
- When no value is set, it defaults to the current time (default
  behavior).
- When a value is specified, it always defaults to the startValue
  property

The onBeforeOpen handles checking this value prior to displaying
the sliders.

Fixes https://github.com/SAP/openui5/issues/1312