### PR TITLE
[FEATURE] Adding custom footer feature to dialog

### DIFF
--- a/src/sap.m/src/sap/m/Dialog.js
+++ b/src/sap.m/src/sap/m/Dialog.js
@@ -1444,7 +1444,7 @@ function(
 					buttons = this.getButtons();
 
 				if (customFooter) {
-					this._footer = customFooter;                                                      
+					this._footer = customFooter;
 				} else if (beginButton || endButton || buttons.length) {
 					this._footer = new AssociativeOverflowToolbar(this.getId() + "-footer");
 					this.setAggregation("_toolbar", this._oToolbar);

--- a/src/sap.m/src/sap/m/Dialog.js
+++ b/src/sap.m/src/sap/m/Dialog.js
@@ -1437,15 +1437,15 @@ function(
 
 		Dialog.prototype._getAnyFooter = function() {
 
-			if(!this._footer) {
+			if (!this._footer) {
 				var customFooter = this.getCustomFooter(),
 					beginButton = this.getBeginButton(),
 					endButton = this.getEndButton(),
 					buttons = this.getButtons();
 
-				if(customFooter) {
+				if (customFooter) {
 					this._footer = customFooter;                                                      
-				} else if(beginButton || endButton || buttons.length) {
+				} else if (beginButton || endButton || buttons.length) {
 					this._footer = new AssociativeOverflowToolbar(this.getId() + "-footer");
 					this.setAggregation("_toolbar", this._oToolbar);
 					this._createToolbarButtons();

--- a/src/sap.m/src/sap/m/Dialog.js
+++ b/src/sap.m/src/sap/m/Dialog.js
@@ -262,6 +262,8 @@ function(
 					 */
 					customHeader: {type: "sap.m.IBar", multiple: false},
 
+					customFooter: {type: "sap.m.IBar", multiple: false},
+
 					/**
 					 * The button which is rendered to the left side (right side in RTL mode) of the <code>endButton</code> in the footer area inside the Dialog. As of version 1.21.1, there's a new aggregation <code>buttons</code> created with which more than 2 buttons can be added to the footer area of the Dialog. If the new <code>buttons</code> aggregation is set, any change made to this aggregation has no effect anymore. When running on a phone, this <code>button</code> (and the <code>endButton</code> together when set) is (are) rendered at the center of the footer area. When running on other platforms, this <code>button</code> (and the <code>endButton</code> together when set) is (are) rendered at the right side (left side in RTL mode) of the footer area.
 					 * @since 1.15.1
@@ -498,8 +500,6 @@ function(
 					vertical: this.getVerticalScrolling()
 				});
 			}
-
-			this._createToolbarButtons();
 
 			if (sap.ui.getCore().getConfiguration().getAccessibility() && this.getState() != ValueState.None) {
 				var oValueState = new InvisibleText({text: this.getValueStateString(this.getState())});
@@ -1395,7 +1395,7 @@ function(
 		};
 
 		Dialog.prototype._createToolbarButtons = function () {
-			var toolbar = this._getToolbar();
+			var toolbar = this._getAnyFooter();
 			var buttons = this.getButtons();
 			var beginButton = this.getBeginButton();
 			var endButton = this.getEndButton(),
@@ -1435,19 +1435,24 @@ function(
 			}
 		};
 
-		/*
-		 *
-		 * @returns {*|sap.m.IBar|null}
-		 * @private
-		 */
-		Dialog.prototype._getToolbar = function () {
-			if (!this._oToolbar) {
-				this._oToolbar = new AssociativeOverflowToolbar(this.getId() + "-footer").addStyleClass("sapMTBNoBorders");
+		Dialog.prototype._getAnyFooter = function() {
 
-				this.setAggregation("_toolbar", this._oToolbar);
+			if(!this._footer) {
+				var customFooter = this.getCustomFooter(),
+					beginButton = this.getBeginButton(),
+					endButton = this.getEndButton(),
+					buttons = this.getButtons();
+
+				if(customFooter) {
+					this._footer = customFooter;                                                      
+				} else if(beginButton || endButton || buttons.length) {
+					this._footer = new AssociativeOverflowToolbar(this.getId() + "-footer");
+					this.setAggregation("_toolbar", this._oToolbar);
+					this._createToolbarButtons();
+				}
 			}
 
-			return this._oToolbar;
+			return this._footer;
 		};
 
 		/**

--- a/src/sap.m/src/sap/m/DialogRenderer.js
+++ b/src/sap.m/src/sap/m/DialogRenderer.js
@@ -41,8 +41,6 @@ sap.ui.define(["sap/m/library", "sap/ui/Device", "sap/ui/core/library"],
 				oHeader = oControl._getAnyHeader(),
 				oSubHeader = oControl.getSubHeader(),
 				bMessage = (sType === DialogType.Message),
-				oLeftButton = oControl.getBeginButton(),
-				oRightButton = oControl.getEndButton(),
 				bHorizontalScrolling = oControl.getHorizontalScrolling(),
 				bVerticalScrolling = oControl.getVerticalScrolling(),
 				sState = oControl.getState(),
@@ -50,7 +48,8 @@ sap.ui.define(["sap/m/library", "sap/ui/Device", "sap/ui/core/library"],
 				bStretchOnPhone = oControl.getStretchOnPhone() && Device.system.phone,
 				bResizable = oControl.getResizable(),
 				bDraggable = oControl.getDraggable(),
-				oValueStateText = oControl.getAggregation("_valueState");
+				oValueStateText = oControl.getAggregation("_valueState"),
+				oFooter = oControl._getAnyFooter();
 
 			// write the HTML into the render manager
 			// the initial size of the dialog have to be 0, because if there is a large dialog content the initial size can be larger than the html's height (scroller)
@@ -83,10 +82,7 @@ sap.ui.define(["sap/m/library", "sap/ui/Device", "sap/ui/core/library"],
 
 			oRm.addClass(DialogRenderer._mStateClasses[sState]);
 
-			// No Footer
-			var noToolbarAndNobuttons = !oControl._oToolbar && !oLeftButton && !oRightButton;
-			var emptyToolbarAndNoButtons = oControl._oToolbar && oControl._isToolbarEmpty() && !oLeftButton && !oRightButton;
-			if (noToolbarAndNobuttons || emptyToolbarAndNoButtons) {
+			if (!oFooter) {
 				oRm.addClass("sapMDialog-NoFooter");
 			}
 
@@ -209,13 +205,13 @@ sap.ui.define(["sap/m/library", "sap/ui/Device", "sap/ui/core/library"],
 			oRm.write("</div>");
 			oRm.write("</section>");
 
-			if (!(noToolbarAndNobuttons || emptyToolbarAndNoButtons)) {
+			if (oFooter) {
 				oRm.write("<footer");
 				oRm.addClass("sapMDialogFooter");
 				oRm.writeClasses();
 				oRm.write(">");
-				oControl._oToolbar._applyContextClassFor("footer");
-				oRm.renderControl(oControl._oToolbar);
+				oFooter._applyContextClassFor("footer");
+				oRm.renderControl(oFooter);
 				oRm.write("</footer>");
 			}
 

--- a/src/sap.m/src/sap/m/themes/base/Dialog.less
+++ b/src/sap.m/src/sap/m/themes/base/Dialog.less
@@ -282,6 +282,10 @@ html.sap-desktop .sapMDialog {
 	font-size: 1rem;
 }
 
+.sapMDialog > .sapMDialogFooter > .sapMTBStandard {
+	&:extend(.sapMTB.sapMTBNoBorders all);
+}
+
 .sapMDialog:not(.sapMDialogWithSubHeader) .sapMDialogSubHeader {
 	display: none;
 }

--- a/src/sap.m/test/sap/m/Dialog.html
+++ b/src/sap.m/test/sap/m/Dialog.html
@@ -872,6 +872,54 @@
 				}
 			});
 
+			var oDialogCustomFooter = new sap.m.Dialog({
+				title: "This Dialog has a custom footer",
+				resizable: true,
+				draggable: true,
+				content: [
+					new sap.ui.core.HTML({
+						content: '<h2>Incoming Request</h2>'
+					})
+				],
+				customFooter: new sap.m.OverflowToolbar({
+					content: [
+						new sap.m.Button({
+							text: "Accept",
+							type: "Accept",
+							press: closeCustomFooter
+						}),
+						new sap.m.Button({
+							text: "Reject",
+							type: "Reject",
+							press: closeCustomFooter
+						}),
+						new sap.m.Button({
+							text: "Ignore",
+							type: "Emphasized",
+							press: closeCustomFooter
+						}),
+						new sap.m.Button({
+							text: "Disabled",
+							enabled: false,
+							press: closeCustomFooter
+						}),
+						new sap.m.ToolbarSpacer(),
+						new sap.m.Button({
+							text: "Info",
+							press: closeCustomFooter
+						}),
+						new sap.m.Button({
+							text: "Cancel",
+							press: closeCustomFooter
+						})
+					]
+				})
+			});
+
+			function closeCustomFooter(oEvent) {
+				oDialogCustomFooter.close();
+			}
+
 			//=================================================================
 			// Real use cases
 			//=================================================================
@@ -1598,6 +1646,14 @@
 						text: "Escape Handler",
 						press: function () {
 							oEscapePreventDialog.open();
+						}
+					}),
+					new sap.ui.core.HTML({content: "<br>"}),
+					new sap.m.Button({
+						text: "Custom Footer",
+						width: _buttonWidth,
+						press: function () {
+							oDialogCustomFooter.open();
 						}
 					}),
 					new sap.m.Label({text: "Starting on"}).addStyleClass("specialLabelDialogPage"),


### PR DESCRIPTION
This adds custom footer support to Dialog. When the `customFooter` aggregation is set the dialog will ignore the `beginButton`, `endButton`, and `buttons` aggregations and render the contents of customFooter.

I also added a demo/test in testsuite. 

This closes #2012 .