### PR TITLE
Fixed: spelling mistake where 'adaptive' was mentioned as 'adative'

### DIFF
--- a/src/sap.f/test/sap/f/adaptivecardvisualtests-manifest.json
+++ b/src/sap.f/test/sap/f/adaptivecardvisualtests-manifest.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-		"id": "adativecard.embedded",
+		"id": "adaptivecard.embedded",
 		"type": "card"
 	},
 	"sap.card": {

--- a/src/sap.f/test/sap/f/cardsdemo/model/cardManifests.json
+++ b/src/sap.f/test/sap/f/cardsdemo/model/cardManifests.json
@@ -1341,7 +1341,7 @@
 		"adaptive1": {
 			"_version": "1.17.0",
 			"sap.app": {
-				"id": "adativecard.embedded",
+				"id": "adaptivecard.embedded",
 				"type": "card"
 			},
 			"sap.card": {
@@ -1468,7 +1468,7 @@
 		"adaptive2": {
 			"_version": "1.17.0",
 			"sap.app": {
-				"id": "adativecard.embedded",
+				"id": "adaptivecard.embedded",
 				"type": "card"
 			},
 			"sap.card": {
@@ -1542,7 +1542,7 @@
 		"adaptive3": {
 			"_version": "1.17.0",
 			"sap.app": {
-				"id": "adativecard.embedded",
+				"id": "adaptivecard.embedded",
 				"type": "card"
 			},
 			"sap.card": {

--- a/src/sap.f/test/sap/f/demokit/sample/GridContainersNavigation/cardManifests.json
+++ b/src/sap.f/test/sap/f/demokit/sample/GridContainersNavigation/cardManifests.json
@@ -59,7 +59,7 @@
 	"adaptiveContent": {
 		"summary": {
 			"sap.app": {
-				"id": "adativecard.embedded",
+				"id": "adaptivecard.embedded",
 				"type": "card"
 			},
 			"sap.card": {

--- a/src/sap.ui.integration/test/sap/ui/integration/adaptivecard-manifest.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/adaptivecard-manifest.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-		"id": "adativecard.embedded",
+		"id": "adaptivecard.embedded",
 		"type": "card"
 	},
 	"sap.card": {

--- a/src/sap.ui.integration/test/sap/ui/integration/adaptivecard-templating-manifest.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/adaptivecard-templating-manifest.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-		"id": "adativecard.embedded",
+		"id": "adaptivecard.embedded",
 		"type": "card"
 	},
 	"sap.card": {

--- a/src/sap.ui.integration/test/sap/ui/integration/adaptivecard-templating-manifest2.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/adaptivecard-templating-manifest2.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-		"id": "adativecard.embedded",
+		"id": "adaptivecard.embedded",
 		"type": "card"
 	},
 	"sap.card": {

--- a/src/sap.ui.integration/test/sap/ui/integration/adaptivecard-templating-manifest3.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/adaptivecard-templating-manifest3.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-		"id": "adativecard.embedded",
+		"id": "adaptivecard.embedded",
 		"type": "card"
 	},
 	"sap.card": {

--- a/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/action-openurl.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/action-openurl.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-		"id": "adativecard.embedded",
+		"id": "adaptivecard.embedded",
 		"type": "card",
 		"title": "Sample of an Adaptive Card with Customized Actions",
 		"subTitle": "Sample of an Adaptive Card with Customized Actions",

--- a/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/action-submit.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/action-submit.json
@@ -1,7 +1,7 @@
 {
   "_version": "1.17.0",
   "sap.app": {
-	"id": "adativecard.embedded",
+	"id": "adaptivecard.embedded",
 	"type": "card",
 	"title": "Sample of an Adaptive Card with Submit Action",
 	"subTitle": "Sample of an Adaptive Card with Submit Action",

--- a/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/adaptive.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/adaptive.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-		"id": "adativecard.embedded",
+		"id": "adaptivecard.embedded",
 		"type": "card",
 		"title": "Sample of an Adaptive Card",
 		"subTitle": "Sample of an Adaptive Card",

--- a/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/data.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/data.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-		"id": "adativecard.embedded",
+		"id": "adaptivecard.embedded",
 		"type": "card",
 		"title": "Sample of an Adaptive Card",
 		"subTitle": "Sample of an Adaptive Card",

--- a/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/form.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/form.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-		"id": "adativecard.embedded",
+		"id": "adaptivecard.embedded",
 		"type": "card",
 		"title": "Sample of an Adaptive Card with Form",
 		"subTitle": "Sample of an Adaptive Card with Form",

--- a/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/markdown.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/markdown.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-		"id": "adativecard.embedded",
+		"id": "adaptivecard.embedded",
 		"type": "card",
 		"title": "Sample of an Adaptive Card with formatted text",
 		"subTitle": "Sample of an Adaptive with formatted text",

--- a/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/richtext.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/richtext.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-		"id": "adativecard.embedded",
+		"id": "adaptivecard.embedded",
 		"type": "card",
 		"title": "Sample of an Adaptive Card with formatted text",
 		"subTitle": "Sample of an Adaptive with formatted text",

--- a/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/templating.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptive/templating.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-		"id": "adativecard.embedded",
+		"id": "adaptivecard.embedded",
 		"type": "card"
 	},
 	"sap.card": {

--- a/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptiveCustomizedActions/CustomizedActionsExtension.js
+++ b/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptiveCustomizedActions/CustomizedActionsExtension.js
@@ -2,7 +2,7 @@ sap.ui.define(["sap/ui/integration/Extension", 'sap/m/MessageToast'
 ], function (Extension, MessageToast) {
 	"use strict";
 
-	var CustomizedActionsExtension = Extension.extend("adativecard.embedded.CustomizedActionsExtension");
+	var CustomizedActionsExtension = Extension.extend("adaptivecard.embedded.CustomizedActionsExtension");
 
 	CustomizedActionsExtension.prototype.init = function () {
 		Extension.prototype.init.apply(this, arguments);

--- a/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptiveCustomizedActions/cardManifest.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/adaptiveCustomizedActions/cardManifest.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-	"id": "adativecard.embedded",
+	"id": "adaptivecard.embedded",
 	"type": "card",
 	"title": "Sample of an Adaptive Card with Customized Actions and Extension",
 	"subTitle": "Sample of an Adaptive Card with Customized Actions and Extension",

--- a/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/hostActions/adaptiveCardManifest.json
+++ b/src/sap.ui.integration/test/sap/ui/integration/demokit/cardExplorer/webapp/samples/hostActions/adaptiveCardManifest.json
@@ -1,7 +1,7 @@
 {
 	"_version": "1.17.0",
 	"sap.app": {
-		"id": "adativecard.embedded",
+		"id": "adaptivecard.embedded",
 		"type": "card",
 		"title": "Sample of an Adaptive Card",
 		"subTitle": "Sample of an Adaptive Card",

--- a/src/sap.ui.integration/test/sap/ui/integration/qunit/util/CardActions.qunit.js
+++ b/src/sap.ui.integration/test/sap/ui/integration/qunit/util/CardActions.qunit.js
@@ -626,7 +626,7 @@ sap.ui.define([
 		var oManifestActionSubmit = {
 			"_version": "1.8.0",
 			"sap.app": {
-				"id": "adativecard.embedded",
+				"id": "adaptivecard.embedded",
 				"type": "card"
 			},
 			"sap.card": {


### PR DESCRIPTION
Hey there,

when trying out some integrations cards I realized that there are quite a few spelling mistakes regarding the word 'adaptive' in a  few tests as well as the samples section on the [Card Explorer](https://ui5.sap.com/test-resources/sap/ui/integration/demokit/cardExplorer/webapp/index.html#/explore/adaptive). 

As I copied sample data I realized, that the path wasn't what I expected it to be `../adative/..`, so I fixed it. Not a big deal or error in general.