### PR TITLE
[FIX] sap.ui.test.actions.Action: Use target element's offset for MouseEvent

### DIFF
--- a/src/sap.ui.core/src/sap/ui/test/actions/Action.js
+++ b/src/sap.ui.core/src/sap/ui/test/actions/Action.js
@@ -152,8 +152,8 @@ function ($, ManagedObject, QUnitUtils, Opa5, Device) {
 		 */
 		_createAndDispatchMouseEvent: function (sName, oDomRef) {
 			var oOffset = $(oDomRef).offset(),
-				x = oOffset.x,
-				y = oOffset.y;
+				x = oOffset.left,
+				y = oOffset.top;
 
 			// See file jquery.sap.events.js for some insights to the magic
 			var oMouseEventObject = {


### PR DESCRIPTION
- jQuery's offset function returns a map with "left" and "top", UI5 expected "x" and "y".

Fixes https://github.com/SAP/openui5/issues/1671