### PR TITLE
[INTERNAL][FIX] Typo in Wizard sample

### DIFF
--- a/src/sap.m/test/sap/m/demokit/sample/Wizard/view/ReviewPage.fragment.xml
+++ b/src/sap.m/test/sap/m/demokit/sample/Wizard/view/ReviewPage.fragment.xml
@@ -49,10 +49,10 @@
 						<Label text="Availability"/>
 						<Text id="AvailabilityChosen" text="{/availabilityType}"/>
 						<Label text="Size"/>
-						<Hbox>
+						<HBox>
 							<Text id="Size" text="{/size}"/>
 							<Text id="Size2" class="sapUiTinyMarginBegin" text="{/measurement}"/>
-						</Hbox>
+						</HBox>
 						<Link press="editStepThree" text="Edit" />
 					</form:content>
 				</form:SimpleForm>


### PR DESCRIPTION
`<Hbox>...</Hbox>` caused a 404 error which broke the sample to be displayed in the Demo Kit.

Fixes: https://github.com/SAP/openui5/issues/2717