### PR TITLE
[INTERNAL] ComponentContainer: JSDoc link fix

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/ComponentContainer.js
+++ b/src/sap.ui.core/src/sap/ui/core/ComponentContainer.js
@@ -56,7 +56,7 @@ sap.ui.define([
 	 *     />
 	 * </pre>
 	 *
-	 * See also {@link sap.ui.core.ComponentSupport}.
+	 * See also {@link module:sap/ui/core/ComponentSupport}.
 	 *
 	 * @extends sap.ui.core.Control
 	 * @version ${version}


### PR DESCRIPTION
Previously, the link was pointing to <code>https://<em>&lt;demokithost></em>/api/sap.ui.core.ComponentSupport</code> which doesn't exist.

Fixes: https://github.com/SAP/openui5/issues/2908