### PR TITLE
[FIX] sap.m.LightBoxItem: Native image source is only getting assigned if the popup open state equals OPEN

### DIFF
--- a/src/sap.m/src/sap/m/LightBoxItem.js
+++ b/src/sap.m/src/sap/m/LightBoxItem.js
@@ -164,7 +164,7 @@ sap.ui.define([
 
             this._imageState = LightBoxLoadingStates.Loading;
 
-            if (oLightBox && oLightBox._oPopup.getOpenState() === OpenState.OPEN) {
+            if (oLightBox && oLightBox._oPopup.getOpenState() !== OpenState.OPEN) {
                 this._oImage.src = sImageSrc;
             }
 

--- a/src/sap.m/test/sap/m/qunit/LightBoxItem.qunit.js
+++ b/src/sap.m/test/sap/m/qunit/LightBoxItem.qunit.js
@@ -43,7 +43,7 @@ sap.ui.define(
 			this.LightBoxItem.setImageSrc(imageSrc);
 
 			// assert
-			assert.strictEqual(this.LightBoxItem._getNativeImage().getAttribute('src'), imageSrc, 'setImageSrc should not set the image src if the popup is open');
+			assert.strictEqual(this.LightBoxItem._getNativeImage().getAttribute('src'), imageSrc, 'setImageSrc should set the src attribute of the native image object if the open state is not OPEN');
 
 			// clean
 			this.LightBoxItem.getParent.restore();

--- a/src/sap.m/test/sap/m/qunit/LightBoxItem.qunit.js
+++ b/src/sap.m/test/sap/m/qunit/LightBoxItem.qunit.js
@@ -2,74 +2,95 @@
 
 sap.ui.define(
 	["sap/m/LightBoxItem"],
-	function(LightBoxItem) {
+	function (LightBoxItem) {
 		'use strict';
 
-
-
 		QUnit.module('API', {
-			beforeEach: function() {
+			beforeEach: function () {
 				this.LightBoxItem = new LightBoxItem();
 			},
-			afterEach: function() {
+			afterEach: function () {
 				this.LightBoxItem.destroy();
 			}
 		});
 
 
-		QUnit.test('Setting image source', function(assert) {
-			//arange
+		QUnit.test('Setting image source', function (assert) {
+			//arrange
 			var imageSrc = 'test.jpg';
 			this.LightBoxItem.setImageSrc(imageSrc);
 			//act
 			var actualResult = this.LightBoxItem.getImageSrc();
 
 			//assert
-			assert.strictEqual(actualResult, imageSrc, 'Shoud set correct image source');
+			assert.strictEqual(actualResult, imageSrc, 'Should set correct image source');
 		});
 
-		QUnit.test('Setting image alt', function(assert) {
-			//arange
+		QUnit.test('Setting native image source when popup is not open', function (assert) {
+			//arrange
+			sinon.stub(this.LightBoxItem, 'getParent', function () {
+				return {
+					_oPopup: {
+						getOpenState: function () {
+							return 'LOADING';
+						}
+					}
+				};
+			});
+			var imageSrc = 'test.jpg';
+
+			// act
+			this.LightBoxItem.setImageSrc(imageSrc);
+
+			// assert
+			assert.strictEqual(this.LightBoxItem._getNativeImage().getAttribute('src'), imageSrc, 'setImageSrc should not set the image src if the popup is open');
+
+			// clean
+			this.LightBoxItem.getParent.restore();
+		});
+
+		QUnit.test('Setting image alt', function (assert) {
+			//arrange
 			var imageAlt = 'test image';
 			this.LightBoxItem.setAlt(imageAlt);
 			//act
 			var actualResult = this.LightBoxItem.getAlt();
 
 			//assert
-			assert.strictEqual(actualResult, imageAlt, 'Shoud set correct image alt');
+			assert.strictEqual(actualResult, imageAlt, 'Should set correct image alt');
 		});
 
-		QUnit.test('Setting image title', function(assert) {
-			//arange
+		QUnit.test('Setting image title', function (assert) {
+			//arrange
 			var imageTitle = 'test image';
 			this.LightBoxItem.setTitle(imageTitle);
 			//act
 			var actualResult = this.LightBoxItem.getTitle();
 
 			//assert
-			assert.strictEqual(actualResult, imageTitle, 'Shoud set correct image title');
+			assert.strictEqual(actualResult, imageTitle, 'Should set correct image title');
 		});
 
-		QUnit.test('Setting image subtitle', function(assert) {
-			//arange
+		QUnit.test('Setting image subtitle', function (assert) {
+			//arrange
 			var imageSubtitle = 'test image';
 			this.LightBoxItem.setSubtitle(imageSubtitle);
 			//act
 			var actualResult = this.LightBoxItem.getSubtitle();
 
 			//assert
-			assert.strictEqual(actualResult, imageSubtitle, 'Shoud set correct image subtitle');
+			assert.strictEqual(actualResult, imageSubtitle, 'Should set correct image subtitle');
 		});
 
-		QUnit.test('Setting image subtitle', function(assert) {
-			//arange
+		QUnit.test('Setting image subtitle', function (assert) {
+			//arrange
 			var imageSubtitle = 'test image';
 			this.LightBoxItem.setSubtitle(imageSubtitle);
 			//act
 			var actualResult = this.LightBoxItem.getSubtitle();
 
 			//assert
-			assert.strictEqual(actualResult, imageSubtitle, 'Shoud set correct image subtitle');
+			assert.strictEqual(actualResult, imageSubtitle, 'Should set correct image subtitle');
 		});
 
 		QUnit.test('Setting image when state is loading', function (assert) {
@@ -87,7 +108,6 @@ sap.ui.define(
 			var imageSrc = 'test.jpg';
 			var image = new window.Image();
 			image.src = imageSrc;
-
 
 			// act
 			this.LightBoxItem.setImageSrc(imageSrc);


### PR DESCRIPTION
I copied the fix from @ffleige of PR #1913 and just added the necessary test myself because the PR is now stale for over 10 months without any further contribution.

I also fixed some typos and added whitespace to make the file more consistent.