### PR TITLE
[INTERNAL][FIX] sample name: Controller Extension

### DIFF
--- a/src/sap.ui.core/test/sap/ui/core/demokit/docuindex.json
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/docuindex.json
@@ -51,7 +51,7 @@
 			},
 			{
 				"id" : "sap.ui.core.mvc.ControllerExtension",
-				"name" : "Control Extensions",
+				"name" : "Controller Extensions",
 				"category" : "Display",
 				"since" : "1.56",
 				"samples" : [


### PR DESCRIPTION
The name for the list item in #/sample/ was incorrectly defined as "Control Extensions" whereas it should be "Controller Extensions".

Fixes: https://github.com/SAP/openui5/issues/2249