### PR TITLE
Fixed incorrect owner link

### DIFF
--- a/OpenUI5RelatedProjects.json
+++ b/OpenUI5RelatedProjects.json
@@ -184,7 +184,7 @@
 			"description": "Neovim deoplete sap-icon plugin", 
 			"githubLink": "https://github.com/Trulsaa/deoplete-sap-icon", 
 			"documentationLink": "https://github.com/Trulsaa/deoplete-sap-icon", 
-			"owner": "Truls Aagaard", 
+			"owner": "Trulsaa", 
 			"license": "MIT License", 
 			"type": "nvim plugin" 
 		}


### PR DESCRIPTION
Edited the owner property on Deoplete sap-icon object in order for it to link to the correct owner profile