### PR TITLE
[FEATURE] sap.m.TablePersoDialog: Change CheckBox selection when List…

### DIFF
--- a/src/sap.m/src/sap/m/TablePersoDialog.js
+++ b/src/sap.m/src/sap/m/TablePersoDialog.js
@@ -144,6 +144,7 @@ sap.ui.define(['jquery.sap.global', './Button', './Dialog', './InputListItem', '
 
 		// Template for list inside the dialog - 1 item per column
 		this._oColumnItemTemplate = new InputListItem(this.getId() + "-li", {
+			type: "Active",
 			label: "{Personalization>text}",
 			content: new CheckBox(this.getId() + "-cb", {
 				selected: "{Personalization>visible}",
@@ -274,13 +275,27 @@ sap.ui.define(['jquery.sap.global', './Button', './Dialog', './InputListItem', '
 			// Scroll container gets focused in Firefox
 			that._oScrollContainer.$().attr('tabindex', '-1');
 		};
+		
+		// Selects or deselects the sap.m.Checkbox when the ListItem is pressed and
+		// triggers the select event.
+		this._fnListItemPressed = jQuery.proxy(function(oEvent) {
+			var oCheckBox = oEvent.getParameter("listItem").getContent()[0];
+			if (oCheckBox.getMetadata().getName() === "sap.m.CheckBox") {
+				var bSelected = !oCheckBox.getSelected();
+				oCheckBox.setSelected(bSelected);
+				oCheckBox.fireSelect({
+					selected: bSelected
+				});
+			}
+		}, this);
 
 		this._oList =  new List(this.getId() + "-colList",{
 			includeItemInSelection: true,
 			noDataText: this._oRb.getText('PERSODIALOG_NO_DATA'),
 			mode: ListMode.SingleSelectMaster,
 			selectionChange: function(){ this._fnUpdateArrowButtons.call(this); }.bind(this),
-			updateFinished: this._fnListUpdateFinished
+			updateFinished: this._fnListUpdateFinished,
+			itemPress: this._fnListItemPressed
 		});
 
 		this._oList.addDelegate({onAfterRendering : this._fnListUpdateFinished});

--- a/src/sap.m/src/sap/m/TablePersoDialog.js
+++ b/src/sap.m/src/sap/m/TablePersoDialog.js
@@ -275,7 +275,7 @@ sap.ui.define(['jquery.sap.global', './Button', './Dialog', './InputListItem', '
 			// Scroll container gets focused in Firefox
 			that._oScrollContainer.$().attr('tabindex', '-1');
 		};
-		
+
 		// Selects or deselects the sap.m.Checkbox when the ListItem is pressed and
 		// triggers the select event.
 		this._fnListItemPressed = jQuery.proxy(function(oEvent) {


### PR DESCRIPTION
This is a small feature for the sap.m.TablePersoDialog that enables the user to change the value of a sap.m.CheckBox when the corresponding sap.m.InputListItem ist pressed.

Additional Question: Is it possible to add this feature to earlier versions? We are currently using SAPUI5 1.38, which is still maintained by SAP and we would like it very much to see that feature in a future 1.38.x patch.