### PR TITLE
[INTERNAL] SearchProvider: Add missing @abstract

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/search/SearchProvider.js
+++ b/src/sap.ui.core/src/sap/ui/core/search/SearchProvider.js
@@ -15,6 +15,7 @@ sap.ui.define(['sap/ui/core/Element', 'sap/ui/core/library', "sap/base/Log"],
 	 * @param {string} [sId] id for the new control, generated automatically if no id is given
 	 * @param {object} [mSettings] initial settings for the new control
 	 *
+	 * @abstract
 	 * @class
 	 * Abstract base class for all SearchProviders which can be e.g. attached to a SearchField.
 	 *
@@ -28,6 +29,7 @@ sap.ui.define(['sap/ui/core/Element', 'sap/ui/core/library', "sap/base/Log"],
 	 */
 	var SearchProvider = Element.extend("sap.ui.core.search.SearchProvider", /** @lends sap.ui.core.search.SearchProvider.prototype */ { metadata : {
 
+		"abstract": true,
 		library : "sap.ui.core",
 		properties : {
 


### PR DESCRIPTION
The module `sap.ui.core.search.SearchProvider` was not marked as "abstract".
The API Reference can now display this as such.

Fixes: https://github.com/SAP/openui5/issues/1730