### PR TITLE
[Internal] fix remaining "oData" typo in JSDoc

### DIFF
--- a/src/sap.ui.core/src/sap/ui/model/odata/ODataAnnotations.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/ODataAnnotations.js
@@ -22,7 +22,7 @@ sap.ui.define([
 	 * @param {sap.ui.model.odata.ODataMetadata} oMetadata
 	 * @param {object} mParams
 	 *
-	 * @class Implementation to access oData Annotations
+	 * @class Implementation to access OData annotations
 	 *
 	 * @author SAP SE
 	 * @version


### PR DESCRIPTION
The capitalization fix in https://github.com/SAP/openui5/pull/2474/files#diff-394cb81c2ea0f62a1baab2c4a7d09b62 was not applied in https://github.com/SAP/openui5/commit/6b76572d404186ddf3c9004dd861648f7b905bce.