### PR TITLE
Explicitly avoid parsing dataurl sourceMappings

### DIFF
--- a/src/sap.ui.core/src/ui5loader.js
+++ b/src/sap.ui.core/src/ui5loader.js
@@ -1348,7 +1348,7 @@
 					// Note: sourcemap annotations URLs in eval'ed sources are resolved relative to the page, not relative to the source
 					if (sScript ) {
 						oMatch = /\/\/[#@] source(Mapping)?URL=(.*)$/.exec(sScript);
-						if ( oMatch && oMatch[1] && /^[^/]+\.js\.map$/.test(oMatch[2]) ) {
+						if ( oMatch && oMatch[1] && /^(?!data:)[^/]+\.js\.map$/.test(oMatch[2]) ) {
 							// found a sourcemap annotation with a typical UI5 generated relative URL
 							sScript = sScript.slice(0, oMatch.index) + oMatch[0].slice(0, -oMatch[2].length) + resolveURL(oMatch[2], oModule.url);
 						}


### PR DESCRIPTION
Since data urls may be long, checking the regexp would have serious impact to script loading performance

See SAP/openui5#1915 and SAP/openui5#1916