### PR TITLE
[FIX] sap.m.MessagePage: increase CSS specificity of main icon

### DIFF
--- a/src/sap.m/src/sap/m/themes/base/MessagePage.less
+++ b/src/sap.m/src/sap/m/themes/base/MessagePage.less
@@ -45,19 +45,13 @@
 /* MessagePage inner controls styles*/
 .sapMMessagePage {
 	.sapMMessagePageInner {
-		.sapUiIcon::before {
+		.sapMMessagePageIcon.sapUiIcon::before {
 			font-size: 6rem;
 			color: @sapUiContentNonInteractiveIconColor;
 		}
 
 		& > .sapMMessagePageContentWrapper > * {
 			max-width: 100%;
-		}
-
-		.sapMBtn {
-			.sapUiIcon::before {
-				font-size: 1rem;
-			}
 		}
 	}
 

--- a/src/sap.m/test/sap/m/MessagePage.html
+++ b/src/sap.m/test/sap/m/MessagePage.html
@@ -43,7 +43,9 @@
 			icon: "sap-icon://warning",
 			buttons: [
 				new sap.m.Button({text: "Change security settings"}),
-				new sap.m.Button({text: "Reload page"})
+				new sap.m.Button({text: "Reload page"}),
+				new sap.m.Button({icon: "sap-icon://sap-ui5", tooltip: "Icon only"}),
+				new sap.m.Button({icon: "sap-icon://sap-ui5", text: "Text with Icon"})
 			],
 			navButtonPress: fnBackToMaster
 		});

--- a/src/themelib_sap_belize/src/sap/m/themes/sap_belize/MessagePage.less
+++ b/src/themelib_sap_belize/src/sap/m/themes/sap_belize/MessagePage.less
@@ -3,6 +3,6 @@
 /* Belize theme                       */
 /* ================================== */
 
-.sapMMessagePage .sapMMessagePageInner .sapUiIcon::before {
+.sapMMessagePage .sapMMessagePageInner .sapMMessagePageIcon.sapUiIcon::before {
 	color: fade(@sapUiContentNonInteractiveIconColor, 50);
 }

--- a/src/themelib_sap_bluecrystal/src/sap/m/themes/sap_bluecrystal/MessagePage.less
+++ b/src/themelib_sap_bluecrystal/src/sap/m/themes/sap_bluecrystal/MessagePage.less
@@ -8,6 +8,6 @@
 	background: fade(@sapUiGroupContentBackground, 70);
 }
 
-.sapMMessagePage .sapMMessagePageInner .sapUiIcon::before {
+.sapMMessagePage .sapMMessagePageInner .sapMMessagePageIcon.sapUiIcon::before {
 	color: fade(@sapUiContentNonInteractiveIconColor, 20);
 }

--- a/src/themelib_sap_fiori_3/src/sap/m/themes/sap_fiori_3/MessagePage.less
+++ b/src/themelib_sap_fiori_3/src/sap/m/themes/sap_fiori_3/MessagePage.less
@@ -6,7 +6,7 @@
 /* MessagePage inner controls styles*/
 .sapMMessagePage {
 	.sapMMessagePageInner {
-		.sapUiIcon::before {
+		.sapMMessagePageIcon.sapUiIcon::before {
 			color: fade(@sapUiContentNonInteractiveIconColor,50);
 		}
 	}

--- a/src/themelib_sap_fiori_3/src/sap/m/themes/sap_fiori_3_dark/MessagePage.less
+++ b/src/themelib_sap_fiori_3/src/sap/m/themes/sap_fiori_3_dark/MessagePage.less
@@ -6,7 +6,7 @@
 /* MessagePage inner controls styles*/
 .sapMMessagePage {
 	.sapMMessagePageInner {
-		.sapUiIcon::before {
+		.sapMMessagePageIcon.sapUiIcon::before {
 			color: fade(@sapUiContentNonInteractiveIconColor,50);
 		}
 	}

--- a/src/themelib_sap_fiori_3/src/sap/m/themes/sap_fiori_3_hcb/MessagePage.less
+++ b/src/themelib_sap_fiori_3/src/sap/m/themes/sap_fiori_3_hcb/MessagePage.less
@@ -6,7 +6,7 @@
 /* MessagePage inner controls styles*/
 .sapMMessagePage {
 	.sapMMessagePageInner {
-		.sapUiIcon::before {
+		.sapMMessagePageIcon.sapUiIcon::before {
 			color: fade(@sapUiContentNonInteractiveIconColor,50);
 		}
 	}

--- a/src/themelib_sap_fiori_3/src/sap/m/themes/sap_fiori_3_hcw/MessagePage.less
+++ b/src/themelib_sap_fiori_3/src/sap/m/themes/sap_fiori_3_hcw/MessagePage.less
@@ -6,7 +6,7 @@
 /* MessagePage inner controls styles*/
 .sapMMessagePage {
 	.sapMMessagePageInner {
-		.sapUiIcon::before {
+		.sapMMessagePageIcon.sapUiIcon::before {
 			color: fade(@sapUiContentNonInteractiveIconColor,50);
 		}
 	}


### PR DESCRIPTION
- Due to the low specificity for MessagePage's main icon, the `font-size` of all icons within the page was set to `6rem` which affected even the icons within inserted buttons.
- Increased specificity by prepending `.sapMMessagePageIcon` to the generic `.sapUiIcon`.

Below are screenshots (in `sap_fiori_3_dark`) of _before and after_ the fix:


## Before
![localhost_8080_test-resources_sap_m_MessagePage html_sap-ui-debug=true sap-ui-language=en-US sap-ui-accessibility=true sap-ui-theme=sap_fiori_3_dark](https://user-images.githubusercontent.com/12143247/106942737-d7af3700-6724-11eb-85b7-44be18e5c9ce.png)

## After
![localhost_8080_test-resources_sap_m_MessagePage html_sap-ui-debug=true sap-ui-language=en-US sap-ui-accessibility=true sap-ui-theme=sap_fiori_3_dark (1)](https://user-images.githubusercontent.com/12143247/106942769-dd0c8180-6724-11eb-9dce-0a3ea9cbf59a.png)


Fixes: https://github.com/SAP/openui5/issues/3145