### PR TITLE
[INTERNAL] sap.m.SegmentedButton: API functions now correctly return this

### DIFF
--- a/src/sap.m/src/sap/m/SegmentedButton.js
+++ b/src/sap.m/src/sap/m/SegmentedButton.js
@@ -569,12 +569,14 @@ sap.ui.define(['./library', 'sap/ui/core/Control', 'sap/ui/core/EnabledPropagato
 	/**
 	 * Adds item to <code>items</code> aggregation.
 	 * @param {sap.m.SegmentedButtonItem} oItem The item to be added
+	 * @returns {sap.m.SegmentedButton} <code>this</code> pointer for chaining
 	 * @public
 	 * @override
 	 */
 	SegmentedButton.prototype.addItem = function (oItem) {
 		this.addAggregation("items", oItem);
 		this.addButton(oItem.oButton);
+		return this;
 	};
 
 	/**
@@ -602,12 +604,14 @@ sap.ui.define(['./library', 'sap/ui/core/Control', 'sap/ui/core/EnabledPropagato
 	 * Inserts item into <code>items</code> aggregation.
 	 * @param {sap.m.SegmentedButtonItem} oItem The item to be inserted
 	 * @param {int} iIndex index the item should be inserted at
+	 * @returns {sap.m.SegmentedButton} <code>this</code> pointer for chaining
 	 * @public
 	 * @override
 	 */
 	SegmentedButton.prototype.insertItem = function (oItem, iIndex) {
 		this.insertAggregation("items", oItem, iIndex);
 		this.insertButton(oItem.oButton, iIndex);
+		return this;
 	};
 
 	/**


### PR DESCRIPTION
* `addItem` and `insertItem` setters of the SegmentedButton were not returning `this` for chaining.

Fixes https://github.com/SAP/openui5/issues/1868