### PR TITLE
[INTERNAL] ui.support: suggest mvc instead of core

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/rules/View.support.js
+++ b/src/sap.ui.core/src/sap/ui/core/rules/View.support.js
@@ -28,7 +28,7 @@ sap.ui.define(["sap/ui/support/library"],
 		minversion: "-",
 		title: "XML View is not configured with namespace 'sap.ui.core.mvc'",
 		description: "For consistency and proper resource loading, the root node of an XML view must be configured with the namespace 'mvc'",
-		resolution: "Define the XML view as '<core:View ...>' and configure the XML namepspace as 'xmlns:mvc=\"sap.ui.core.mvc\"'",
+		resolution: "Define the XML view as '<mvc:View ...>' and configure the XML namepspace as 'xmlns:mvc=\"sap.ui.core.mvc\"'",
 		resolutionurls: [{
 			text: "Documentation: Namespaces in XML Views",
 			href: "https://sapui5.hana.ondemand.com/#docs/guide/2421a2c9fa574b2e937461b5313671f0.html"


### PR DESCRIPTION
* For consistency and proper resource loading, the root node of an XML view must be configured with the namespace `mvc`.
* The resolution text of the support rule "xmlViewWrongNamespace", however, was still suggesting to define the root node as `<core:View ...>`.
* The resolution text is now aligned with the description text.

Fixes: https://github.com/SAP/openui5/issues/2155