### PR TITLE
[INTERNAL] Missing library dependency

### DIFF
--- a/src/sap.tnt/test/sap/tnt/demokit/toolpageapp/webapp/manifest.json
+++ b/src/sap.tnt/test/sap/tnt/demokit/toolpageapp/webapp/manifest.json
@@ -31,7 +31,8 @@
 		"sap.ui.core": {},
 		"sap.m": {},
 		"sap.tnt": {},
-		"sap.ui.layout": {}
+		"sap.ui.layout": {},
+		"sap.uxap": {}
 	  }
 	},
 	"models": {


### PR DESCRIPTION
The dependency to library sap.uxap was not defined in the manifest of the Shop Administration Tool demo application. This caused an unnecessary drop in performance when accessing the settings page for the first time.