### PR TITLE
[FEATURE] FileUploader: processing of files before upload via interface

### DIFF
--- a/src/sap.ui.unified/src/sap/ui/unified/FileUploader.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/FileUploader.js
@@ -23,7 +23,7 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/Control', './library', 'sap/ui/
 	 * @class
 	 * The framework generates an input field and a button with text "Browse ...". The API supports features such as on change uploads (the upload starts immediately after a file has been selected), file uploads with explicit calls, adjustable control sizes, text display after uploads, or tooltips containing complete file paths.
 	 * @extends sap.ui.core.Control
-	 * @implements sap.ui.core.IFormContent
+	 * @implements sap.ui.core.IFormContent, sap.ui.unified.IProcessableBlobs
 	 *
 	 * @author SAP SE
 	 * @version ${version}
@@ -35,7 +35,7 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/Control', './library', 'sap/ui/
 	 */
 	var FileUploader = Control.extend("sap.ui.unified.FileUploader", /** @lends sap.ui.unified.FileUploader.prototype */ { metadata : {
 
-		interfaces : ["sap.ui.core.IFormContent"],
+		interfaces : ["sap.ui.core.IFormContent", "sap.ui.unified.IProcessableBlobs"],
 		library : "sap.ui.unified",
 		properties : {
 
@@ -1038,8 +1038,7 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/Control', './library', 'sap/ui/
 			this._bUploading = true;
 			if (this.getSendXHR() && window.File) {
 				var aFiles = this.FUEl.files;
-
-				this._sendFilesWithXHR(aFiles);
+				this._sendProcessedFilesWithXHR(aFiles);
 			} else if (uploadForm) {
 				uploadForm.submit();
 				this._resetValueAfterUploadStart();
@@ -1321,7 +1320,7 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/Control', './library', 'sap/ui/
 				var formData = new window.FormData();
 				var name = this.FUEl.name;
 				for (var l = 0; l < aFiles.length; l++) {
-					formData.append(name, aFiles[l]);
+					formData.append(name, aFiles[l], aFiles[l].name);
 				}
 				formData.append("_charset_", "UTF-8");
 				var data = this.FUDataEl.name;
@@ -1348,6 +1347,21 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/Control', './library', 'sap/ui/
 			this._resetValueAfterUploadStart();
 		}
 
+		return this;
+	};
+
+	/*
+	* Processes the passed files and sends them afterwards via XHR request.
+	* @param {array} [aFiles] list of files from type window.File
+	* @returns this
+	* @private
+	*/
+	FileUploader.prototype._sendProcessedFilesWithXHR = function (aFiles) {
+		this.getProcessedBlobsFromArray(aFiles).then(function(aBlobs){
+			this._sendFilesWithXHR(aBlobs);
+		}.bind(this)).catch(function(oResult){
+			jQuery.sap.log.error("File upload failed: " + oResult && oResult.message ? oResult.message : "no details available");
+		});
 		return this;
 	};
 
@@ -1440,9 +1454,8 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/Control', './library', 'sap/ui/
 	*/
 	FileUploader.prototype._sendFilesFromDragAndDrop = function (aFiles) {
 		if (this._areFilesAllowed(aFiles)) {
-			this._sendFilesWithXHR(aFiles);
+			this._sendProcessedFilesWithXHR(aFiles);
 		}
-
 		return this;
 	};
 
@@ -1633,6 +1646,25 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/Control', './library', 'sap/ui/
 				this.ontap(); // The default behaviour on click on label is to open "open file" dialog. The only way to attach click event that is transferred from the label to the button is this way. AttachPress and attachTap don't work in this case.
 			}.bind(this));
 		}
