### PR TITLE
[FIX] sap.m.SuggestionsPopover: Improve highlightSuggestionItems performance ~300%

### DIFF
--- a/src/sap.m/src/sap/m/SuggestionsPopover.js
+++ b/src/sap.m/src/sap/m/SuggestionsPopover.js
@@ -1017,8 +1017,14 @@ sap.ui.define([
 			return;
 		}
 
+		var highlightedTexts = [];
+
 		for (i = 0; i < aItemsDomRef.length; i++) {
-			aItemsDomRef[i].innerHTML = this._createHighlightedText(aItemsDomRef[i], sInputValue, bWordMode);
+			highlightedTexts.push(this._createHighlightedText(aItemsDomRef[i], sInputValue, bWordMode));
+		}
+
+		for (i = 0; i < aItemsDomRef.length; i++) {
+			aItemsDomRef[i].innerHTML = highlightedTexts[i];
 		}
 	};
 


### PR DESCRIPTION
The function is very slow due to non-grouped multiple commits to the DOM. Just creating the highlighted texts first and then changing the DOM does the job.

Original:
- highlightSuggestionItems 466.6ms
- Painting 3.5ms

![image](https://user-images.githubusercontent.com/443888/78858615-4faec100-7a70-11ea-8398-6ba1a2cd6f77.png)

![image](https://user-images.githubusercontent.com/443888/78858627-5b01ec80-7a70-11ea-8cf3-a6bc2b036653.png)


Proposed:
- highlightSuggestionItems 157.9ms
- Painting 1.9ms

![image](https://user-images.githubusercontent.com/443888/78858638-65bc8180-7a70-11ea-8ecb-ea1fea679ece.png)

![image](https://user-images.githubusercontent.com/443888/78858645-69500880-7a70-11ea-8386-b586b6f74623.png)


Tested on: https://github.com/SAP/openui5/blob/master/src/sap.m/test/sap/m/MultiComboBox.html

![image](https://user-images.githubusercontent.com/443888/78858843-ebd8c800-7a70-11ea-8a95-9de5494cb7cb.png)
