### PR TITLE
[INTERNAL] sap.ui.unified.ColorPickerPopover: emphasize primary action

### DIFF
--- a/src/sap.ui.unified/src/sap/ui/unified/ColorPickerPopover.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/ColorPickerPopover.js
@@ -31,6 +31,9 @@ sap.ui.define([
 		var ColorPickerMode = library.ColorPickerMode,
 			ColorPickerDisplayMode = library.ColorPickerDisplayMode;
 
+		// shortcut for sap.m.ButtonType
+		var ButtonType = mLibrary.ButtonType;
+
 		/**
 		 *
 		 * Constructor for a new <code>ColorPickerPopover</code>.
@@ -241,6 +244,7 @@ sap.ui.define([
 				showCloseButton: false,
 				beginButton: new Button({
 					text: oLibraryResourceBundle.getText("COLOR_PICKER_SUBMIT"),
+					type: ButtonType.Emphasized,
 					press: function () {
 						that.fireChange(that._oLastChangeCPParams);
 						oPopover.close();


### PR DESCRIPTION
Primary action button (in this case, the "Submit" button) should be emphasized according to Fiori Design Guidelines.
Fixes: https://github.com/SAP/openui5/issues/2254