### PR TITLE
[INTERNAL][FIX] sap.ui.layout.VerticalLayoutRenderer: added missing API version

### DIFF
--- a/src/sap.ui.layout/src/sap/ui/layout/VerticalLayoutRenderer.js
+++ b/src/sap.ui.layout/src/sap/ui/layout/VerticalLayoutRenderer.js
@@ -13,6 +13,7 @@ sap.ui.define([],
 	 * @namespace
 	 */
 	var VerticalLayoutRenderer = {
+		apiVersion: 2
 	};
 
 	/**


### PR DESCRIPTION
Semantic rendering requires `apiVersion: 2` in the renderer object which was missing from the last commit https://github.com/SAP/openui5/commit/ea82dfd5d36f64220ae0c89a1625e5010c78fef0.