### PR TITLE
[INTERNAL][FIX] sap.ui.core.BusyIndicator sample

### DIFF
--- a/src/sap.ui.core/test/sap/ui/core/demokit/sample/BusyIndicator/Page.controller.js
+++ b/src/sap.ui.core/test/sap/ui/core/demokit/sample/BusyIndicator/Page.controller.js
@@ -1,4 +1,4 @@
-sap.ui.define(['sap/ui/core/Busyindicator', 'sap/ui/core/mvc/Controller'],
+sap.ui.define(['sap/ui/core/BusyIndicator', 'sap/ui/core/mvc/Controller'],
 	function(BusyIndicator, Controller) {
 	"use strict";
 


### PR DESCRIPTION
The sample was failing to load due to a typo in the controller definition.

Fixes: https://github.com/SAP/openui5/issues/2786