### PR TITLE
Improving the API docs on Grouping

### DIFF
--- a/src/sap.ui.core/src/sap/ui/base/ManagedObject.js
+++ b/src/sap.ui.core/src/sap/ui/base/ManagedObject.js
@@ -3239,8 +3239,10 @@ sap.ui.define([
 	 * @param {string|function} oBindingInfo.key the name of the key property or a function getting the context as only parameter to calculate a key for entries. This can be used to improve update behaviour in models, where a key is not already available.
 	 * @param {object} [oBindingInfo.parameters] a map of parameters which is passed to the binding.
 	 * The supported parameters are listed in the corresponding model-specific implementation of <code>sap.ui.model.ListBinding</code> or <code>sap.ui.model.TreeBinding</code>.
-	 * @param {function} [oBindingInfo.groupHeaderFactory] a factory function to generate custom group visualization (optional)
-	 *
+	 * @param {function} [oBindingInfo.groupHeaderFactory] a factory function to generate custom group visualization (optional).
+	 * The factory function must return a {@link sap.m.GroupHeaderListItem}. It will be called with an <code>oGroup<code>
+	 * object containing the intended header string as the property <code>oGroup.key<code>. To change that key provide a
+	 * custom <code>fnGroup<code> function on your {@link sap.ui.model.Sorter}.
 	 * @return {sap.ui.base.ManagedObject} reference to the instance itself
 	 * @public
 	 */

--- a/src/sap.ui.core/src/sap/ui/model/Sorter.js
+++ b/src/sap.ui.core/src/sap/ui/model/Sorter.js
@@ -67,7 +67,8 @@ sap.ui.define(['sap/ui/base/Object'],
 
 		/**
 		 * Returns a group object, at least containing a key property for group detection.
-		 * May contain additional properties as provided by a custom group function.
+		 * May contain additional properties as provided by a custom group function <code>fnGroup</code>.
+		 * See {@link  #.getGroupFunction Sorter.getGroupFunction} for further details.
 		 *
 		 * @param {sap.ui.model.Context} oContext the binding context
 		 * @return {object} An object containing a key property and optional custom properties
@@ -88,6 +89,10 @@ sap.ui.define(['sap/ui/base/Object'],
 		 * undefined, if no explicit group function has been defined the default group function is returned.
 		 * The returned function is bound to its Sorter, so it will group according to its own property path,
 		 * even if it is used in the context of another Sorter.
+		 *
+		 * To provide an explicit group function just override the function <code>fnGroup</code> of this Sorter.
+		 * The current {@link sap.ui.model.Context} will be passed into the custom function. It must return
+		 * a string value.
 		 *
 		 * @return {function} The group function
 		 * @public


### PR DESCRIPTION
Improving the API docs on Grouping particularly groupHeaderFactory (sap.ui.base.ManagedObject) and fnGroup (sap.ui.model.Sorter).

I found it very hard to understand how grouping is intended to work from the API docs. Therefore tried to improve.