### PR TITLE
[FIX] Button#setText removes <bdi> tags

### DIFF
--- a/src/sap.m/src/sap/m/ButtonRenderer.js
+++ b/src/sap.m/src/sap/m/ButtonRenderer.js
@@ -193,11 +193,16 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/Device', 'sap/ui/core/library', 'sap
 				oRm.writeAttribute("dir", sTextDir.toLowerCase());
 			}
 			oRm.writeClasses();
-			oRm.writeAttribute("id", oButton.getId() + "-content");
+			if (!bRenderBDI) {
+				// without bdi, the span is the content container
+				oRm.writeAttribute("id", oButton.getId() + "-content");
+			}
 			oRm.write(">");
 
 			if (bRenderBDI) {
-				oRm.write("<bdi>");
+				oRm.write("<bdi ");
+				oRm.writeAttribute("id", oButton.getId() + "-content");
+				oRm.write(">");
 			}
 			oRm.writeEscaped(sText);
 			if (bRenderBDI) {

--- a/src/sap.m/test/sap/m/qunit/Button.qunit.html
+++ b/src/sap.m/test/sap/m/qunit/Button.qunit.html
@@ -239,11 +239,11 @@
 
 	QUnit.test("BDI set when no textdirection is given explicitly", function(assert) {
 		var bIE_Edge = sap.ui.Device.browser.internet_explorer || sap.ui.Device.browser.edge;
-		var $btnBDITag = document.getElementById('b1-content').firstChild.nodeName;
+		var $btnBDITag = document.getElementById('b1-content').nodeName;
 		if (!bIE_Edge) {
-			assert.equal($btnBDITag.toLowerCase(), "bdi", "Control has bidi tag set");
+			assert.equal($btnBDITag.toLowerCase(), "bdi", "Control has bdi tag set");
 		} else {
-			assert.ok(!($btnBDITag.toLowerCase() == "bdi"), "Control doesn't have bidi tag set when the browser is IE or Edge, since it's not supported");
+			assert.ok(!($btnBDITag.toLowerCase() == "bdi"), "Control doesn't have bdi tag set when the browser is IE or Edge, since it's not supported");
 		}
 	});
 


### PR DESCRIPTION
This provides a fix for the following UI5 bug:

OpenUI5 version: checked on 1.52.5 and master

Browser/version (+device/version): All except (Internet Explorer and Edge)

URL (minimal example if possible): https://jsfiddle.net/ww4xvzmf/5/

# Steps to reproduce the problem:
1. Render a sap.m.Button with textDirection=TextDirection.Inherit on a non-microsoft browser
1. A `<bdi>` was rendered inside the button content
2. Call `myButton#setText("changing content")`
2. No more `<bdi>` inside the button
3. Call `myButton#rerender()`
3. The `<bdi>` reappeared

# What is the expected result?
The `<bdi>` tag should be present all the time.

# What happens instead?
The `<bdi>` disappears when `Button#setText` updates the button contents.

# Any other information? (attach screenshot if possible)
[ButtonRenderer](https://github.com/SAP/openui5/blob/rel-1.52.5/src/sap.m/src/sap/m/ButtonRenderer.js#L43) renders with a bdi iff `(theControlsDirection === TextDirection.Inherit) && !isInternetExplorerOrEdge`. The `this.$("content")` sub element yet is the parent span of that bdi.

[Button#setText](https://github.com/SAP/openui5/blob/rel-1.52.5/src/sap.m/src/sap/m/Button.js#L500) will remove any `<bdi>`. The reason is that it replaces its `this.$("content")` regardless if it contains a bdi or not.

# Solution

ButtonRenderer puts the content id onto the `<bdi id="...-content">` if any. Otherwise the span contains the id `<span ... id="...-content">`.

I updated `/sap/m/qunit/Button.qunit.html` to regression test this.