### PR TITLE
[INTERNAL][FIX] sap.ui.core.IndicationColor: `@since` added

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/library.js
+++ b/src/sap.ui.core/src/sap/ui/core/library.js
@@ -1243,18 +1243,21 @@ sap.ui.define([
 		/**
 		 * Indication Color 6
 		 * @public
+		 * @since 1.75
 		 */
 		Indication06 : "Indication06",
 
 		/**
 		 * Indication Color 7
 		 * @public
+		 * @since 1.75
 		 */
 		Indication07 : "Indication07",
 
 		/**
 		 * Indication Color 8
 		 * @public
+		 * @since 1.75
 		 */
 		Indication08 : "Indication08"
 	};


### PR DESCRIPTION
The enum `sap.ui.core.IndicationColor` was enhanced with `06`, `07`, and `08` in v1.75 (https://github.com/SAP/openui5/commit/c2f98a4b369f005356ca76d89c80398b48ed827f).

Added missing `@since` information.