### PR TITLE
[FIX] sap.m.SuggestionsPopover: Improve highlightSuggestionItems performance ~300%

### DIFF
--- a/src/sap.m/src/sap/m/SuggestionsPopover.js
+++ b/src/sap.m/src/sap/m/SuggestionsPopover.js
@@ -949,7 +949,7 @@ sap.ui.define([
 	 */
 	SuggestionsPopover.prototype._createHighlightedText = function (oItemDomRef, sInputValue, bWordMode) {
 		var sDomRefLowerText, iStartHighlightingIndex, iInputLength, iNextSpaceIndex, sChunk,
-			sText = oItemDomRef ? oItemDomRef.innerText : "",
+			sText = oItemDomRef ? oItemDomRef.textContent : "",
 			sFormattedText = "";
 
 		if (!SuggestionsPopover._wordStartsWithValue(sText, sInputValue)) {

--- a/src/sap.m/src/sap/m/SuggestionsPopover.js
+++ b/src/sap.m/src/sap/m/SuggestionsPopover.js
@@ -1017,8 +1017,14 @@ sap.ui.define([
 			return;
 		}
 
+		var highlightedTexts = [];
+
 		for (i = 0; i < aItemsDomRef.length; i++) {
-			aItemsDomRef[i].innerHTML = this._createHighlightedText(aItemsDomRef[i], sInputValue, bWordMode);
+			highlightedTexts.push(this._createHighlightedText(aItemsDomRef[i], sInputValue, bWordMode));
+		}
+
+		for (i = 0; i < aItemsDomRef.length; i++) {
+			aItemsDomRef[i].innerHTML = highlightedTexts[i];
 		}
 	};
 


### PR DESCRIPTION
The function is very slow due to non-grouped multiple commits to the DOM. Just creating the highlighted texts first and then changing the DOM does the job.

Original:

highlightSuggestionItems 466.6ms
Painting 3.5ms
![image](https://user-images.githubusercontent.com/443888/79540446-87021b00-80cb-11ea-8050-6ca22fcfae05.png)

![image](https://user-images.githubusercontent.com/443888/79540464-8e292900-80cb-11ea-8f9c-c58022443942.png)


Proposed:

highlightSuggestionItems 157.9ms
Painting 1.9ms
![image](https://user-images.githubusercontent.com/443888/79540478-95e8cd80-80cb-11ea-9c5e-fb1ccda43403.png)


![image](https://user-images.githubusercontent.com/443888/79540491-9b461800-80cb-11ea-8d65-b5462bd31969.png)


Tested on: https://github.com/SAP/openui5/blob/master/src/sap.m/test/sap/m/MultiComboBox.html

![image](https://user-images.githubusercontent.com/443888/79540503-a00acc00-80cb-11ea-9e3c-a849aa1f671a.png)
