### PR TITLE
[INTERNAL][FIX] ObjectPageLayout: test page typos

### DIFF
--- a/src/sap.uxap/test/sap/uxap/FullscreenObjectPageWithTable.html
+++ b/src/sap.uxap/test/sap/uxap/FullscreenObjectPageWithTable.html
@@ -82,7 +82,7 @@
 <body id="body" class="sapUiBody">
 <script>
     sap.ui.define([
-                "jQuery.sap.global",
+                "jquery.sap.global",
                 "sap/m/App",
                 "sap/m/Page"
             ],

--- a/src/sap.uxap/test/sap/uxap/ObjectPageWithTable.html
+++ b/src/sap.uxap/test/sap/uxap/ObjectPageWithTable.html
@@ -144,7 +144,7 @@
 <body id="body" class="sapUiBody">
 <script>
     sap.ui.define([
-            "jQuery.sap.global",
+            "jquery.sap.global",
             "sap/m/App",
             "sap/m/Page"
         ],


### PR DESCRIPTION
Fixed `"jQuery.sap.global"` to `"jquery.sap.global"` when requiring them.

Due to the typo, https://openui5nightly.hana.ondemand.com/test-resources/sap/uxap/ObjectPageWithTable.html was not executable.