### PR TITLE
[FEATURE] sap.ui.layout.form.Form adds new event defaultAction

### DIFF
--- a/src/sap.ui.layout/src/sap/ui/layout/form/Form.js
+++ b/src/sap.ui.layout/src/sap/ui/layout/form/Form.js
@@ -3,8 +3,8 @@
  */
 
 // Provides control sap.ui.layout.form.Form.
-sap.ui.define(['sap/ui/core/Control', 'sap/ui/layout/library'],
-	function(Control, library) {
+sap.ui.define(['sap/ui/core/Control', 'sap/ui/layout/library', 'jquery.sap.global'],
+	function(Control, library, jQuery) {
 	"use strict";
 
 	/**
@@ -103,8 +103,30 @@ sap.ui.define(['sap/ui/core/Control', 'sap/ui/layout/library'],
 			 */
 			ariaLabelledBy: { type: "sap.ui.core.Control", multiple: true, singularName: "ariaLabelledBy" }
 		},
+		events: {
+
+			/**
+			 * Fired when the user hits enter within the form.
+			 */
+			 defaultAction: {}
+		},
 		designTime : true
 	}});
+
+	/**
+	 * Handle the key up event for ENTER.
+	 * @param {jQuery.Event} oEvent - the keyboard event.
+	 * @private
+	 */
+
+	Form.prototype.onkeyup = function(oEvent) {
+
+		if (oEvent.which === jQuery.sap.KeyCodes.ENTER) {
+			// mark the event for components that needs to know if the event was handled by the form
+			oEvent.setMarked();
+			this.fireDefaultAction();
+		}
+	};
 
 	Form.prototype.toggleContainerExpanded = function(oContainer){
 

--- a/src/sap.ui.layout/test/sap/ui/layout/form/Form.html
+++ b/src/sap.ui.layout/test/sap/ui/layout/form/Form.html
@@ -63,6 +63,7 @@
 			title: new sap.ui.core.Title({text: "Form Title", icon: "../../commons/images/ui5_small.png", tooltip: "Title tooltip"}),
 			tooltip: "Form tooltip",
 			editable: true,
+			defaultAction: (e) => sap.m.MessageToast.show('Default Action Triggered'),
 			layout: oLayout1,
 			formContainers: [
 				new sap.ui.layout.form.FormContainer("C1",{


### PR DESCRIPTION
Adds a new event to sap.ui.layout.form.Form which is triggered by
hitting the Enter key. Many users are accustomed to utilizing the
Enter key to submit a form, for example hitting Enter after entering a
username / password and subsequently being logged into the system. By
adding the new event, defaultAction, UI5 developers can trigger any
controller action when the user hits the Enter key within the form.
Ideally, this would be the same controller action tied to the form's
default button's press event.

Fixes https://github.com/SAP/openui5/issues/649