### PR TITLE
Add missing modules to require calls.

### DIFF
--- a/src/sap.m/src/sap/m/ActionSheet.js
+++ b/src/sap.m/src/sap/m/ActionSheet.js
@@ -13,6 +13,7 @@ sap.ui.define([
 	'sap/ui/base/ManagedObject',
 	'sap/ui/Device',
 	'./ActionSheetRenderer',
+	'./Button',
 	"sap/ui/thirdparty/jquery"
 ],
 	function(
@@ -25,6 +26,7 @@ sap.ui.define([
 		ManagedObject,
 		Device,
 		ActionSheetRenderer,
+		Button,
 		jQuery
 	) {
 	"use strict";
@@ -418,7 +420,7 @@ sap.ui.define([
 			var sCancelButtonText = (this.getCancelButtonText()) ? this.getCancelButtonText() : sap.ui.getCore().getLibraryResourceBundle("sap.m").getText("ACTIONSHEET_CANCELBUTTON_TEXT"),
 				that = this;
 	//			var sButtonStyle = (sap.ui.Device.os.ios) ? sap.m.ButtonType.Unstyled : sap.m.ButtonType.Default;
-			this._oCancelButton = new sap.m.Button(this.getId() + '-cancelBtn', {
+			this._oCancelButton = new Button(this.getId() + '-cancelBtn', {
 				text: sCancelButtonText,
 				type: ButtonType.Reject,
 				press : function() {

--- a/src/sap.m/src/sap/m/BarRenderer.js
+++ b/src/sap.m/src/sap/m/BarRenderer.js
@@ -3,8 +3,8 @@
  * ${copyright}
  */
 
-sap.ui.define(['./BarInPageEnabler', 'sap/ui/Device', "sap/base/Log"],
-	function(BarInPageEnabler, Device, Log) {
+sap.ui.define(['./BarInPageEnabler', 'sap/ui/Device', "sap/base/Log", 'sap/m/HBox'],
+	function(BarInPageEnabler, Device, Log, HBox) {
 	"use strict";
 
 
@@ -86,7 +86,7 @@ sap.ui.define(['./BarInPageEnabler', 'sap/ui/Device', "sap/base/Log"],
 		oRM.writeClasses();
 		oRM.write(">");
 		if (oControl.getEnableFlexBox()) {
-			oControl._oflexBox = oControl._oflexBox || new sap.m.HBox(oControl.getId() + "-BarPH", {alignItems: "Center"}).addStyleClass("sapMBarPH").setParent(oControl, null, true);
+			oControl._oflexBox = oControl._oflexBox || new HBox(oControl.getId() + "-BarPH", {alignItems: "Center"}).addStyleClass("sapMBarPH").setParent(oControl, null, true);
 			var bContentLeft = !!oControl.getContentLeft().length,
 				bContentMiddle = !!oControl.getContentMiddle().length,
 				bContentRight = !!oControl.getContentRight().length;

--- a/src/sap.m/src/sap/m/BusyIndicator.js
+++ b/src/sap.m/src/sap/m/BusyIndicator.js
@@ -7,9 +7,11 @@ sap.ui.define([
 	'./library',
 	'sap/ui/core/Control',
 	'sap/ui/core/library',
+	'sap/m/Image',
+	'sap/m/Label',
 	"./BusyIndicatorRenderer"
 ],
-	function(library, Control, coreLibrary, BusyIndicatorRenderer) {
+	function(library, Control, coreLibrary, Image, Label, BusyIndicatorRenderer) {
 	"use strict";
 
 
@@ -213,7 +215,7 @@ sap.ui.define([
 
 	BusyIndicator.prototype._createCustomIcon = function(sName, sValue){
 		if (!this._iconImage) {
-			this._iconImage = new sap.m.Image(this.getId() + "-icon", {
+			this._iconImage = new Image(this.getId() + "-icon", {
 				width: "44px",
 				height: "44px"
 			}).addStyleClass("sapMBsyIndIcon");
@@ -231,7 +233,7 @@ sap.ui.define([
 
 	BusyIndicator.prototype._createLabel = function (sName, sValue) {
 		if (!this._busyLabel) {
-			this._busyLabel = new sap.m.Label(this.getId() + "-label", {
+			this._busyLabel = new Label(this.getId() + "-label", {
 				labelFor: this.getId(),
 				textAlign: "Center"
 			});

--- a/src/sap.m/src/sap/m/DatePicker.js
+++ b/src/sap.m/src/sap/m/DatePicker.js
@@ -19,6 +19,7 @@ sap.ui.define([
 	"sap/ui/core/IconPool",
 	"sap/ui/core/Popup",
 	"./InstanceManager",
+	"sap/ui/unified/DateRange",
 	// jQuery Plugin "cursorPos"
 	"sap/ui/dom/jquery/cursorPos"
 ],
@@ -37,7 +38,8 @@ sap.ui.define([
 		Log,
 		IconPool,
 		Popup,
-		InstanceManager
+		InstanceManager,
+		DateRange
 	) {
 	"use strict";
 
@@ -1030,7 +1032,7 @@ sap.ui.define([
 		var aVisibleDays = oCalendar._getVisibleDays();
 
 		// Convert to local JavaScript Date
-		return new sap.ui.unified.DateRange({
+		return new DateRange({
 			startDate: aVisibleDays[0].toLocalJSDate(), // First visible date
 			endDate: aVisibleDays[aVisibleDays.length - 1].toLocalJSDate() // Last visible date
 		});
@@ -1055,7 +1057,7 @@ sap.ui.define([
 						});
 					}.bind(this)
 				});
-			this._oDateRange = new sap.ui.unified.DateRange();
+			this._oDateRange = new DateRange();
 			this._oCalendar.addSelectedDate(this._oDateRange);
 			if (this.$().closest(".sapUiSizeCompact").length > 0) {
 				this._oCalendar.addStyleClass("sapUiSizeCompact");

--- a/src/sap.m/src/sap/m/DateTimePicker.js
+++ b/src/sap.m/src/sap/m/DateTimePicker.js
@@ -16,6 +16,10 @@ sap.ui.define([
 	'sap/ui/core/LocaleData',
 	'./DateTimePickerRenderer',
 	'./TimePickerSliders',
+	'./SegmentedButton',
+	'./SegmentedButtonItem',
+	'./ResponsivePopover',
+	'./Button',
 	"sap/ui/events/KeyCodes",
 	"sap/ui/core/IconPool"
 ], function(
@@ -31,6 +35,10 @@ sap.ui.define([
 	LocaleData,
 	DateTimePickerRenderer,
 	TimePickerSliders,
+	SegmentedButton,
+	SegmentedButtonItem,
+	ResponsivePopover,
+	Button,
 	KeyCodes,
 	IconPool
 ) {
@@ -223,10 +231,11 @@ sap.ui.define([
 				var sTimeText = oResourceBundle.getText("DATETIMEPICKER_TIME");
 
 
-				oSwitcher = new sap.m.SegmentedButton(this.getId() + "-Switch", {
+				oSwitcher = new SegmentedButton(this.getId() + "-Switch", {
 					selectedKey: "Cal",
-					items: [ new sap.m.SegmentedButtonItem(this.getId() + "-Switch-Cal", {key: "Cal", text: sDateText}),
-								new sap.m.SegmentedButtonItem(this.getId() + "-Switch-Sli", {key: "Sli", text: sTimeText})
+					items: [
+						new SegmentedButtonItem(this.getId() + "-Switch-Cal", {key: "Cal", text: sDateText}),
+						new SegmentedButtonItem(this.getId() + "-Switch-Sli", {key: "Sli", text: sTimeText})
 					]
 				});
 				oSwitcher.attachSelect(this._handleSelect, this);
@@ -485,12 +494,12 @@ sap.ui.define([
 			this._oPopupContent = new PopupContent(this.getId() + "-PC");
 			this._oPopupContent._oDateTimePicker = this;
 
-			this._oPopup = new sap.m.ResponsivePopover(this.getId() + "-RP", {
+			this._oPopup = new ResponsivePopover(this.getId() + "-RP", {
 				showCloseButton: false,
 				showHeader: false,
 				placement: PlacementType.VerticalPreferedBottom,
-				beginButton: new sap.m.Button(this.getId() + "-OK", { text: sOKButtonText, press: jQuery.proxy(_handleOkPress, this) }),
-				endButton: new sap.m.Button(this.getId() + "-Cancel", { text: sCancelButtonText, press: jQuery.proxy(_handleCancelPress, this) }),
+				beginButton: new Button(this.getId() + "-OK", { text: sOKButtonText, press: jQuery.proxy(_handleOkPress, this) }),
+				endButton: new Button(this.getId() + "-Cancel", { text: sCancelButtonText, press: jQuery.proxy(_handleCancelPress, this) }),
 				content: this._oPopupContent
 			});
 

--- a/src/sap.m/src/sap/m/Dialog.js
+++ b/src/sap.m/src/sap/m/Dialog.js
@@ -8,6 +8,7 @@ sap.ui.define([
 	'./InstanceManager',
 	'./AssociativeOverflowToolbar',
 	'./ToolbarSpacer',
+	'./Title',
 	'./library',
 	'sap/ui/core/Control',
 	'sap/ui/core/IconPool',
@@ -35,6 +36,7 @@ function(
 	InstanceManager,
 	AssociativeOverflowToolbar,
 	ToolbarSpacer,
+	Title,
 	library,
 	Control,
 	IconPool,
@@ -1587,7 +1589,7 @@ function(
 			if (this._headerTitle) {
 				this._headerTitle.setText(sTitle);
 			} else {
-				this._headerTitle = new sap.m.Title(this.getId() + "-title", {
+				this._headerTitle = new Title(this.getId() + "-title", {
 					text: sTitle,
 					level: "H2"
 				}).addStyleClass("sapMDialogTitle");

--- a/src/sap.m/src/sap/m/FacetFilterList.js
+++ b/src/sap.m/src/sap/m/FacetFilterList.js
@@ -9,9 +9,11 @@ sap.ui.define([
 	'sap/ui/model/ChangeReason',
 	'sap/ui/model/Filter',
 	'./FacetFilterListRenderer',
+	'./FacetFilterItem',
+	'./ListBase',
 	"sap/base/Log"
 ],
-	function(List, library, ChangeReason, Filter, FacetFilterListRenderer, Log) {
+	function(List, library, ChangeReason, Filter, FacetFilterListRenderer, FacetFilterItem, ListBase, Log) {
 	"use strict";
 
 
@@ -212,12 +214,12 @@ sap.ui.define([
 		var aSelectedItems = [];
 		// Track which items are added from the aggregation so that we don't add them again when adding the remaining selected key items
 		var oCurrentSelectedItemsMap = {};
-		var aCurrentSelectedItems = sap.m.ListBase.prototype.getSelectedItems.apply(this, arguments);
+		var aCurrentSelectedItems = ListBase.prototype.getSelectedItems.apply(this, arguments);
 
 		// First add items according to what is selected in the 'items' aggregation. This maintains indexes of currently selected items in the returned array.
 		aCurrentSelectedItems.forEach(function(oItem) {
 
-			aSelectedItems.push(new sap.m.FacetFilterItem({
+			aSelectedItems.push(new FacetFilterItem({
 				text: oItem.getText(),
 				key: oItem.getKey(),
 				selected: true
@@ -235,7 +237,7 @@ sap.ui.define([
 			aSelectedKeys.forEach(function(sKey) {
 
 				if (!oCurrentSelectedItemsMap[sKey]) {
-					aSelectedItems.push(new sap.m.FacetFilterItem({
+					aSelectedItems.push(new FacetFilterItem({
 						text: oSelectedKeys[sKey],
 						key: sKey,
 						selected: true
@@ -255,10 +257,10 @@ sap.ui.define([
 	 */
 	FacetFilterList.prototype.getSelectedItem = function() {
 
-		var oItem = sap.m.ListBase.prototype.getSelectedItem.apply(this, arguments);
+		var oItem = ListBase.prototype.getSelectedItem.apply(this, arguments);
 		var aSelectedKeys = Object.getOwnPropertyNames(this.getSelectedKeys());
 		if (!oItem && aSelectedKeys.length > 0) {
-			oItem = new sap.m.FacetFilterItem({
+			oItem = new FacetFilterItem({
 				text: this.getSelectedKeys()[aSelectedKeys[0]],
 				key: aSelectedKeys[0],
 				selected: true
@@ -277,7 +279,7 @@ sap.ui.define([
 		// See _resetItemsBinding to understand why we override the ListBase method
 		if (this._allowRemoveSelections) {
 
-			bAll ? this.setSelectedKeys() : sap.m.ListBase.prototype.removeSelections.call(this, bAll);
+			bAll ? this.setSelectedKeys() : ListBase.prototype.removeSelections.call(this, bAll);
 		}
 		return this;
 	};
@@ -328,7 +330,7 @@ sap.ui.define([
 			}
 			this._selectItemsByKeys();
 		} else {
-			sap.m.ListBase.prototype.removeSelections.call(this);
+			ListBase.prototype.removeSelections.call(this);
 		}
 	};
 
@@ -382,13 +384,13 @@ sap.ui.define([
 	 */
 	FacetFilterList.prototype.removeSelectedKeys = function() {
 		this._oSelectedKeys = {};
-		sap.m.ListBase.prototype.removeSelections.call(this, true);
+		ListBase.prototype.removeSelections.call(this, true);
 	};
 
 	FacetFilterList.prototype.removeItem = function(vItem) {
 
 		// Update the selected keys cache if an item is removed
-		var oItem = sap.m.ListBase.prototype.removeItem.apply(this, arguments);
+		var oItem = ListBase.prototype.removeItem.apply(this, arguments);
 		if (!this._filtering) {
 			oItem && oItem.getSelected() && this.removeSelectedKey(oItem.getKey(), oItem.getText());
 			return oItem;
@@ -491,7 +493,7 @@ sap.ui.define([
 
 			this._searchValue = ""; // Clear the search value since items are being reinitialized
 			this._allowRemoveSelections = false;
-			sap.m.ListBase.prototype._resetItemsBinding.apply(this, arguments);
+			ListBase.prototype._resetItemsBinding.apply(this, arguments);
 			this._allowRemoveSelections = true;
 		}
 	};
@@ -803,7 +805,7 @@ sap.ui.define([
 		} else {
 			this._removeSelectedKey(oItem.getKey(), oItem.getText());
 		}
-		sap.m.ListBase.prototype.onItemSelectedChange.apply(this, arguments);
+		ListBase.prototype.onItemSelectedChange.apply(this, arguments);
 
 		if (this.getMode() === ListMode.MultiSelect) {
 			/* At least one item needs to be selected to consider the list as active.
@@ -827,7 +829,7 @@ sap.ui.define([
 	 */
 	FacetFilterList.prototype.updateItems = function(sReason) {
 	  this._filtering = sReason === ChangeReason.Filter;
-	  sap.m.ListBase.prototype.updateItems.apply(this,arguments);
+	  ListBase.prototype.updateItems.apply(this,arguments);
 	  this._filtering = false;
 	  // If this list is not set to growing or it has been filtered then we must make sure that selections are
 	  // applied to items matching keys contained in the selected keys cache.  Selections

--- a/src/sap.m/src/sap/m/FlexBoxRenderer.js
+++ b/src/sap.m/src/sap/m/FlexBoxRenderer.js
@@ -6,9 +6,10 @@ sap.ui.define([
 	'./FlexBoxStylingHelper',
 	'sap/m/library',
 	"sap/base/security/encodeXML",
-	"sap/base/Log"
+	"sap/base/Log",
+    "sap/m/FlexItemData"
 ],
-	function(FlexBoxStylingHelper, library, encodeXML, Log) {
+	function(FlexBoxStylingHelper, library, encodeXML, Log, FlexItemData) {
 	"use strict";
 
 	// shortcut for sap.m.FlexDirection
@@ -47,7 +48,7 @@ sap.ui.define([
 
 			// Set layout properties for flex item
 			var oLayoutData = oControl.getLayoutData();
-			if (oLayoutData instanceof sap.m.FlexItemData) {
+			if (oLayoutData instanceof FlexItemData) {
 				FlexBoxStylingHelper.setFlexItemStyles(oRm, oLayoutData);
 			}
 
@@ -150,11 +151,11 @@ sap.ui.define([
 
 		// If no layout data is set, create it so that an ID can be set on the wrapper
 		if (sWrapperTag && !oLayoutData) {
-			oItem.setAggregation("layoutData", new sap.m.FlexItemData(), true);
+			oItem.setAggregation("layoutData", new FlexItemData(), true);
 			oLayoutData = oItem.getLayoutData();
 		}
 
-		if (!(oLayoutData instanceof sap.m.FlexItemData)) {
+		if (!(oLayoutData instanceof FlexItemData)) {
 			if (oLayoutData) {
 				Log.warning(oLayoutData + " set on " + oItem + " is not of type sap.m.FlexItemData");
 			}

--- a/src/sap.m/src/sap/m/GrowingEnablement.js
+++ b/src/sap.m/src/sap/m/GrowingEnablement.js
@@ -10,6 +10,7 @@ sap.ui.define([
 	'sap/ui/model/ChangeReason',
 	'sap/ui/base/ManagedObjectMetadata',
 	'sap/ui/core/HTML',
+	'sap/m/CustomListItem',
 	"sap/base/security/encodeXML"
 ],
 	function(
@@ -19,6 +20,7 @@ sap.ui.define([
 		ChangeReason,
 		ManagedObjectMetadata,
 		HTML,
+		CustomListItem,
 		encodeXML
 	) {
 	"use strict";
@@ -220,7 +222,7 @@ sap.ui.define([
 			}
 
 			// The growing button is changed to span tag as h1 tag was semantically incorrect.
-			this._oTrigger = new sap.m.CustomListItem({
+			this._oTrigger = new CustomListItem({
 				id: sTriggerID,
 				busyIndicatorDelay: 0,
 				type: ListType.Active,

--- a/src/sap.m/src/sap/m/IconTabBar.js
+++ b/src/sap.m/src/sap/m/IconTabBar.js
@@ -8,9 +8,10 @@ sap.ui.define([
 	'sap/ui/core/Control',
 	'sap/ui/base/ManagedObject',
 	'./IconTabBarRenderer',
+	'./IconTabHeader',
 	"sap/ui/thirdparty/jquery"
 ],
-	function(library, Control, ManagedObject, IconTabBarRenderer, jQuery) {
+	function(library, Control, ManagedObject, IconTabBarRenderer, IconTabHeader, jQuery) {
 	"use strict";
 
 
@@ -530,7 +531,7 @@ sap.ui.define([
 		var oControl = this.getAggregation("_header");
 
 		if (!oControl) {
-			oControl = new sap.m.IconTabHeader(this.getId() + "--header", {
+			oControl = new IconTabHeader(this.getId() + "--header", {
 			});
 			this.setAggregation("_header", oControl, true);
 		}

--- a/src/sap.m/src/sap/m/Input.js
+++ b/src/sap.m/src/sap/m/Input.js
@@ -19,6 +19,7 @@ sap.ui.define([
 	'./SuggestionsPopover',
 	'./Toolbar',
 	'./ToolbarSpacer',
+	'./Button',
 	"sap/ui/dom/containsOrEquals",
 	"sap/base/assert",
 	"sap/base/util/deepEqual",
@@ -43,6 +44,7 @@ function(
 	SuggestionsPopover,
 	Toolbar,
 	ToolbarSpacer,
+	Button,
 	containsOrEquals,
 	assert,
 	deepEqual,
@@ -1998,7 +2000,7 @@ function(
 	 * @return {sap.m.Button} Show more button.
 	 */
 	Input.prototype._getShowMoreButton = function() {
-		return this._oShowMoreButton || (this._oShowMoreButton = new sap.m.Button({
+		return this._oShowMoreButton || (this._oShowMoreButton = new Button({
 			text : this._oRb.getText("INPUT_SUGGESTIONS_SHOW_ALL"),
 			press : function() {
 				if (this.getShowTableSuggestionValueHelp()) {

--- a/src/sap.m/src/sap/m/LightBox.js
+++ b/src/sap.m/src/sap/m/LightBox.js
@@ -16,6 +16,7 @@ sap.ui.define([
 	'sap/ui/core/InvisibleText',
 	'sap/ui/core/library',
 	'./LightBoxRenderer',
+	'sap/m/BusyIndicator',
 	"sap/ui/thirdparty/jquery"
 ],
 	function(
@@ -32,6 +33,7 @@ sap.ui.define([
 		InvisibleText,
 		coreLibrary,
 		LightBoxRenderer,
+		BusyIndicator,
 		jQuery
 	) {
 
@@ -393,7 +395,7 @@ sap.ui.define([
 			var busyIndicator = this.getAggregation("_busy");
 
 			if (!busyIndicator) {
-				busyIndicator = new sap.m.BusyIndicator();
+				busyIndicator = new BusyIndicator();
 				this.setAggregation("_busy", busyIndicator, true);
 			}
 

--- a/src/sap.m/src/sap/m/MaskEnabler.js
+++ b/src/sap.m/src/sap/m/MaskEnabler.js
@@ -10,9 +10,10 @@ sap.ui.define([
 	"sap/ui/events/KeyCodes",
 	"sap/base/Log",
 	"sap/ui/thirdparty/jquery",
+	"sap/m/MaskInputRule",
 	// jQuery Plugin "cursorPos"
 	"sap/ui/dom/jquery/cursorPos"
-], function(Control, InputBase, Device, coreLibrary, KeyCodes, Log, jQuery) {
+], function(Control, InputBase, Device, coreLibrary, KeyCodes, Log, jQuery, MaskInputRule) {
 	"use strict";
 
 	// shortcut for sap.ui.core.TextDirection
@@ -513,11 +514,11 @@ sap.ui.define([
 		 */
 		this._setDefaultRules = function () {
 			this._bSkipSetupMaskVariables = true;
-			this.addRule(new sap.m.MaskInputRule({
+			this.addRule(new MaskInputRule({
 				maskFormatSymbol: "a",
 				regex: "[A-Za-z]"
 			}), true);
-			this.addRule(new sap.m.MaskInputRule({
+			this.addRule(new MaskInputRule({
 				maskFormatSymbol: "9",
 				regex: "[0-9]"
 			}), true);

--- a/src/sap.m/src/sap/m/MessagePage.js
+++ b/src/sap.m/src/sap/m/MessagePage.js
@@ -12,6 +12,7 @@ sap.ui.define([
 	'sap/m/Image',
 	'sap/m/Button',
 	'sap/m/Title',
+	'sap/m/Bar',
 	'sap/m/FormattedText',
 	'./MessagePageRenderer',
 	"sap/ui/thirdparty/jquery"
@@ -24,6 +25,7 @@ sap.ui.define([
 	Image,
 	Button,
 	Title,
+	Bar,
 	FormattedText,
 	MessagePageRenderer,
 	jQuery
@@ -196,7 +198,7 @@ sap.ui.define([
 				}, this)
 			});
 
-			this.setAggregation("_internalHeader", new sap.m.Bar(this.getId() + "-intHeader", {
+			this.setAggregation("_internalHeader", new Bar(this.getId() + "-intHeader", {
 				design: BarDesign.Header
 			}));
 

--- a/src/sap.m/src/sap/m/MultiComboBox.js
+++ b/src/sap.m/src/sap/m/MultiComboBox.js
@@ -13,6 +13,7 @@ sap.ui.define([
 	'./List',
 	'./Popover',
 	'./GroupHeaderListItem',
+	'./StandardListItem',
 	'./library',
 	'sap/ui/core/EnabledPropagator',
 	'sap/ui/core/IconPool',
@@ -44,6 +45,7 @@ function(
 	List,
 	Popover,
 	GroupHeaderListItem,
+  StandardListItem,
 	library,
 	EnabledPropagator,
 	IconPool,
@@ -1264,7 +1266,7 @@ function(
 		}
 
 		// Fill Tokenizer
-		var oToken = new sap.m.Token({
+		var oToken = new Token({
 			key: mOptions.key
 		});
 		oToken.setText(mOptions.item.getText());
@@ -1856,7 +1858,7 @@ function(
 	 * @private
 	 */
 	MultiComboBox.prototype._createTokenizer = function() {
-		var oTokenizer = new sap.m.Tokenizer({
+		var oTokenizer = new Tokenizer({
 			tokens: []
 		}).attachTokenChange(this._handleTokenChange, this);
 		oTokenizer._setAdjustable(true);
@@ -2702,7 +2704,7 @@ function(
 		sListItem = oRenderer.CSS_CLASS_MULTICOMBOBOX + "Item";
 		sListItemSelected = (this.isItemSelected(oItem)) ? sListItem + "Selected" : "";
 
-		oListItem = new sap.m.StandardListItem({
+		oListItem = new StandardListItem({
 			type: ListType.Active,
 			info: sAdditionalText,
 			visible: oItem.getEnabled()
@@ -2714,7 +2716,7 @@ function(
 		oListItem.setTitle(oItem.getText());
 
 		if (sListItemSelected) {
-			var oToken = new sap.m.Token({
+			var oToken = new Token({
 				key: oItem.getKey()
 			});
 			oToken.setText(oItem.getText());

--- a/src/sap.m/src/sap/m/MultiInput.js
+++ b/src/sap.m/src/sap/m/MultiInput.js
@@ -18,6 +18,7 @@ sap.ui.define([
 	'./Title',
 	'./Bar',
 	'./Toolbar',
+	'./StandardListItem',
 	'sap/ui/core/ResizeHandler',
 	'sap/ui/core/IconPool',
 	'./MultiInputRenderer',
@@ -44,6 +45,7 @@ function(
 	Title,
 	Bar,
 	Toolbar,
+	StandardListItem,
 	ResizeHandler,
 	IconPool,
 	MultiInputRenderer,
@@ -1640,7 +1642,7 @@ function(
 			return null;
 		}
 
-		var oListItem = new sap.m.StandardListItem({
+		var oListItem = new StandardListItem({
 			selected: true,
 			title: oToken.getText()
 		});

--- a/src/sap.m/src/sap/m/NotificationListItem.js
+++ b/src/sap.m/src/sap/m/NotificationListItem.js
@@ -10,6 +10,7 @@ sap.ui.define([
 	'sap/ui/core/IconPool',
 	'sap/ui/core/ResizeHandler',
 	'sap/m/Button',
+	'sap/m/Text',
 	'./NotificationListItemRenderer'
 ],
 function(
@@ -20,6 +21,7 @@ function(
 	IconPool,
 	ResizeHandler,
 	Button,
+	Text,
 	NotificationListItemRenderer
 	) {
 	'use strict';
@@ -308,7 +310,7 @@ function(
 		var bodyText = this.getAggregation('_bodyText');
 
 		if (!bodyText) {
-			bodyText = new sap.m.Text({
+			bodyText = new Text({
 				id: this.getId() + '-body',
 				text: this.getDescription(),
 				maxLines: 2

--- a/src/sap.m/src/sap/m/ObjectHeader.js
+++ b/src/sap.m/src/sap/m/ObjectHeader.js
@@ -11,6 +11,8 @@ sap.ui.define([
 	'sap/ui/Device',
 	'sap/m/Text',
 	'./ObjectHeaderRenderer',
+	'./ObjectMarker',
+	'./ObjectNumber',
 	"sap/ui/thirdparty/jquery"
 ],
 	function(
@@ -21,6 +23,8 @@ sap.ui.define([
 		Device,
 		Text,
 		ObjectHeaderRenderer,
+    ObjectMarker,
+    ObjectNumber,
 		jQuery
 	) {
 	"use strict";
@@ -701,7 +705,7 @@ sap.ui.define([
 		}
 
 		if (!bHasMarker) {
-			this.insertAggregation("markers", new sap.m.ObjectMarker({
+			this.insertAggregation("markers", new ObjectMarker({
 				id: this.getId() + oIds[markerType],
 				type: markerType,
 				visible: bMarked
@@ -739,7 +743,7 @@ sap.ui.define([
 		var oControl = this.getAggregation("_objectNumber");
 
 		if (!oControl) {
-			oControl = new sap.m.ObjectNumber(this.getId() + "-number", {
+			oControl = new ObjectNumber(this.getId() + "-number", {
 				emphasized: false
 			});
 

--- a/src/sap.m/src/sap/m/ObjectHeaderRenderer.js
+++ b/src/sap.m/src/sap/m/ObjectHeaderRenderer.js
@@ -7,9 +7,11 @@ sap.ui.define([
 	'sap/m/library',
 	'sap/ui/Device',
 	"sap/base/Log",
+	'sap/m/Link',
+	'sap/m/Text',
 	"sap/ui/thirdparty/jquery"
 ],
-	function(Control, coreLibrary, library, Device, Log, jQuery) {
+	function(Control, coreLibrary, library, Device, Log, Link, Text, jQuery) {
 	"use strict";
 
 
@@ -174,13 +176,13 @@ sap.ui.define([
 	 */
 	ObjectHeaderRenderer._renderIntro = function(oRM, oOH, sIntroClass, sIntroActiveClass) {
 		if (oOH.getIntroActive()) {
-			oOH._introText = new sap.m.Link(oOH.getId() + "-intro");
+			oOH._introText = new Link(oOH.getId() + "-intro");
 			oOH._introText.setText(oOH.getIntro());
 			oOH._introText.setHref(oOH.getIntroHref());
 			oOH._introText.setTarget(oOH.getIntroTarget());
 			oOH._introText.press = oOH.introPress;
 		} else {
-			oOH._introText = new sap.m.Text(oOH.getId() + "-intro");
+			oOH._introText = new Text(oOH.getId() + "-intro");
 			oOH._introText.setText(oOH.getIntro());
 			oOH._introText.setMaxLines(3);
 		}

--- a/src/sap.m/src/sap/m/ObjectIdentifier.js
+++ b/src/sap.m/src/sap/m/ObjectIdentifier.js
@@ -5,6 +5,8 @@
 // Provides control sap.m.ObjectIdentifier.
 sap.ui.define([
 	'./library',
+	'./Link',
+	'./Text',
 	'sap/ui/core/Control',
 	'sap/ui/core/IconPool',
 	'sap/ui/core/InvisibleText',
@@ -15,6 +17,8 @@ sap.ui.define([
 ],
 function(
 	library,
+	Link,
+	Text,
 	Control,
 	IconPool,
 	InvisibleText,
@@ -265,7 +269,7 @@ function(
 		if (!oTitleControl) {
 			// Lazy initialization
 			if (this.getProperty("titleActive")) {
-				oTitleControl = new sap.m.Link({
+				oTitleControl = new Link({
 					id : sId + "-link",
 					text: ManagedObject.escapeSettingsValue(this.getProperty("title")),
 					//Add a custom hidden role "ObjectIdentifier" with hidden text
@@ -273,7 +277,7 @@ function(
 				});
 				oTitleControl.addAssociation("ariaLabelledBy", sId + "-text", true);
 			} else {
-				oTitleControl = new sap.m.Text({
+				oTitleControl = new Text({
 					id : sId + "-txt",
 					text: ManagedObject.escapeSettingsValue(this.getProperty("title"))
 				});
@@ -299,7 +303,7 @@ function(
 
 		if (bIsTitleActive && oTitleControl instanceof sap.m.Text) {
 			this.destroyAggregation("_titleControl", true);
-			oTitleControl = new sap.m.Link({
+			oTitleControl = new Link({
 				id : sId + "-link",
 				text: ManagedObject.escapeSettingsValue(this.getProperty("title")),
 				//Add a custom hidden role "ObjectIdentifier" with hidden text
@@ -309,7 +313,7 @@ function(
 			this.setAggregation("_titleControl", oTitleControl, true);
 		} else if (!bIsTitleActive && oTitleControl instanceof sap.m.Link) {
 			this.destroyAggregation("_titleControl", true);
-			oTitleControl = new sap.m.Text({
+			oTitleControl = new Text({
 				id : sId + "-txt",
 				text: ManagedObject.escapeSettingsValue(this.getProperty("title"))
 			});
@@ -339,7 +343,7 @@ function(
 		var oTextControl = this.getAggregation("_textControl");
 
 		if (!oTextControl) {
-			oTextControl = new sap.m.Text({
+			oTextControl = new Text({
 				text: ManagedObject.escapeSettingsValue(this.getProperty("text"))
 			});
 			this.setAggregation("_textControl", oTextControl, true);

--- a/src/sap.m/src/sap/m/ObjectListItem.js
+++ b/src/sap.m/src/sap/m/ObjectListItem.js
@@ -11,6 +11,8 @@ sap.ui.define([
 	'sap/ui/core/IconPool',
 	'sap/m/ObjectNumber',
 	'sap/ui/core/library',
+	'./ObjectMarker',
+	'./Text',
 	'./ObjectListItemRenderer'
 ],
 function(
@@ -21,6 +23,8 @@ function(
 	IconPool,
 	ObjectNumber,
 	coreLibrary,
+  ObjectMarker,
+	Text,
 	ObjectListItemRenderer
 	) {
 		"use strict";
@@ -603,7 +607,7 @@ function(
 			}
 
 			if (!bHasMarker) {
-				this.insertAggregation("markers", new sap.m.ObjectMarker({
+				this.insertAggregation("markers", new ObjectMarker({
 					id: this.getId() + oIds[markerType],
 					type: markerType,
 					visible: bMarked
@@ -621,7 +625,7 @@ function(
 		ObjectListItem.prototype._getTitleText = function() {
 
 			if (!this._oTitleText) {
-				this._oTitleText = new sap.m.Text(this.getId() + "-titleText", {
+				this._oTitleText = new Text(this.getId() + "-titleText", {
 					maxLines: 2
 				});
 

--- a/src/sap.m/src/sap/m/PlanningCalendar.js
+++ b/src/sap.m/src/sap/m/PlanningCalendar.js
@@ -17,6 +17,8 @@ sap.ui.define([
 	'sap/ui/unified/CalendarDateInterval',
 	'sap/ui/unified/CalendarWeekInterval',
 	'sap/ui/unified/CalendarOneMonthInterval',
+	'sap/ui/unified/CalendarMonthInterval',
+	'sap/ui/unified/CalendarTimeInterval',
 	'sap/ui/Device',
 	'sap/ui/core/Element',
 	'sap/ui/core/Renderer',
@@ -37,6 +39,8 @@ sap.ui.define([
 	'sap/m/StandardListItemRenderer',
 	'sap/m/PlanningCalendarRow',
 	'sap/m/PlanningCalendarRenderer',
+	'sap/m/PlanningCalendarView',
+	'sap/m/CheckBox',
 	'sap/m/library',
 	"sap/base/util/deepEqual",
 	"sap/base/Log",
@@ -57,6 +61,8 @@ sap.ui.define([
 	CalendarDateInterval,
 	CalendarWeekInterval,
 	CalendarOneMonthInterval,
+	CalendarMonthInterval,
+	CalendarTimeInterval,
 	Device,
 	Element,
 	Renderer,
@@ -77,6 +83,8 @@ sap.ui.define([
 	StandardListItemRenderer,
 	PlanningCalendarRow,
 	PlanningCalendarRenderer,
+	PlanningCalendarView,
+	CheckBox,
 	library,
 	deepEqual,
 	Log,
@@ -1149,7 +1157,7 @@ sap.ui.define([
 			switch (sIntervalType) {
 				case CalendarIntervalType.Hour:
 					if (!this._oTimeInterval) {
-						this._oTimeInterval = new sap.ui.unified.CalendarTimeInterval(this.getId() + "-TimeInt", {
+						this._oTimeInterval = new CalendarTimeInterval(this.getId() + "-TimeInt", {
 							startDate: new Date(oStartDate.getTime()), // use new date object
 							items: iIntervals,
 							pickerPopup: true,
@@ -1220,7 +1228,7 @@ sap.ui.define([
 
 				case CalendarIntervalType.Month:
 					if (!this._oMonthInterval) {
-						this._oMonthInterval = new sap.ui.unified.CalendarMonthInterval(this.getId() + "-MonthInt", {
+						this._oMonthInterval = new CalendarMonthInterval(this.getId() + "-MonthInt", {
 							startDate: new Date(oStartDate.getTime()), // use new date object
 							months: iIntervals,
 							pickerPopup: true,
@@ -2347,7 +2355,7 @@ sap.ui.define([
 			switch (sViewKey) {
 				case oViewType.Hour:
 					return this._oViews[oViewType.Hour] ||
-						(this._oViews[oViewType.Hour] = new sap.m.PlanningCalendarView(this.getId() + "-HourView", {
+						(this._oViews[oViewType.Hour] = PlanningCalendarView(this.getId() + "-HourView", {
 							key: oViewType.Hour,
 							intervalType: oIntervalType.Hour,
 							description: this._oRB.getText("PLANNINGCALENDAR_HOURS"),
@@ -2357,7 +2365,7 @@ sap.ui.define([
 						}));
 				case oViewType.Day:
 					return this._oViews[oViewType.Day] ||
-						(this._oViews[oViewType.Day] = new sap.m.PlanningCalendarView(this.getId() + "-DayView", {
+						(this._oViews[oViewType.Day] = PlanningCalendarView(this.getId() + "-DayView", {
 							key: oViewType.Day,
 							intervalType: oIntervalType.Day,
 							description: this._oRB.getText("PLANNINGCALENDAR_DAYS"),
@@ -2367,7 +2375,7 @@ sap.ui.define([
 						}));
 				case oViewType.Month:
 					return  this._oViews[oViewType.Month] ||
-						(this._oViews[oViewType.Month] = new sap.m.PlanningCalendarView(this.getId() + "-MonthView", {
+						(this._oViews[oViewType.Month] = PlanningCalendarView(this.getId() + "-MonthView", {
 							key: oViewType.Month,
 							intervalType: oIntervalType.Month,
 							description: this._oRB.getText("PLANNINGCALENDAR_MONTHS"),
@@ -2377,7 +2385,7 @@ sap.ui.define([
 						}));
 				case oViewType.Week:
 					return this._oViews[oViewType.Week] ||
-						(this._oViews[oViewType.Week] = new sap.m.PlanningCalendarView(this.getId() + "-WeekView", {
+						(this._oViews[oViewType.Week] = PlanningCalendarView(this.getId() + "-WeekView", {
 							key: oViewType.Week,
 							intervalType: oIntervalType.Week,
 							description: this._oRB.getText("PLANNINGCALENDAR_WEEK"),
@@ -2387,7 +2395,7 @@ sap.ui.define([
 						}));
 				case oViewType.OneMonth:
 					return this._oViews[oViewType.OneMonth] ||
-						( this._oViews[oViewType.OneMonth] = new sap.m.PlanningCalendarView(this.getId() + "-OneMonthView", {
+						( this._oViews[oViewType.OneMonth] = new PlanningCalendarView(this.getId() + "-OneMonthView", {
 							key: oViewType.OneMonth,
 							intervalType: oIntervalType.OneMonth,
 							description: this._oRB.getText("PLANNINGCALENDAR_ONE_MONTH"),
@@ -3736,7 +3744,7 @@ sap.ui.define([
 			}
 		} else {
 			if (!this._oSelectAllCheckBox) {
-				this._oSelectAllCheckBox = new sap.m.CheckBox(this.getId() + "-All", {
+				this._oSelectAllCheckBox = new CheckBox(this.getId() + "-All", {
 					text: this._oRB.getText("COLUMNSPANEL_SELECT_ALL")
 				});
 				this._oSelectAllCheckBox.attachEvent("select", handleSelectAll, this);

--- a/src/sap.m/src/sap/m/Popover.js
+++ b/src/sap.m/src/sap/m/Popover.js
@@ -9,6 +9,7 @@ sap.ui.define([
 	'./Button',
 	'./InstanceManager',
 	'./library',
+	'./Title',
 	'sap/ui/core/Control',
 	'sap/ui/core/Popup',
 	'sap/ui/core/delegate/ScrollEnablement',
@@ -33,6 +34,7 @@ sap.ui.define([
 		Button,
 		InstanceManager,
 		library,
+    Title,
 		Control,
 		Popup,
 		ScrollEnablement,
@@ -2278,7 +2280,7 @@ sap.ui.define([
 			if (this._headerTitle) {
 				this._headerTitle.setText(sTitle);
 			} else {
-				this._headerTitle = new sap.m.Title(this.getId() + "-title", {
+				this._headerTitle = new Title(this.getId() + "-title", {
 					text: this.getTitle(),
 					level: "H2"
 				});

--- a/src/sap.m/src/sap/m/RadioButton.js
+++ b/src/sap.m/src/sap/m/RadioButton.js
@@ -8,6 +8,7 @@ sap.ui.define([
 	'sap/ui/core/Control',
 	'sap/ui/core/EnabledPropagator',
 	'./RadioButtonGroup',
+	'./Label',
 	'sap/ui/core/library',
 	'sap/base/strings/capitalize',
 	'./RadioButtonRenderer'
@@ -17,6 +18,7 @@ function(
 	Control,
 	EnabledPropagator,
 	RadioButtonGroup,
+	Label,
 	coreLibrary,
 	capitalize,
 	RadioButtonRenderer
@@ -622,7 +624,7 @@ function(
 	 * @private
 	 */
 	RadioButton.prototype._createLabel = function(prop, value) {
-		this._oLabel = new sap.m.Label(this.getId() + "-label").addStyleClass("sapMRbBLabel").setParent(this, null, true);
+		this._oLabel = new Label(this.getId() + "-label").addStyleClass("sapMRbBLabel").setParent(this, null, true);
 		this._oLabel.setProperty(prop, value, false);
 	};
 

--- a/src/sap.m/src/sap/m/ResponsivePopover.js
+++ b/src/sap.m/src/sap/m/ResponsivePopover.js
@@ -12,6 +12,9 @@ sap.ui.define([
 	'sap/ui/base/ManagedObject',
 	'sap/ui/Device',
 	'./ResponsivePopoverRenderer',
+	'./Toolbar',
+	'./ToolbarSpacer',
+	'./Button',
 	"sap/ui/thirdparty/jquery"
 ],
 	function(
@@ -23,6 +26,9 @@ sap.ui.define([
 		ManagedObject,
 		Device,
 		ResponsivePopoverRenderer,
+		Toolbar,
+		ToolbarSpacer,
+		Button,
 		jQuery
 	) {
 	"use strict";
@@ -438,7 +444,7 @@ sap.ui.define([
 	ResponsivePopover.prototype._getCloseButton = function(){
 		if (!this._oCloseButton) {
 			var that = this;
-			this._oCloseButton = new sap.m.Button(this.getId() + "-closeButton", {
+			this._oCloseButton = new Button(this.getId() + "-closeButton", {
 				icon: IconPool.getIconURI("decline"),
 				press: function() {
 					that._oControl._oCloseTrigger = this;
@@ -589,8 +595,8 @@ sap.ui.define([
 			return this._oFooter;
 		}
 
-		this._oFooter = new sap.m.Toolbar(this.getId() + "-footer", {
-			content: [new sap.m.ToolbarSpacer()]
+		this._oFooter = new Toolbar(this.getId() + "-footer", {
+			content: [new ToolbarSpacer()]
 		});
 
 		return this._oFooter;

--- a/src/sap.m/src/sap/m/SegmentedButton.js
+++ b/src/sap.m/src/sap/m/SegmentedButton.js
@@ -5,6 +5,8 @@
 // Provides control sap.m.SegmentedButton.
 sap.ui.define([
 	'./library',
+	'./Button',
+	'./Select',
 	'sap/ui/core/Control',
 	'sap/ui/core/EnabledPropagator',
 	'sap/ui/core/delegate/ItemNavigation',
@@ -15,6 +17,8 @@ sap.ui.define([
 ],
 function(
 	library,
+  Button,
+	Select,
 	Control,
 	EnabledPropagator,
 	ItemNavigation,
@@ -480,7 +484,7 @@ function(
 	 * @ui5-metamodel This method also will be described in the UI5 (legacy) designtime metamodel
 	 */
 	SegmentedButton.prototype.createButton = function (sText, sURI, bEnabled, sTextDirection) {
-		var oButton = new sap.m.Button();
+		var oButton = new Button();
 
 		if (sText !== null) {
 			oButton.setText(sText);
@@ -860,7 +864,7 @@ function(
 		var oSelect = this.getAggregation("_select");
 
 		if (!oSelect) {
-			oSelect = new sap.m.Select(this.getId() + "-select");
+			oSelect = new Select(this.getId() + "-select");
 			oSelect.attachChange(this._selectChangeHandler, this);
 			oSelect.addStyleClass("sapMSegBSelectWrapper");
 			this.setAggregation("_select", oSelect, true);

--- a/src/sap.m/src/sap/m/SplitContainer.js
+++ b/src/sap.m/src/sap/m/SplitContainer.js
@@ -14,6 +14,7 @@ sap.ui.define([
 	'sap/ui/base/ManagedObject',
 	'sap/m/NavContainer',
 	'sap/m/Popover',
+	'sap/m/Button',
 	'./SplitContainerRenderer',
 	"sap/ui/dom/containsOrEquals",
 	"sap/base/Log",
@@ -30,6 +31,7 @@ function(
 	ManagedObject,
 	NavContainer,
 	Popover,
+	Button,
 	SplitContainerRenderer,
 	containsOrEquals,
 	Log,
@@ -1877,7 +1879,7 @@ function(
 			return;
 		}
 
-		this._oShowMasterBtn = new sap.m.Button(this.getId() + "-MasterBtn", {
+		this._oShowMasterBtn = new Button(this.getId() + "-MasterBtn", {
 			icon: IconPool.getIconURI("menu2"),
 			tooltip: this.getMasterButtonTooltip(),
 			type: ButtonType.Default,

--- a/src/sap.m/src/sap/m/TabContainer.js
+++ b/src/sap.m/src/sap/m/TabContainer.js
@@ -7,9 +7,12 @@ sap.ui.define([
 	'./library',
 	'sap/ui/core/Control',
 	'sap/ui/core/IconPool',
-	'./TabContainerRenderer'
+	'./TabContainerRenderer',
+    './TabStrip',
+    './TabStripItem',
+    './Button'
 ],
-	function(library, Control, IconPool, TabContainerRenderer) {
+	function(library, Control, IconPool, TabContainerRenderer, TabStrip, TabStripItem, Button) {
 		"use strict";
 
 		// shortcut for sap.m.ButtonType
@@ -148,7 +151,7 @@ sap.ui.define([
 				}
 
 				Control.prototype.constructor.apply(this, arguments);
-				var oControl = new sap.m.TabStrip(this.getId() + "--tabstrip", {
+				var oControl = new TabStrip(this.getId() + "--tabstrip", {
 					hasSelect: true,
 					itemSelect: function(oEvent) {
 						var oItem = oEvent.getParameter("item"),
@@ -214,7 +217,7 @@ sap.ui.define([
 			var oRb = sap.ui.getCore().getLibraryResourceBundle("sap.m");
 
 			if (!oControl) {
-				oControl = new sap.m.Button({
+				oControl = new Button({
 					type: ButtonType.Transparent,
 					tooltip: oRb.getText("TABCONTAINER_ADD_NEW_TAB"),
 					icon: IconPool.getIconURI("add"),
@@ -427,7 +430,7 @@ sap.ui.define([
 			this.addAggregation("items", oItem, false);
 
 			this._getTabStrip().addItem(
-				new sap.m.TabStripItem({
+				new TabStripItem({
 					key: oItem.getId(),
 					text: oItem.getName(),
 					additionalText: oItem.getAdditionalText(),
@@ -464,7 +467,7 @@ sap.ui.define([
 		 */
 		TabContainer.prototype.insertItem = function(oItem, iIndex) {
 			this._getTabStrip().insertItem(
-				new sap.m.TabStripItem({
+				new TabStripItem({
 					key: oItem.getId(),
 					text: oItem.getName(),
 					additionalText: oItem.getAdditionalText(),

--- a/src/sap.m/src/sap/m/TimePicker.js
+++ b/src/sap.m/src/sap/m/TimePicker.js
@@ -21,6 +21,7 @@ sap.ui.define([
 	"sap/ui/events/KeyCodes",
 	"sap/base/Log",
 	"sap/ui/core/InvisibleText",
+	'./Button',
 	"sap/ui/thirdparty/jquery"
 ],
 function(
@@ -41,6 +42,7 @@ function(
 	KeyCodes,
 	Log,
 	InvisibleText,
+  Button,
 	jQuery
 ) {
 		"use strict";
@@ -1077,8 +1079,8 @@ function(
 				horizontalScrolling: false,
 				verticalScrolling: false,
 				placement: PlacementType.VerticalPreferedBottom,
-				beginButton: new sap.m.Button({ text: sOKButtonText, press: jQuery.proxy(this._handleOkPress, this) }),
-				endButton: new sap.m.Button({ text: sCancelButtonText, press: jQuery.proxy(this._handleCancelPress, this) }),
+				beginButton: new Button({ text: sOKButtonText, press: jQuery.proxy(this._handleOkPress, this) }),
+				endButton: new Button({ text: sCancelButtonText, press: jQuery.proxy(this._handleCancelPress, this) }),
 				content: [
 					new TimePickerSliders(this.getId() + "-sliders", {
 						support2400: this.getSupport2400(),

--- a/src/sap.m/src/sap/m/TimePickerSlider.js
+++ b/src/sap.m/src/sap/m/TimePickerSlider.js
@@ -8,9 +8,10 @@ sap.ui.define([
 	'sap/ui/core/IconPool',
 	'sap/ui/Device',
 	"sap/ui/events/KeyCodes",
+	"sap/m/Button",
 	"sap/ui/thirdparty/jquery"
 ],
-	function(Control, TimePickerSliderRenderer, IconPool, Device, KeyCodes, jQuery) {
+	function(Control, TimePickerSliderRenderer, IconPool, Device, KeyCodes, Button, jQuery) {
 		"use strict";
 
 		/**
@@ -1153,7 +1154,7 @@ sap.ui.define([
 		TimePickerSlider.prototype._initArrows = function() {
 			var that = this, oArrowUp, oArrowDown;
 
-			oArrowUp = new sap.m.Button({
+			oArrowUp = new Button({
 				icon: IconPool.getIconURI("slim-arrow-up"),
 				press: function (oEvent) {
 					that._offsetValue(-1);
@@ -1168,7 +1169,7 @@ sap.ui.define([
 
 			this.setAggregation("_arrowUp", oArrowUp);
 
-			oArrowDown = new sap.m.Button({
+			oArrowDown = new Button({
 				icon: IconPool.getIconURI("slim-arrow-down"),
 				press: function (oEvent) {
 					that._offsetValue(1);

--- a/src/sap.m/src/sap/m/ViewSettingsDialog.js
+++ b/src/sap.m/src/sap/m/ViewSettingsDialog.js
@@ -19,7 +19,15 @@ sap.ui.define([
 	'./ViewSettingsDialogRenderer',
 	"sap/m/GroupHeaderListItem",
 	"sap/base/Log",
-	"sap/ui/thirdparty/jquery",
+	"./NavContainer",
+	"./Label",
+	"./Bar",
+	"./SegmentedButton",
+	"./Button",
+	"./Page",
+	"./Dialog",
+	"./ViewSettingsItem",
+  "sap/ui/thirdparty/jquery",
 	// jQuery Plugin "firstFocusableDomRef"
 	"sap/ui/dom/jquery/Focusable"
 ],
@@ -39,6 +47,14 @@ function(
 	ViewSettingsDialogRenderer,
 	GroupHeaderListItem,
 	Log,
+	NavContainer,
+	Label,
+	Bar,
+	SegmentedButton,
+	Button,
+	Page,
+	Dialog,
+	ViewSettingsItem,
 	jQuery
 ) {
 	"use strict";
@@ -1509,7 +1525,7 @@ function(
 
 		// create an internal instance of a dialog
 		if (this._dialog === undefined) {
-			this._dialog = new sap.m.Dialog(this.getId() + "-dialog", {
+			this._dialog = new Dialog(this.getId() + "-dialog", {
 				ariaLabelledBy      : this._sTitleLabelId,
 				showHeader          : false,
 				stretch             : Device.system.phone,
@@ -1518,11 +1534,11 @@ function(
 				contentWidth        : this._sDialogWidth,
 				contentHeight       : this._sDialogHeight,
 				content             : this._getNavContainer(),
-				beginButton         : new sap.m.Button(this.getId() + "-acceptbutton", {
+				beginButton         : new Button(this.getId() + "-acceptbutton", {
 					text : this._rb.getText("VIEWSETTINGS_ACCEPT"),
 					type: sap.m.ButtonType.Emphasized
 				}).attachPress(this._onConfirm, this),
-				endButton           : new sap.m.Button(this.getId() + "-cancelbutton", {
+				endButton           : new Button(this.getId() + "-cancelbutton", {
 					text : this._rb.getText("VIEWSETTINGS_CANCEL")
 				}).attachPress(this._onCancel, this)
 			}).addStyleClass("sapMVSD");
@@ -1561,7 +1577,7 @@ function(
 	ViewSettingsDialog.prototype._getNavContainer = function() {
 		// create an internal instance of a dialog
 		if (this._navContainer === undefined) {
-			this._navContainer = new sap.m.NavContainer(this.getId()
+			this._navContainer = new NavContainer(this.getId()
 			+ '-navcontainer', {
 				pages : []
 			});
@@ -1576,7 +1592,7 @@ function(
 	 */
 	ViewSettingsDialog.prototype._getTitleLabel = function() {
 		if (this._titleLabel === undefined) {
-			this._titleLabel = new sap.m.Label(this._sTitleLabelId, {
+			this._titleLabel = new Label(this._sTitleLabelId, {
 				text : this._rb.getText("VIEWSETTINGS_TITLE")
 			}).addStyleClass("sapMVSDTitle");
 		}
@@ -1592,7 +1608,7 @@ function(
 		var that = this;
 
 		if (this._resetButton === undefined) {
-			this._resetButton = new sap.m.Button(this.getId() + "-resetbutton", {
+			this._resetButton = new Button(this.getId() + "-resetbutton", {
 				press : function() {
 					that._onClearFilters();
 				},
@@ -1609,7 +1625,7 @@ function(
 	 */
 	ViewSettingsDialog.prototype._getDetailTitleLabel = function() {
 		if (this._detailTitleLabel === undefined) {
-			this._detailTitleLabel = new sap.m.Label(this.getId() + "-detailtitle",
+			this._detailTitleLabel = new Label(this.getId() + "-detailtitle",
 				{
 					text : this._rb.getText("VIEWSETTINGS_TITLE_FILTERBY")
 				}).addStyleClass("sapMVSDTitle");
@@ -1624,7 +1640,7 @@ function(
 	 */
 	ViewSettingsDialog.prototype._getHeader = function() {
 		if (this._header === undefined) {
-			this._header = new sap.m.Bar({
+			this._header = new Bar({
 				contentMiddle : [ this._getTitleLabel() ]
 			}).addStyleClass("sapMVSDBar");
 		}
@@ -1638,7 +1654,7 @@ function(
 	 */
 	ViewSettingsDialog.prototype._getSubHeader = function() {
 		if (this._subHeader === undefined) {
-			this._subHeader = new sap.m.Bar({
+			this._subHeader = new Bar({
 				contentLeft : [ this._getSegmentedButton() ]
 			}).addStyleClass("sapMVSDBar");
 		}
@@ -1657,7 +1673,7 @@ function(
 			i                   = 0;
 
 		if (this._segmentedButton === undefined) {
-			this._segmentedButton = new sap.m.SegmentedButton({
+			this._segmentedButton = new SegmentedButton({
 				select : function(oEvent) {
 					var selectedId = oEvent.getParameter('id');
 					if (selectedId === that.getId() + "-sortbutton") {
@@ -1695,7 +1711,7 @@ function(
 	 */
 	ViewSettingsDialog.prototype._getSortButton = function() {
 		if (this._sortButton === undefined) {
-			this._sortButton = new sap.m.Button(this.getId() + "-sortbutton", {
+			this._sortButton = new Button(this.getId() + "-sortbutton", {
 				icon : IconPool.getIconURI("sort"),
 				tooltip : this._rb.getText("VIEWSETTINGS_TITLE_SORT")
 			});
@@ -1710,7 +1726,7 @@ function(
 	 */
 	ViewSettingsDialog.prototype._getGroupButton = function() {
 		if (this._groupButton === undefined) {
-			this._groupButton = new sap.m.Button(this.getId() + "-groupbutton", {
+			this._groupButton = new Button(this.getId() + "-groupbutton", {
 				icon : IconPool.getIconURI("group-2"),
 				tooltip : this._rb.getText("VIEWSETTINGS_TITLE_GROUP")
 			});
@@ -1725,7 +1741,7 @@ function(
 	 */
 	ViewSettingsDialog.prototype._getFilterButton = function() {
 		if (this._filterButton === undefined) {
-			this._filterButton = new sap.m.Button(this.getId() + "-filterbutton", {
+			this._filterButton = new Button(this.getId() + "-filterbutton", {
 				icon : IconPool.getIconURI("filter"),
 				tooltip : this._rb.getText("VIEWSETTINGS_TITLE_FILTER")
 			});
@@ -1741,7 +1757,7 @@ function(
 	 */
 	ViewSettingsDialog.prototype._getPage1 = function(bSuppressCreation) {
 		if (this._page1 === undefined && !bSuppressCreation) {
-			this._page1 = new sap.m.Page(this.getId() + '-page1', {
+			this._page1 = new Page(this.getId() + '-page1', {
 				title           : this._rb.getText("VIEWSETTINGS_TITLE"),
 				customHeader    : this._getHeader()
 			});
@@ -1761,23 +1777,23 @@ function(
 
 		if (this._page2 === undefined) {
 			// init internal page content
-			oBackButton = new sap.m.Button(this.getId() + "-backbutton", {
+			oBackButton = new Button(this.getId() + "-backbutton", {
 				icon : IconPool.getIconURI("nav-back"),
 				press : [this._pressBackButton, this]
 			});
-			oDetailResetButton = new sap.m.Button(this.getId()
+			oDetailResetButton = new Button(this.getId()
 			+ "-detailresetbutton", {
 				press : function() {
 					that._onClearFilters();
 				},
 				text : this._rb.getText("VIEWSETTINGS_RESET")
 			});
-			oDetailHeader = new sap.m.Bar({
+			oDetailHeader = new Bar({
 				contentLeft     : [ oBackButton ],
 				contentMiddle   : [ this._getDetailTitleLabel() ],
 				contentRight    : [ oDetailResetButton ]
 			}).addStyleClass("sapMVSDBar");
-			this._page2 = new sap.m.Page(this.getId() + '-page2', {
+			this._page2 = new Page(this.getId() + '-page2', {
 				title           : this._rb.getText("VIEWSETTINGS_TITLE_FILTERBY"),
 				customHeader    : oDetailHeader
 			});
@@ -1954,7 +1970,7 @@ function(
 
 			if (!this._oGroupingNoneItem || this._oGroupingNoneItem.bIsDestroyed) {
 				bHasSelections = !!this.getSelectedGroupItem();
-				this._oGroupingNoneItem = new sap.m.ViewSettingsItem({
+				this._oGroupingNoneItem = new ViewSettingsItem({
 					text: this._rb.getText("VIEWSETTINGS_NONE_ITEM"),
 					selected: !bHasSelections,
 					/**
@@ -2185,7 +2201,7 @@ function(
 		if (oButton) {
 			return oButton;
 		} else {
-			return new sap.m.Button({
+			return new Button({
 				id      : sButtonId,
 				icon    : oCustomTab.getIcon(),
 				tooltip : oCustomTab.getTooltip()

--- a/src/sap.m/src/sap/m/WizardProgressNavigator.js
+++ b/src/sap.m/src/sap/m/WizardProgressNavigator.js
@@ -10,6 +10,7 @@ sap.ui.define([
 	"sap/ui/Device",
 	"sap/m/ActionSheet",
 	"./WizardProgressNavigatorRenderer",
+	"./Button",
 	"sap/ui/thirdparty/jquery"
 ],
 function(
@@ -20,6 +21,7 @@ function(
 	Device,
 	ActionSheet,
 	WizardProgressNavigatorRenderer,
+  Button,
 	jQuery
 ) {
 	"use strict";
@@ -637,7 +639,7 @@ function(
 			icon = this.getStepIcons()[i];
 			title = this._cachedSteps[i].childNodes[0].getAttribute("title");
 
-			this._actionSheet.addButton(new sap.m.Button({
+			this._actionSheet.addButton(new Button({
 				width: "200px",
 				text: title,
 				icon: icon,


### PR DESCRIPTION
When building a "standalone" build using the beautiful new ui5-tooling its pretty important that every  required module/class is in fact mentioned in the dependents `sap.ui.require`-call because thats where the tooling looks for the classes/files it needs to pack. While playing around with this stuff I found that there are a lot of cases where the current UI5 version still does not meet this requirement. 

The intend of this PR is to supply a changeset that improves the situation. It does not solve it. Using a quick grep as a measure, this PR removes about 40% of the cases where a new instance of a class is instantiated via `new sap.a.b.Class` instead of `new Class` & adding `sap/a/b/Class` to the dependency list. I stared with sap.m, as that is where most of the Controls we are using live, and skipped a few big offenders like `sap.m.FacetFilters` with 22 occurences of `new sap.m.`. 

I did run the eslint lints but wasn't able to get the `grunt test` suite running even on master so…
> Beware of bugs in the above code; I have only [guessed it's] correct, not tried it.

