### PR TITLE
[FIX] m.SelectList: browser navigation with alt + arrow keys

### DIFF
--- a/src/sap.m/src/sap/m/SelectList.js
+++ b/src/sap.m/src/sap/m/SelectList.js
@@ -725,6 +725,17 @@ sap.ui.define([
 			if (!this._oItemNavigation) {
 				this._oItemNavigation = new ItemNavigation(null, null, !this.getEnabled() /* not in tab chain */);
 				this._oItemNavigation.attachEvent(ItemNavigation.Events.AfterFocus, this.onAfterFocus, this);
+				this._oItemNavigation.setDisabledModifiers({
+					// Alt + arrow keys are reserved for browser navigation
+					sapnext: [
+						"alt", // Windows and Linux
+						"meta" // Apple (⌘)
+					],
+					sapprevious: [
+						"alt",
+						"meta"
+					]
+				});
 				this.addEventDelegate(this._oItemNavigation);
 			}
 

--- a/src/sap.m/test/sap/m/qunit/SelectList.qunit.js
+++ b/src/sap.m/test/sap/m/qunit/SelectList.qunit.js
@@ -2031,6 +2031,35 @@ sap.ui.define([
 		oSelectList.destroy();
 	});
 
+	QUnit.test("When keyboardNavigationMode is set to Delimited, it shouldn't prevent browser from navigating to previous or next page.", function(assert) {
+
+		// system under test
+		var oSelectList = new SelectList({
+			items: [
+				new Item({
+					text: "lorem ipsum"
+				})
+			]
+		});
+
+		// arrange
+		oSelectList.placeAt("content");
+		sap.ui.getCore().applyChanges();
+
+		var oModifiers = oSelectList._oItemNavigation.getDisabledModifiers();
+
+		// assert
+		assert.ok(oModifiers["sapnext"], "sapnext has disabled modifiers");
+		assert.ok(oModifiers["sapprevious"], "sapprevious has disabled modifiers");
+		assert.ok(oModifiers["sapnext"].indexOf("alt") !== -1, "forward item navigation is not handled when altKey is pressed");
+		assert.ok(oModifiers["sapnext"].indexOf("meta") !== -1, "forward item navigation on MacOS is not handled when metaKey is pressed");
+		assert.ok(oModifiers["sapprevious"].indexOf("alt") !== -1, "backward item navigation is not handled when altKey is pressed");
+		assert.ok(oModifiers["sapprevious"].indexOf("meta") !== -1, "backward item navigation on MacOS is not handled when metaKey is pressed");
+
+		// cleanup
+		oSelectList.destroy();
+	});
+
 	QUnit.module("removeItem()");
 
 	QUnit.test("it should give a warning when called with faulty parameter", function(assert) {


### PR DESCRIPTION
 - Browsers allow page navigation with the following keyboard shortcuts: https://en.wikipedia.org/wiki/Table_of_keyboard_shortcuts#Browsers_/_Go_menu
SelectList was preventing users from doing so as long as one of its items had the focus.
 - Now users can navigate with keyboard shortcuts.

Fixes: https://github.com/SAP/openui5/issues/1414
Specifically: https://github.com/SAP/openui5/issues/1414#issuecomment-447364113