### PR TITLE
Improved focus handling after sap.m.StepInput button press

### DIFF
--- a/src/sap.m/src/sap/m/StepInput.js
+++ b/src/sap.m/src/sap/m/StepInput.js
@@ -675,7 +675,7 @@ function(
 			}
 
 			// Return the focus on the main element
-			this.$().focus();
+			this._getInput().focus();
 
 			return this;
 		};


### PR DESCRIPTION
While implementing #2356, an issue arises when the +/- buttons are pressed. Before this change is applied, the +/- button moves the focus to the `div` outside instead of the `input` inside.
Now focus is given to the inner `input` instead of the `div` outside after the buttons are pressed.

This together with #2356 makes the `StepInput` behave in the same way as browser default `<input type="number">`.