### PR TITLE
[FIX] sap.m.HeaderContainer is rendered once

### DIFF
--- a/src/sap.m/src/sap/m/HeaderContainer.js
+++ b/src/sap.m/src/sap/m/HeaderContainer.js
@@ -340,6 +340,9 @@ sap.ui.define([
 		};
 
 		HeaderContainer.prototype.onBeforeRendering = function () {
+			var isHorizontal = this.getOrientation() === Orientation.Horizontal,
+				sIconPrev = isHorizontal ? "sap-icon://slim-arrow-left" : "sap-icon://slim-arrow-up",
+				sIconNext = isHorizontal ? "sap-icon://slim-arrow-right" : "sap-icon://slim-arrow-down";
 			if (!this.getHeight()) {
 				Log.warning("No height provided", this);
 			}
@@ -347,11 +350,11 @@ sap.ui.define([
 				Log.warning("No width provided", this);
 			}
 			if (Device.system.desktop) {
-				this._oArrowPrev.setIcon(this.getOrientation() === Orientation.Horizontal ? "sap-icon://slim-arrow-left" : "sap-icon://slim-arrow-up");
-				this._oArrowNext.setIcon(this.getOrientation() === Orientation.Horizontal ? "sap-icon://slim-arrow-right" : "sap-icon://slim-arrow-down");
+				this._oArrowPrev.setProperty("icon", sIconPrev, true);
+				this._oArrowNext.setProperty("icon", sIconNext, true);
 			} else if (Device.system.phone || Device.system.tablet) {
-				this._oArrowPrev.setSrc(this.getOrientation() === Orientation.Horizontal ? "sap-icon://slim-arrow-left" : "sap-icon://slim-arrow-up");
-				this._oArrowNext.setSrc(this.getOrientation() === Orientation.Horizontal ? "sap-icon://slim-arrow-right" : "sap-icon://slim-arrow-down");
+				this._oArrowPrev.setProperty("src", sIconPrev, true);
+				this._oArrowNext.setProperty("src", sIconNext, true);
 			}
 		};
 

--- a/src/sap.m/test/sap/m/qunit/HeaderContainer.qunit.js
+++ b/src/sap.m/test/sap/m/qunit/HeaderContainer.qunit.js
@@ -162,6 +162,19 @@ sap.ui.define([
 		assert.equal(sRole, "list", "scrollContainer role is of type list");
 	});
 
+	QUnit.test("onAfterRendering is triggered only once after initial rendering", function (assert) {
+		//Arrange
+		var oHeaderContainer = new HeaderContainer();
+		var oSpy = sinon.spy(oHeaderContainer, "onAfterRendering");
+		//Act
+		oHeaderContainer.placeAt("qunit-fixture");
+		sap.ui.getCore().applyChanges();
+		//Assert
+		assert.strictEqual(oSpy.callCount, 1, "HeaderContainer was rendered only once");
+		//Cleanup
+		oHeaderContainer.destroy();
+	});
+
 	QUnit.module("Background design", {
 		beforeEach: function () {
 			this.oHeaderContainer = new HeaderContainer("headerContainer");


### PR DESCRIPTION
Before this change, the `onAfterRendering` of `sap.m.HeaderContainer` was triggered twice due to invalidating the control within `onBeforeRendering` caused by calling generated mutators of its aggregations.

Now it is triggered only once by still manipulating the arrow icons but suppressing consequent invalidation.

Fixes: https://github.com/SAP/openui5/issues/3250