### PR TITLE
Adds openui5-password and openui5-validator to OpenUI5 related projects

### DIFF
--- a/OpenUI5RelatedProjects.json
+++ b/OpenUI5RelatedProjects.json
@@ -115,5 +115,23 @@
 			"owner": "jonathanbaker7",
 			"license": "Apache 2.0",
 			"type": "JS Library"
-	  }
+	  },
+		"openui5-password": {
+			"name": "OpenUI5 Password",
+			"description": "An OpenUI5 Control which checks your password strength and validates it.",
+			"githubLink": "https://github.com/mauriciolauffer/openui5-password",
+			"documentationLink": "https://github.com/mauriciolauffer/openui5-password",
+			"owner": "mauriciolauffer",
+			"license": "MIT",
+			"type": "JS Library"
+		},
+		"openui5-validator": {
+			"name": "OpenUI5 Generic App Testing",
+			"description": "An OpenUI5 library to validate fields.",
+			"githubLink": "https://github.com/mauriciolauffer/openui5-validator",
+			"documentationLink": "https://github.com/mauriciolauffer/openui5-validator",
+			"owner": "mauriciolauffer",
+			"license": "MIT",
+			"type": "JS Library"
+		}
 	}


### PR DESCRIPTION
Hi guys.

I've released 2 UI5 libraries and I'd like to add them to the related projects page:

https://github.com/mauriciolauffer/openui5-password
openui5-password is a control for password input. It calculates the password strength and validates its content according to few rules you can set on the control.

https://github.com/mauriciolauffer/openui5-validator
openui5-validator is a generic validation class where you pass a json validation schema with all rules you want.
