### PR TITLE
[FIX] sap.ui.model.odata: add request header "X-Requested-With"

### DIFF
--- a/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
@@ -485,6 +485,10 @@ sap.ui.define([
 				this.oHeaders["MaxDataServiceVersion"] = this.sMaxDataServiceVersion;
 			}
 
+			// indicate these requests are originating from an AJAX request
+			// with this header present @sap/approuter responds with a 401 on a GET request
+			this.oHeaders["X-Requested-With"] = "XMLHttpRequest";
+
 		},
 		metadata : {
 			publicMethods : ["read", "create", "update", "remove", "submitChanges", "getServiceMetadata", "metadataLoaded",

--- a/src/sap.ui.core/src/sap/ui/model/odata/v4/lib/_Requestor.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/v4/lib/_Requestor.js
@@ -113,7 +113,8 @@ sap.ui.define([
 		"Accept" : "application/json;odata.metadata=minimal;IEEE754Compatible=true",
 		"OData-MaxVersion" : "4.0",
 		"OData-Version" : "4.0",
-		"X-CSRF-Token" : "Fetch"
+		"X-CSRF-Token" : "Fetch",
+		"X-Requested-With" : "XMLHttpRequest"
 	};
 
 	/**

--- a/src/sap.ui.core/src/sap/ui/model/odata/v4/lib/_V2Requestor.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/v4/lib/_V2Requestor.js
@@ -58,7 +58,8 @@ sap.ui.define([
 		"Accept" : "application/json",
 		"MaxDataServiceVersion" : "2.0",
 		"DataServiceVersion" : "2.0",
-		"X-CSRF-Token" : "Fetch"
+		"X-CSRF-Token" : "Fetch",
+		"X-Requested-With" : "XMLHttpRequest"
 	};
 
 	/**

--- a/src/sap.ui.core/test/sap/ui/core/qunit/odata/v2/ODataModel.integration.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/odata/v2/ODataModel.integration.qunit.js
@@ -844,6 +844,7 @@ sap.ui.define([
 				delete mHeaders["MaxDataServiceVersion"];
 				delete mHeaders["sap-cancel-on-close"];
 				delete mHeaders["sap-contextid-accept"];
+				delete mHeaders["X-Requested-With"];
 				delete oActualRequest["_handle"];
 				delete oActualRequest["adjustDeepPath"];
 				delete oActualRequest["async"];

--- a/src/sap.ui.core/test/sap/ui/core/qunit/odata/v2/ODataModelNoFakeService.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/odata/v2/ODataModelNoFakeService.qunit.js
@@ -108,6 +108,14 @@ sap.ui.define([
 
 		assert.strictEqual(oModel.mCodeListModelParams, "~codeListModelParameters");
 		assert.strictEqual(oModel.sMetadataUrl, "~metadataUrl");
+		assert.deepEqual(oModel.oHeaders, {
+			"Accept": "application/json",
+			"Accept-Language": sap.ui.getCore().getConfiguration().getLanguageTag(),
+			"DataServiceVersion": "2.0",
+			"MaxDataServiceVersion": "2.0",
+			"sap-contextid-accept": "header",
+			"X-Requested-With": "XMLHttpRequest"
+		});
 	});
 
 	//*********************************************************************************************

--- a/src/sap.ui.core/test/sap/ui/core/qunit/odata/v4/lib/_Requestor.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/odata/v4/lib/_Requestor.qunit.js
@@ -237,7 +237,8 @@ sap.ui.define([
 			"Accept" : "application/json;odata.metadata=minimal;IEEE754Compatible=true",
 			"OData-MaxVersion" : "4.0",
 			"OData-Version" : "4.0",
-			"X-CSRF-Token" : "Fetch"
+			"X-CSRF-Token" : "Fetch",
+			"X-Requested-With": "XMLHttpRequest"
 		}
 	}, {
 		sODataVersion : "2.0",
@@ -251,7 +252,8 @@ sap.ui.define([
 			"Accept" : "application/json",
 			"MaxDataServiceVersion" : "2.0",
 			"DataServiceVersion" : "2.0",
-			"X-CSRF-Token" : "Fetch"
+			"X-CSRF-Token" : "Fetch",
+			"X-Requested-With": "XMLHttpRequest"
 		}
 	}].forEach(function (oFixture) {
 		var sTest = "factory function: check members for OData version = " + oFixture.sODataVersion;

--- a/src/sap.ui.core/test/sap/ui/core/qunit/odata/v4/lib/_V2Requestor.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/odata/v4/lib/_V2Requestor.qunit.js
@@ -46,7 +46,8 @@ sap.ui.define([
 			"Accept" : "foo",
 			"MaxDataServiceVersion" : "foo",
 			"DataServiceVersion" : "foo",
-			"X-CSRF-Token" : "foo"
+			"X-CSRF-Token" : "foo",
+			"X-Requested-With": "foo"
 		}
 	}].forEach(function (oRequestor) {
 		QUnit.test("check headers (V2): ", function (assert) {
@@ -63,7 +64,8 @@ sap.ui.define([
 				"Accept" : "application/json",
 				"MaxDataServiceVersion" : "2.0",
 				"DataServiceVersion" : "2.0",
-				"X-CSRF-Token" : "Fetch"
+				"X-CSRF-Token" : "Fetch",
+				"X-Requested-With": "XMLHttpRequest"
 			});
 		});
 	});


### PR DESCRIPTION
In case the session has timed out and a new GET request comes in, the @sap/approuter component responds with status 200 and HTML content to store session and redirect the browser. By indicating the request originates from an AJAX call, the @sap/approuter is informed that it should return a 401 in case the session has timed out.