+	};
+
+	/**
+	 * Allows to process Blobs before they get uploaded. This API can be used to create custom Blobs
+	 * and upload these custom Blobs instead of the received/initials Blobs in the parameter <code>aBlobs</code>.
+	 * One use case could be to create and upload zip archives based on the passed Blobs.
+	 * The default implementation of this API should simply resolve with the received Blobs (parameter <code>aBlobs</code>).
+	 *
+	 * This API is only supported in case sendXHR is true. This means only IE10+ is supported, while IE9 and below is not.
+	 *
+	 * This is a default implementation of the interface </code>sap.ui.unified.IProcessableBlobs</code>.
+	 *
+	 * @param {Blob[]} aBlobs The initial Blobs which can be used to determine/calculate a new array of Blobs for further processing.
+	 * @return {Promise} A Promise that resolves with an array of Blobs which is used for the final uploading.
+	 */
+	FileUploader.prototype.getProcessedBlobsFromArray = function (aBlobs){
+		return new Promise(function(resolve){
+			resolve(aBlobs);
+		});
 	};
 
 

--- a/src/sap.ui.unified/src/sap/ui/unified/library.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/library.js
@@ -26,7 +26,9 @@ sap.ui.define([
 			"sap.ui.unified.ContentSwitcherAnimation",
 			"sap.ui.unified.ColorPickerMode"
 		],
-		interfaces: [],
+		interfaces: [
+			"sap.ui.unified.IProcessableBlobs"
+		],
 		controls: [
 			"sap.ui.unified.calendar.DatesRow",
 			"sap.ui.unified.calendar.Header",
@@ -439,6 +441,30 @@ sap.ui.define([
 		HSL : "HSL"
 
 	};
+
+	/**
+	 * Marker interface for controls that process instances of window.Blob, i.e. window.File.
+	 * The implementation of this Interface should implement the following Interface methods:
+	 * <ul>
+	 * <li><code>getProcessedBlobsFromArray</code></li>
+	 * </ul>
+	 *
+	 * @name sap.ui.unified.IProcessableBlobs
+	 * @interface
+	 * @public
+	 * @ui5-metamodel This interface also will be described in the UI5 (legacy) designtime metamodel
+	 */
+
+	/**
+	 * Allows to process Blobs before they get uploaded. This API can be used to create custom Blobs
+	 * and upload these custom Blobs instead of the received/initials Blobs in the parameter <code>aBlobs</code>.
+	 * One use case could be to create and upload zip archives based on the passed Blobs.
+	 * The default implementation of this API should simply resolve with the received Blobs (parameter <code>aBlobs</code>).
+	 * @param {Blob[]} aBlobs The initial Blobs which can be used to determine a new array of Blobs for further processing.
+	 * @return {Promise} A Promise that resolves with an array of Blobs which is used for the final uploading.
+	 * @function
+	 * @name sap.ui.unified.IProcessableBlobs.getProcessedBlobsFromArray
+	 */
 
 	thisLib._ContentRenderer = BaseObject.extend("sap.ui.unified._ContentRenderer", {
 		constructor : function(oControl, sContentContainerId, oContent, fAfterRenderCallback) {


### PR DESCRIPTION
The **sap.ui.unified.FileUploader** is an amazing control. However, making reuse of the existing code in custom controls can sometimes only be implemented using private APIs of **sap.ui.unified.FileUploader** which is always a bad practice. 

This change introduces the new interface **sap.ui.unified.IUploadableBlobs** and changes the **sap.ui.unified.FileUploader** control to use this interface when **upload()** is called. It makes it save to implement custom controls that extend **sap.ui.unified.FileUploader** in order to modify the files before they get uploaded. This comes in handy in many use cases such, i.e. creating zip files for the upload. 

This changes introduces minimal changes to the **upload()** APIs by using Promises internally. Here, the interface API **sap.ui.unified.IUploadableBlobs.getProcessedBlobsFromArray** is used - a simple way to allow sub-controls to re-use the functionality in an "upgrade-save" way. The default implementation of the interface API does nothing but resolving the promise with the files received from the **sap.ui.unified.FileUploader** without changing them. This default implementation makes sure that the current behaviour is not changed.
