### PR TITLE
Fix jQuery dependency definition

### DIFF
--- a/src/sap.ui.core/src/sap/base/util/LoaderExtensions.js
+++ b/src/sap.ui.core/src/sap/base/util/LoaderExtensions.js
@@ -7,7 +7,7 @@ sap.ui.define([
 	'sap/base/Log',
 	'sap/base/assert'
 ], function(
-	jquery,
+	jQuery,
 	Log,
 	assert
 ) {


### PR DESCRIPTION
In the LoaderExtension jQuery is used only with the variable name with an uppercase Q. However, it was defined with all lowercase letters in the function parameter. When jQuery is not in the global namespace this leads to an error as `jQuery` is undefined.