### PR TITLE
[FIX][INTERNAL] sap.m.Popover: Stabilize _onOrientationChange method

### DIFF
--- a/src/sap.m/src/sap/m/Popover.js
+++ b/src/sap.m/src/sap/m/Popover.js
@@ -965,8 +965,8 @@ sap.ui.define([
 		};
 
 		Popover.prototype._onOrientationChange = function () {
-			var ePopupState = this.oPopup.getOpenState();
-			if (!(ePopupState === OpenState.OPEN || ePopupState === OpenState.OPENING)) {
+			var ePopupState = (this.oPopup && this.oPopup.getOpenState()) || {};
+			if (ePopupState !== OpenState.OPEN && ePopupState !== OpenState.OPENING) {
 				return;
 			}
 


### PR DESCRIPTION
There is a fix from v1.75. Please correct me if I am wrong about the correction process.
-------------------------------------------------------
There might be some race conditions where the Popover gets destroyed and the orientation to change.
So, we should ensure that if there's no popover, this method would be skipped.

Change-Id: Id4cc8e7e4f967c543483af1db737ba316a1cbfc3
BCP: 2080040422