### PR TITLE
sap.m.SelectDialog: Allow clear in single selection mode

### DIFF
--- a/src/sap.m/src/sap/m/SelectDialog.js
+++ b/src/sap.m/src/sap/m/SelectDialog.js
@@ -1069,7 +1069,7 @@ function(
 				press: function() {
 					this.clearSelection();
 					if (!this.getMultiSelect()) {
-						fnClearAfterClose = function () {
+						var fnClearAfterClose = function () {
 							this._oSelectedItem = this._oList.getSelectedItem();
 							this._aSelectedItems = this._oList.getSelectedItems();
 


### PR DESCRIPTION
The clear button will always be enabled, if `showClearButton=true` and `multiSelect=false`.
The clear button behavior is redefined to act as clear+confirm in single selection mode.

This closes #2379. This will provide a workaround for #898.

P.S. I'm not sure if this should count as a [FIX] or a [FEATURE], so it's not included in any title.