### PR TITLE
[FIX] Demo Kit: move templateShareable to binding info

### DIFF
--- a/src/sap.ui.documentation/src/sap/ui/documentation/sdk/view/DemoApps.view.xml
+++ b/src/sap.ui.documentation/src/sap/ui/documentation/sdk/view/DemoApps.view.xml
@@ -103,9 +103,11 @@
 							</Toolbar>
 						</headerToolbar>
 						<l:BlockLayout
-							content="{rows}"
-							background="Light"
-							templateShareable="false">
+							content="{
+								 path: 'rows',
+								 templateShareable: false
+							}"
+							background="Light">
 							<l:BlockLayoutRow content="{
 								path: '',
 								factory: '.createDemoAppCell'


### PR DESCRIPTION
"templateShareable" was improperly set as a control property which caused error logs when visiting /#/demoapps.
Now it's set properly as a property of the aggregation binding info.