### PR TITLE
Fix DropPosition dependency in TableDragAndDropExtension

### DIFF
--- a/src/sap.ui.table/src/sap/ui/table/TableDragAndDropExtension.js
+++ b/src/sap.ui.table/src/sap/ui/table/TableDragAndDropExtension.js
@@ -4,11 +4,12 @@
 
 // Provides helper sap.ui.table.TableDragAndDropExtension.
 sap.ui.define([
-	"./TableExtension", "sap/ui/table/TableUtils", "sap/ui/core/dnd/DropPosition"
-], function(TableExtension, TableUtils, DropPosition) {
+	"./TableExtension", "sap/ui/table/TableUtils", "sap/ui/core/library"
+], function(TableExtension, TableUtils, coreLibrary) {
 	"use strict";
 
 	var SESSION_DATA_KEY_NAMESPACE = "sap.ui.table";
+	var DropPosition = coreLibrary.dnd.DropPosition;
 
 	var ExtensionHelper = {
 		/**


### PR DESCRIPTION
DropPosition is not a module and hence should not be declared as a dependency. It is defined in the library file within the sap.ui.core library.
The correct way to include it is to require the library module and use the value from there.