### PR TITLE
[FIX] Icon Explorer: typo "templateSharable"

### DIFF
--- a/src/sap.m/test/sap/m/demokit/iconExplorer/webapp/controller/Overview.controller.js
+++ b/src/sap.m/test/sap/m/demokit/iconExplorer/webapp/controller/Overview.controller.js
@@ -740,7 +740,7 @@ sap.ui.define([
 				path: sGroupPath + "/icons",
 				length: this.getModel("view").getProperty("/growingThreshold"),
 				template: this.byId("results").getBindingInfo(this._sAggregationName).template.clone(),
-				templateSharable: true,
+				templateShareable: true,
 				events: {
 					change: this.onUpdateFinished.bind(this)
 				},


### PR DESCRIPTION
An "e" was missing in "templateSharable".
It should be "templateShareable".