### PR TITLE
[INTERNAL] sap.m.Link: documentation of rel fix

### DIFF
--- a/src/sap.m/src/sap/m/Link.js
+++ b/src/sap.m/src/sap/m/Link.js
@@ -114,9 +114,9 @@ function(
 			target : {type : "string", group : "Behavior", defaultValue : null},
 
 			/**
-			 * Specifies the value of the HTML <code>rel<code> attribute.
+			 * Specifies the value of the HTML <code>rel</code> attribute.
 			 *
-			 * <b>Note:</b> A default value of <code>noopener noreferrer<code> is set only to links that have a cross-origin URL
+			 * <b>Note:</b> A default value of <code>noopener noreferrer</code> is set only to links that have a cross-origin URL
 			 * and a specified <code>target</code> with value other than <code>_self</code>.
 			 * @since 1.84
 			 */


### PR DESCRIPTION
Some `<code>` tags were not properly closed which caused improper formatting in the Demo Kit - API reference (https://openui5.hana.ondemand.com/1.84.1/#/api/sap.m.Link%23controlProperties).

![openui5 hana ondemand com_1 84 1_](https://user-images.githubusercontent.com/12143247/103554971-09c44380-4eb0-11eb-98c6-d119573235ed.png)

This PR fixes the issue above.