### PR TITLE
[FIX] Fixed memory leak in NavigationList when closing popover

### DIFF
--- a/src/sap.tnt/src/sap/tnt/NavigationList.js
+++ b/src/sap.tnt/src/sap/tnt/NavigationList.js
@@ -230,6 +230,7 @@ sap.ui.define(['jquery.sap.global', './library', 'sap/ui/core/Control', 'sap/m/P
 				verticalScrolling: true,
 				initialFocus: selectedItem,
 				afterClose: function () {
+					that._popover.destroy();
 					that._popover = null;
 				},
 				content: list,


### PR DESCRIPTION
OpenUI5 version: 1.48.6

Browser/version (+device/version): Chrome 60.0.3112.113 (Offizieller Build) (64-Bit) (Kohorte: Stable) (Windows 7)

Any other tested browsers/devices(OK/FAIL):
Potentially all other supported browser but did not test other

URL (minimal example if possible):
https://openui5.hana.ondemand.com/test-resources/sap/tnt/demokit/toolpageapp/webapp/index.html#

User/password (if required and possible - do not post any confidential information here):
None

Steps to reproduce the problem: 1. 2. 3.

 1. Go to https://openui5.hana.ondemand.com/test-resources/sap/tnt/demokit/toolpageapp/webapp/index.html#
 2. Collapse the side bar
 3. Click a lot of times on a menu item e.g. Statistics

What is the expected result?
 * All the time when the popover is closed the DOM node is removed as well

What happens instead?
 * The DOM get polluted with more and more nodes and consumes more and more memory until we hit F5

Any other information? (attach screenshot if possible)
![2017-09-08_12h47_19](https://user-images.githubusercontent.com/30871340/30208486-ee70402c-9493-11e7-96aa-603acd46ddab.png)