### PR TITLE
Context.getPath's parameter sPath is optional

### DIFF
--- a/src/sap.ui.core/src/sap/ui/model/Context.js
+++ b/src/sap.ui.core/src/sap/ui/model/Context.js
@@ -58,7 +58,7 @@ sap.ui.define(['sap/ui/base/Object'],
 	/**
 	 * Getter for path of the context itself or a subpath
 	 * @public
-	 * @param {String} sPath the binding path (optional)
+	 * @param {String} [sPath] the binding path (optional)
 	 * @return {String} the binding path
 	 */
 	Context.prototype.getPath = function(sPath) {

--- a/src/sap.ui.core/src/sap/ui/model/Context.js
+++ b/src/sap.ui.core/src/sap/ui/model/Context.js
@@ -58,7 +58,7 @@ sap.ui.define(['sap/ui/base/Object'],
 	/**
 	 * Getter for path of the context itself or a subpath
 	 * @public
-	 * @param {String} sPath the binding path
+	 * @param {String} sPath the binding path (optional)
 	 * @return {String} the binding path
 	 */
 	Context.prototype.getPath = function(sPath) {


### PR DESCRIPTION
I'm using typescript definition files generated by the JsDoc, and some code are getting errors because the parameter sPath (that is optional) is required in the definition file.

I had already created one #1718, but it wasn't with squared brackets in js doc.