### PR TITLE
[INTERNAL] Fix typo from "oData" to "OData"

### DIFF
--- a/src/sap.ui.core/src/sap/ui/model/odata/ODataAnnotations.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/ODataAnnotations.js
@@ -22,7 +22,7 @@ sap.ui.define([
 	 * @param {sap.ui.model.odata.ODataMetadata} oMetadata
 	 * @param {object} mParams
 	 *
-	 * @class Implementation to access oData Annotations
+	 * @class Implementation to access OData Annotations
 	 *
 	 * @author SAP SE
 	 * @version

--- a/src/sap.ui.core/src/sap/ui/model/odata/ODataListBinding.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/ODataListBinding.js
@@ -38,7 +38,7 @@ sap.ui.define([
 
 	/**
 	 * @class
-	 * List binding implementation for oData format.
+	 * List binding implementation for OData format.
 	 *
 	 * @param {sap.ui.model.odata.ODataModel} oModel Model that this list binding belongs to
 	 * @param {string} sPath Path into the model data, relative to the given <code>oContext</code>

--- a/src/sap.ui.core/src/sap/ui/model/odata/ODataMetadata.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/ODataMetadata.js
@@ -31,7 +31,7 @@ sap.ui.define([
 	 * @param {string} [mParams.cacheKey] (optional) A valid cache key
 	 *
 	 * @class
-	 * Implementation to access oData metadata
+	 * Implementation to access OData metadata
 	 *
 	 * @author SAP SE
 	 * @version ${version}

--- a/src/sap.ui.core/src/sap/ui/model/odata/ODataModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/ODataModel.js
@@ -86,7 +86,7 @@ sap.ui.define([
 	 * @param {boolean} [mParameters.skipMetadataAnnotationParsing] Whether to skip the automated loading of annotations from the metadata document. Loading annotations from metadata does not have any effects (except the lost performance by invoking the parser) if there are not annotations inside the metadata document
 	 *
 	 * @class
-	 * Model implementation for oData format
+	 * Model implementation for OData format
 	 *
 	 *
 	 * @author SAP SE

--- a/src/sap.ui.core/src/sap/ui/model/odata/ODataPropertyBinding.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/ODataPropertyBinding.js
@@ -17,7 +17,7 @@ sap.ui.define([
 	/**
 	 *
 	 * @class
-	 * Property binding implementation for oData format
+	 * Property binding implementation for OData format
 	 *
 	 * @param {sap.ui.model.Model} oModel
 	 * @param {string} sPath

--- a/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataListBinding.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataListBinding.js
@@ -48,7 +48,7 @@ sap.ui.define([
 
 	/**
 	 * @class
-	 * List binding implementation for oData format.
+	 * List binding implementation for OData format.
 	 *
 	 * @param {sap.ui.model.odata.v2.ODataModel} oModel Model that this list binding belongs to
 	 * @param {string} sPath Path into the model data, relative to the given <code>oContext</code>

--- a/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
@@ -158,7 +158,7 @@ sap.ui.define([
 	 *            Set this array to make custom response headers bindable via the entity's "__metadata/headers" property
 	 * @param {boolean} [mParameters.canonicalRequests=false]
 	 *            When setting this flag to <code>true</code> the model tries to calculate a canonical url to the data.
-	 * @param {boolean} [mParameters.tokenHandlingForGet=false] Send CSRF token for GET requests in case read access logging is activated for the oData Service in the backend.
+	 * @param {boolean} [mParameters.tokenHandlingForGet=false] Send CSRF token for GET requests in case read access logging is activated for the OData service in the backend.
 	 * @class
 	 * Model implementation based on the OData protocol.
 	 *


### PR DESCRIPTION
Respecting proper capitalization of the name of the standard; "OData" instead of "oData".
This change applies to publicly documented modules only.