### PR TITLE
[FIX] CustomStyleClassSupport  IE11 issue with undefined root dom

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/CustomStyleClassSupport.js
+++ b/src/sap.ui.core/src/sap/ui/core/CustomStyleClassSupport.js
@@ -146,7 +146,7 @@ sap.ui.define(['./Element', "sap/base/assert", "sap/base/Log", "sap/ui/Device"],
 			}
 
 			var oRoot = this.getDomRef();
-			if (oRoot) { // non-rerendering shortcut
+			if (oRoot && oRoot.classList) { // non-rerendering shortcut
 				if ( aClasses ) {
 					addAll.apply(oRoot.classList, aClasses);
 				} else {
@@ -206,7 +206,7 @@ sap.ui.define(['./Element', "sap/base/assert", "sap/base/Log", "sap/ui/Device"],
 
 			if (bExist) {
 				var oRoot = this.getDomRef();
-				if (oRoot) { // non-rerendering shortcut
+				if (oRoot && oRoot.classList) { // non-rerendering shortcut
 					if ( aClasses ) {
 						removeAll.apply(oRoot.classList, aClasses);
 					} else {


### PR DESCRIPTION
Sometimes under IE11, it will return an empty ```oRoot``` object from ```this.getDomRef()```, this will cause issues to reference the ```classList``` with ```oRoot```.