### PR TITLE
JSDoc sap.m.InputRenderer, TableRenderer, TextAreaRenderer

### DIFF
--- a/src/sap.m/src/sap/m/InputRenderer.js
+++ b/src/sap.m/src/sap/m/InputRenderer.js
@@ -14,8 +14,6 @@ sap.ui.define(['sap/ui/core/InvisibleText', 'sap/ui/core/Renderer', './InputBase
 	/**
 	 * Input renderer.
 	 * @namespace
-	 *
-	 * InputRenderer extends the InputBaseRenderer
 	 */
 	var InputRenderer = Renderer.extend(InputBaseRenderer);
 	InputRenderer.apiVersion = 2;

--- a/src/sap.m/src/sap/m/TableRenderer.js
+++ b/src/sap.m/src/sap/m/TableRenderer.js
@@ -14,8 +14,6 @@ sap.ui.define(["sap/ui/core/Renderer", "sap/ui/core/Core", "./library", "./ListB
 	/**
 	 * Table renderer.
 	 * @namespace
-	 *
-	 * TableRenderer extends the ListBaseRenderer
 	 */
 	var TableRenderer = Renderer.extend(ListBaseRenderer);
 	TableRenderer.apiVersion = 2;

--- a/src/sap.m/src/sap/m/TextAreaRenderer.js
+++ b/src/sap.m/src/sap/m/TextAreaRenderer.js
@@ -23,14 +23,7 @@ sap.ui.define([
 	var TextAreaRenderer = {
 		apiVersion: 2
 	};
-
-
-	/**
-	 * Input renderer.
-	 * @namespace
-	 *
-	 * TextAreaRenderer extends the TextAreaRenderer
-	 */
+	
 	TextAreaRenderer = Renderer.extend(InputBaseRenderer);
 
 	// Adds control specific class


### PR DESCRIPTION
The JSDoc parser seems to get very confused about the existance of the text strings after the tags.

```
  {
    "id": "InputRenderer extends the InputBaseRenderer",
    "longname": "InputRenderer extends the InputBaseRenderer",
    "name": "InputRenderer extends the InputBaseRenderer",
    "kind": "namespace",
    "scope": "global",
    "description": "Input renderer.",
    "meta": {
      "lineno": 16,
      "filename": "InputRenderer.js",
    },
    "order": 1858
  },
  {
    "id": "TableRenderer extends the ListBaseRenderer",
    "longname": "TableRenderer extends the ListBaseRenderer",
    "name": "TableRenderer extends the ListBaseRenderer",
    "kind": "namespace",
    "scope": "global",
    "description": "Table renderer.",
    "meta": {
      "lineno": 16,
      "filename": "TableRenderer.js",
    },
    "order": 5932
  },
  {
    "id": "TextAreaRenderer extends the TextAreaRenderer",
    "longname": "TextAreaRenderer extends the TextAreaRenderer",
    "name": "TextAreaRenderer extends the TextAreaRenderer",
    "kind": "namespace",
    "scope": "global",
    "description": "Input renderer.",
    "meta": {
      "lineno": 29,
      "filename": "TextAreaRenderer.js",
    },
    "order": 6179
  },
```

Basically it gets interpreted as the id, name and longname.

This PR just removes the text strings so it's working similar to the other Renderer.js in that area.
A proper solution would most likely be to @id them.

Also, the comment on the TextAreaRenderer was confused aswell - apparently it extends itself (it doesn't) and the comment block is in twice.

Would you prefer general fix for this (properly define the Renderer classes as described in the documentation example)?