### PR TITLE
[FIX] Fixed missing sample source in sap.m.SelectDialog

### DIFF
--- a/src/sap.m/test/sap/m/demokit/sample/SelectDialog/Component.js
+++ b/src/sap.m/test/sap/m/demokit/sample/SelectDialog/Component.js
@@ -21,7 +21,8 @@ sap.ui.define(['sap/ui/core/UIComponent'],
 					files : [
 						"V.view.xml",
 						"C.controller.js",
-						"Dialog.fragment.xml"
+						"Dialog.fragment.xml",
+						"ValueHelp.fragment.xml"
 					]
 				}
 			}


### PR DESCRIPTION
## Issue
In [the `SelectDialog` sample](https://openui5.hana.ondemand.com/#/sample/sap.m.sample.SelectDialog/code), one of the source files is missing from the source code view.
#### C.controller.js
```JS
84	this._oValueHelpDialog = sap.ui.xmlfragment("sap.m.sample.SelectDialog.ValueHelp",this);
```