### PR TITLE
Use height and width from component config if available

### DIFF
--- a/src/sap.ui.core/src/sap/ui/test/launchers/componentLauncher.js
+++ b/src/sap.ui.core/src/sap/ui/test/launchers/componentLauncher.js
@@ -44,11 +44,11 @@ sap.ui.define([
 				jQueryDOM("body").append(_$Component).addClass("sapUiOpaBodyComponent");
 
 				// create and place the component into html
-				_oComponentContainer = new ComponentContainer({
-					component: oComponent,
-					height: "100%",
-					width: "100%"
-				});
+                		_oComponentContainer = new ComponentContainer({
+                    			component: oComponent,
+                    			height: mComponentConfig.height ? mComponentConfig.height : "100%",
+                   			width: mComponentConfig.width ? mComponentConfig.width : "100%"
+                		});
 
 				_oComponentContainer.placeAt(sId);
 			});


### PR DESCRIPTION
Hello,

Here is an easy fix that solves many of our issues when testing using OPA.
An earlier fix tried to improve the current status. Which was better, when a component is able to properly compute its size.
When this is not possible, then you can define a height and width, as you would do for a frame test (same exact config).

Could you backport this fix into UI5 1.74 LTS ? We cannot upgrade to a cloud version.