### PR TITLE
fix: Never use unload event on modern browsers

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/Component.js
+++ b/src/sap.ui.core/src/sap/ui/core/Component.js
@@ -666,7 +666,8 @@ sap.ui.define([
 		if (this.onWindowUnload) {
 
 			this._fnWindowUnloadHandler = this.onWindowUnload.bind(this);
-			window.addEventListener("unload", this._fnWindowUnloadHandler);
+			var terminationEvent = "onpagehide" in window ? "pagehide" : "unload";
+			window.addEventListener(terminationEvent, this._fnWindowUnloadHandler);
 		}
 
 	};
@@ -700,7 +701,8 @@ sap.ui.define([
 			delete this._fnWindowBeforeUnloadHandler;
 		}
 		if (this._fnWindowUnloadHandler) {
-			window.removeEventListener("unload", this._fnWindowUnloadHandler);
+			var terminationEvent = "onpagehide" in window ? "pagehide" : "unload";
+			window.removeEventListener(terminationEvent, this._fnWindowUnloadHandler);
 			delete this._fnWindowUnloadHandler;
 		}
 

--- a/src/sap.ui.core/src/sap/ui/core/ResizeHandler.js
+++ b/src/sap.ui.core/src/sap/ui/core/ResizeHandler.js
@@ -52,7 +52,8 @@ sap.ui.define([
 
 			this.fDestroyHandler = this.destroy.bind(this);
 
-			jQuery(window).on("unload", this.fDestroyHandler);
+			var terminationEvent = "onpagehide" in window ? "pagehide" : "unload";
+			jQuery(window).on(terminationEvent, this.fDestroyHandler);
 
 			ActivityDetection.attachActivate(initListener, this);
 		}
@@ -82,7 +83,8 @@ sap.ui.define([
 	 */
 	ResizeHandler.prototype.destroy = function(oEvent) {
 		ActivityDetection.detachActivate(initListener, this);
-		jQuery(window).off("unload", this.fDestroyHandler);
+		var terminationEvent = "onpagehide" in window ? "pagehide" : "unload";
+		jQuery(window).off(terminationEvent, this.fDestroyHandler);
 		oCoreRef = null;
 		this.aResizeListeners = [];
 		this.aSuspendedDomRefs = [];

--- a/src/sap.ui.core/src/sap/ui/core/support/Support.js
+++ b/src/sap.ui.core/src/sap/ui/core/support/Support.js
@@ -73,7 +73,8 @@ sap.ui.define(['sap/ui/base/EventProvider', './Plugin', 'sap/ui/Device', "sap/ba
 				case mTypes.TOOL:
 					this._oRemoteWindow = window.opener;
 					this._sRemoteOrigin = UriParameters.fromQuery(window.location.search).get("sap-ui-xx-support-origin");
-					jQuery(window).on("unload", function(oEvent){
+					var terminationEvent = "onpagehide" in window ? "pagehide" : "unload";
+					jQuery(window).on(terminationEvent, function(oEvent){
 						that.sendEvent(mEvents.TEAR_DOWN);
 						Support.exitPlugins(that, true);
 					});

--- a/src/sap.ui.core/src/sap/ui/debug/DebugEnv.js
+++ b/src/sap.ui.core/src/sap/ui/debug/DebugEnv.js
@@ -164,7 +164,8 @@ sap.ui.define('sap/ui/debug/DebugEnv', ['sap/ui/base/Interface', './ControlTree'
 			this.oControlTree.renderDelayed();
 		}
 
-		window.addEventListener("unload", function(oEvent) {
+		var terminationEvent = "onpagehide" in window ? "pagehide" : "unload";
+		window.addEventListener(terminationEvent, function(oEvent) {
 			this.oControlTree.exit();
 			this.oPropertyList.exit();
 		}.bind(this));

--- a/src/sap.ui.core/test/sap/ui/core/qunit/component/Component.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/component/Component.qunit.js
@@ -1963,7 +1963,8 @@ sap.ui.define([
 		this.oComponent = new MyOnWindowUnloadComponent();
 
 		assert.equal(typeof this.oComponent._fnWindowUnloadHandler, "function", "Handler has been created");
-		sinon.assert.calledWithExactly(this.addEventListenerSpy, "unload", this.oComponent._fnWindowUnloadHandler);
+		var terminationEvent = "onpagehide" in window ? "pagehide" : "unload";
+		sinon.assert.calledWithExactly(this.addEventListenerSpy, terminationEvent, this.oComponent._fnWindowUnloadHandler);
 		assert.equal(this.addEventListenerSpy.getCall(0).thisValue, window, "addEventListener has been called on the window object");
 
 		var oFakeEvent = {};
@@ -1977,7 +1978,7 @@ sap.ui.define([
 		this.oComponent.destroy();
 
 		assert.equal(this.oComponent._fnWindowUnloadHandler, undefined, "Handler has been removed");
-		sinon.assert.calledWithExactly(this.removeEventListenerSpy, "unload", handler);
+		sinon.assert.calledWithExactly(this.removeEventListenerSpy, terminationEvent, handler);
 		assert.equal(this.removeEventListenerSpy.getCall(0).thisValue, window, "removeEventListener has been called on the window object");
 	});
 


### PR DESCRIPTION
Window unload event is extremely unreliable, it doesn't fire in multiple scenarios, especially in mobiles.
Replacing "unload" by "pagehide" event.

PR for issue https://github.com/SAP/openui5/issues/3085

https://developers.google.com/web/updates/2018/07/page-lifecycle-api?utm_source=lighthouse&utm_medium=devtools#legacy-lifecycle-apis-to-avoid
https://web.dev/bfcache/
https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event