### PR TITLE
Match sap-ui-core.js in Karma tests

### DIFF
--- a/src/sap.ui.core/src/sap-ui-core.js
+++ b/src/sap.ui.core/src/sap-ui-core.js
@@ -24,7 +24,7 @@
 		for (i = 0; i < aScripts.length; i++) {
 			sSrc = aScripts[i].getAttribute("src");
 			if (sSrc) {
-				mMatch = sSrc.match(/(.*\/)sap-ui-core\.js$/i);
+				mMatch = sSrc.match(/(.*\/)sap-ui-core\.js(?:\?[a-f0-9]+)?$/i);
 				if (mMatch) {
 					sBaseUrl = mMatch[1];
 					break;


### PR DESCRIPTION
Karma test runner adds a hash to the URL for cache busting. When this is done OpenUI5 doesn't detect the sap-ui-core.js file anymore and tests cannot be executed. This is fixed with this change.
See discussion in `karma-openui5` repository.

Fixes: https://github.com/SAP/karma-openui5/issues/3