### PR TITLE
[Fix] sap.m.BlockLayoutCellRenderer: tag names must be lower case

### DIFF
--- a/src/sap.ui.layout/src/sap/ui/layout/BlockLayoutCellRenderer.js
+++ b/src/sap.ui.layout/src/sap/ui/layout/BlockLayoutCellRenderer.js
@@ -82,7 +82,7 @@ sap.ui.define(['./library', 'sap/ui/core/library', "sap/base/Log"],
 
 				var level = blockLayoutCell.getTitleLevel(),
 					autoLevel = level === TitleLevel.Auto,
-					tag = autoLevel ? "h2" : level;
+					tag = autoLevel ? "h2" : level.toLowerCase();
 
 				var aTitleClassesSeparated = titleClass.split(" ");
 


### PR DESCRIPTION
 - RM.openStart expects tag names to be lower-case
 similar to https://github.com/SAP/openui5/commit/cc23bb01d249e49d585e8661f3164bffa4e956d8