### PR TITLE
[INTERNAL][FIX] Demo Kit: missing `}` added in settings dialog fragment

### DIFF
--- a/src/sap.ui.documentation/src/sap/ui/documentation/sdk/view/appSettingsDialog.fragment.xml
+++ b/src/sap.ui.documentation/src/sap/ui/documentation/sdk/view/appSettingsDialog.fragment.xml
@@ -25,7 +25,7 @@
 						<core:Item text="Compact" key="compact"/>
 						<core:Item text="Condensed" key="condensed"/>
 					</Select>
-					<Link text="{i18n>APP_SETTINGS_DIALOG_READ_MORE" href="topic/e54f729da8e3405fae5e4fe8ae7784c1" target="_blank" class="sapUiTinyMarginTop"/>
+					<Link text="{i18n>APP_SETTINGS_DIALOG_READ_MORE}" href="topic/e54f729da8e3405fae5e4fe8ae7784c1" target="_blank" class="sapUiTinyMarginTop"/>
 
 					<HBox class="sapUiTinyMarginTop" alignItems="Center" justifyContent="SpaceBetween">
 						<Label text="{i18n>APP_SETTINGS_DIALOG_RTL}" design="Standard" labelFor="RTLSwitch" />


### PR DESCRIPTION
The Demo Kit Samples page was failing to open the settings dialog due to a missing brace in the i18n text binding definition.
The browser then reported the following:
> Uncaught SyntaxError: no closing braces found in '{i18n>APP_SETTINGS_DIALOG_READ_MORE' after pos:0

Added `}` accordingly.