### PR TITLE
[INTERNAL] m.ObjectAttribute: Apply alignment to other cases

### DIFF
--- a/src/sap.m/src/sap/m/themes/base/ObjectAttribute.less
+++ b/src/sap.m/src/sap/m/themes/base/ObjectAttribute.less
@@ -18,7 +18,7 @@
 .sapMObjectAttributeActive {
 	pointer-events: none;
 	.sapMObjectAttributeColon {
-		vertical-align: middle;
+		vertical-align: top;
 	}
 }
 
@@ -60,7 +60,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	max-width: 50%;
-	vertical-align: middle;
+	vertical-align: top;
 	/* we need this otherwise the focus get broken when the link is on more lines */
 	display: inline-block;
 }
@@ -79,11 +79,12 @@
 }
 
 .sapMOH .sapMObjectAttributeText > .sapMText {
-	vertical-align: bottom;
+	vertical-align: top;
 }
 
 .sapMObjectAttributeDiv{
 	outline: none;
+	font-size: @sapMFontMediumSize;
 }
 
 .sapMLIBActive .sapMObjectAttributeText,
@@ -124,7 +125,7 @@ html[data-sap-ui-browser^='ie'], html[data-sap-ui-browser^='ed'] {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	max-width: 50%;
-	vertical-align: middle;
+	vertical-align: top;
 }
 
 .sapMOHR .sapMOHRAttr .sapMObjectAttributeTitle {
@@ -147,7 +148,7 @@ html[data-sap-ui-browser^='ie'], html[data-sap-ui-browser^='ed'] {
 	max-width: 0.5rem;
 	margin-left: -0.5rem;
 	overflow: auto;
-	vertical-align: middle;
+	vertical-align: top;
 }
 
 .sapMOHR .sapMObjectAttributeActive .sapMObjectAttributeText {


### PR DESCRIPTION
This commit is a continuation of https://github.com/SAP/openui5/commit/dafabfd3c0c2a0e0a901bf4ec11b1a3d8d59d687.

 * Vertical alignment was not applied to other cases such as when ObjectAttribute has "active" enabled.
 * @sapMFontMediumSize added to keep the height consistent with other text based controls. See https://github.com/SAP/openui5/issues/2368#issuecomment-465133762.

Fixes: https://github.com/SAP/openui5/issues/2368