### PR TITLE
FIX issue with parenthesis parsing in ODATA filters

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/util/MockServer.js
+++ b/src/sap.ui.core/src/sap/ui/core/util/MockServer.js
@@ -562,12 +562,12 @@ sap.ui
 			 */
 			MockServer.prototype._getBracketIndices = function(sString) {
 				var aStack = [];
-				var bReserved = false;
+				var iReserved = 0;
 				var iStartIndex, iEndIndex = 0;
 				for (var character = 0; character < sString.length; character++) {
 					if (sString[character] === '(') {
 						if (/[substringof|endswith|startswith]$/.test(sString.substring(0, character))) {
-							bReserved = true;
+							++iReserved;
 						} else {
 							aStack.push(sString[character]);
 							if (iStartIndex === undefined) {
@@ -575,7 +575,7 @@ sap.ui
 							}
 						}
 					} else if (sString[character] === ')') {
-						if (!bReserved) {
+						if (!iReserved) {
 							aStack.pop();
 							iEndIndex = character;
 							if (aStack.length === 0) {
@@ -585,7 +585,7 @@ sap.ui
 								};
 							}
 						} else {
-							bReserved = false;
+							--iReserved;
 						}
 					}
 				}

--- a/src/sap.ui.core/test/sap/ui/core/qunit/mockserver/MockServer.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/mockserver/MockServer.qunit.js
@@ -4619,4 +4619,44 @@ sap.ui.define([
 		return oModel;
 	}
 
+	var getBracketIndices = MockServer.prototype._getBracketIndices;
+	[{
+		string: "MeetupID eq 'P'",
+		start: undefined,
+		end: 0
+	}, {
+		string: "(MeetupID eq 'P')",
+		start: 0,
+		end: 16
+	}, {
+		string: "MeetupID eq 'P' or (Title eq 'P')",
+		start: 19,
+		end: 32
+	}, {
+		string: "substringof('P',MeetupID)",
+		start: undefined,
+		end: 0
+	}, {
+		string: "substringof('P',toupper(MeetupID))",
+		start: undefined,
+		end: 0
+	}, {
+		string: "(substringof('P',toupper(MeetupID)) or substringof('P',toupper(Title)))",
+		start: 0,
+		end: 70
+	}, {
+		string: "substringof('P',toupper(MeetupID)) or substringof('P',toupper(Title))",
+		start: undefined,
+		end: 0
+	}, {
+		string: "substringof('P',toupper(MeetupID)) or (substringof('P',toupper(Title)))",
+		start: 38,
+		end: 70
+	}].forEach(function (oScenario) {
+		QUnit.test("Parenthesis wrapping in filters: " + oScenario.string, function (assert) {
+			var oResult = getBracketIndices(oScenario.string);
+			assert.strictEqual(oResult.start, oScenario.start, "start");
+			assert.strictEqual(oResult.end, oScenario.end, "end");
+		});
+	});
 });


### PR DESCRIPTION
The MockServer suffers from a parsing issue that treats improperly parenthesis *wrapping* the filter.
To put it short, the method MockServer.prototype._getBracketIndices fails on the following string : "substringof('P',toupper(MeetupID)) or substringof('P',toupper(Title)))". A quick code analysis revealed that when it reach the parenthesis of toupper, it considers it as a parenthesis for susbstringof and the closing parenthesis are improperly counted (because of the flag bReserved that should be a counter rather than a boolean).

This change proposes a quick fix to better handle the parenthesis.