### PR TITLE
[FEATURE] FileUploader: processing of files before upload via interface

### DIFF
--- a/src/sap.ui.unified/src/sap/ui/unified/library.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/library.js
@@ -32,7 +32,9 @@ sap.ui.define(['jquery.sap.global',
 			"sap.ui.unified.ContentSwitcherAnimation",
 			"sap.ui.unified.ColorPickerMode"
 		],
-		interfaces: [],
+		interfaces: [
+			"sap.ui.unified.IUploadableBlobs"
+		],
 		controls: [
 			"sap.ui.unified.calendar.DatesRow",
 			"sap.ui.unified.calendar.Header",
@@ -434,6 +436,30 @@ sap.ui.define(['jquery.sap.global',
 		HSL : "HSL"
 
 	};
+
+	/**
+	 * Marker interface for controls that process instances of window.Blob, i.e. window.File.
+	 * The implementation of this Interface should implement the following Interface methods:
+	 * <ul>
+	 * <li><code>getProcessedBlobsFromArray</code></li>
+	 * </ul>
+	 *
+	 * @name sap.ui.unified.IUploadableBlobs
+	 * @interface
+	 * @public
+	 * @ui5-metamodel This interface also will be described in the UI5 (legacy) designtime metamodel
+	 */
+
+	/**
+	 * Allows to process Blobs before they get uploaded. This API can be used to create custom Blobs
+	 * and upload these custom Blobs instead of the received/initials Blobs in the parameter <code>aBlobs</code>.
+	 * One use case could be to create and upload zip archives based on the passed Blobs.
+	 * The default implementation of this API should simply resolve with the received Blobs (parameter <code>aBlobs</code>).
+	 * @param {Blob[]} aBlobs The initial Blobs which can be used to determine a new array of Blobs for further processing.
+	 * @return {Promise} A Promise that resolves with an array of Blobs which is used for the final uploading.
+	 * @function
+	 * @name sap.ui.unified.IUploadableBlobs.getProcessedBlobsFromArray
+	 */
 
 	sap.ui.base.Object.extend("sap.ui.unified._ContentRenderer", {
 		constructor : function(oControl, sContentContainerId, oContent, fAfterRenderCallback) {


### PR DESCRIPTION
The **sap.ui.unified.FileUploader** is an amazing control. However, making reuse of the existing code in custom controls can sometimes only be implemented using private APIs of **sap.ui.unified.FileUploader** which is always a bad practice. 

This change introduces the new interface **sap.ui.unified.IUploadableBlobs** and changes the **sap.ui.unified.FileUploader** control to use this interface when **upload()** is called. It makes it save to implement custom controls that extend **sap.ui.unified.FileUploader** in order to modify the files before they get uploaded. This comes in handy in many use cases such, i.e. creating zip files for the upload. 

This changes introduces minimal changes to the **upload()** APIs by using Promises are internally. Here, the interface API **sap.ui.unified.IUploadableBlobs.getProcessedBlobsFromArray** is used - a simple way to allow sub-controls the functionality in an "upgrade-save" way. The default implementation of the interface API does nothing but resolving the promise with the files received from the in the **sap.ui.unified.FileUploader** without changing them. This default implementation makes sure that the current behaviour is not changed.