### PR TITLE
Bugfix: Take resourceBundleAlias from oView

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/mvc/XMLView.js
+++ b/src/sap.ui.core/src/sap/ui/core/mvc/XMLView.js
@@ -305,7 +305,7 @@ sap.ui.define([
 				// if ResourceBundle was created with async flag vBundle will be a Promise
 				if (vBundle instanceof Promise) {
 					return vBundle.then(function() {
-						oView.setModel(oModel, mSettings.resourceBundleAlias);
+						oView.setModel(oModel, oView._resourceBundleAlias);
 					});
 				}
 				oView.setModel(oModel, oView._resourceBundleAlias);


### PR DESCRIPTION
resourceBundleAlias is not part of mSettings, see XMLTemplateProcessor.parseViewAttributes