### PR TITLE
[FIX] MockServer: avoid loading metadata twice

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/util/MockServer.js
+++ b/src/sap.ui.core/src/sap/ui/core/util/MockServer.js
@@ -1075,15 +1075,17 @@ sap.ui
 
 			/**
 			 * Refreshes the service metadata document and the mockdata
-			 *
+			 * @param {boolean} bSkipMetadata if truthy then the metadata will not be reloaded
 			 * @private
 			 */
-			MockServer.prototype._refreshData = function() {
+			MockServer.prototype._refreshData = function(bSkipMetadata) {
 
 				// load the metadata
-				var oMetadata = this._loadMetadata(this._sMetadataString);
-				if (!oMetadata) {
-					return;
+				if (!bSkipMetadata){
+					var oMetadata = this._loadMetadata(this._sMetadataString);
+					if (!oMetadata) {
+						return;
+					}
 				}
 
 				// here we need to analyse the EDMX and identify the entity sets
@@ -1950,7 +1952,7 @@ sap.ui
 					var DraftEnabledMockServer = sap.ui.requireSync("sap/ui/core/util/DraftEnabledMockServer");
 					DraftEnabledMockServer.handleDraft(oAnnotations, this);
 				}
-				this._refreshData();
+				this._refreshData(true);
 
 				// helper to handle xsrf token
 				var fnHandleXsrfTokenHeader = function(oXhr, mHeaders) {


### PR DESCRIPTION
See issue https://github.com/SAP/openui5/issues/1909
I chose to add a simple flag which allows to keep the old functionality of `MockServer.prototype._refreshData` although it's not really needed like at this moment because 
- I have no clue if `MockServer.prototype._refreshData` is used somewhere else although private (i.e. in tests)
- maybe turning on loading of metadata in `MockServer.prototype._refreshData` via parameter/flag is needed later...