### PR TITLE
[INTERNAL][FIX] API Reference: Metadata modules can be displayed

### DIFF
--- a/src/sap.ui.documentation/src/sap/ui/documentation/sdk/controller/ApiDetail.controller.js
+++ b/src/sap.ui.documentation/src/sap/ui/documentation/sdk/controller/ApiDetail.controller.js
@@ -691,7 +691,7 @@ sap.ui.define([
 						if (oBaseClass) {
 							baseClassCache = oBaseClass["ui5-metadata"] || [];
 
-							if (!oControlData["ui5-metadata"].defaultAggregation && baseClassCache.defaultAggregation) {
+							if (oControlData["ui5-metadata"] && !oControlData["ui5-metadata"].defaultAggregation && baseClassCache.defaultAggregation) {
 								oControlData["ui5-metadata"].defaultAggregation = baseClassCache.defaultAggregation;
 							}
 


### PR DESCRIPTION
Some modules are Metadata themselves. The control might have no `ui5-metadata` object.
Fixes: https://github.com/SAP/openui5/issues/3254