### PR TITLE
Replace jQuery $().toggleClass by vanilla js classList.toggle in sap.f library

### DIFF
--- a/src/sap.f/src/sap/f/DynamicPage.js
+++ b/src/sap.f/src/sap/f/DynamicPage.js
@@ -699,22 +699,15 @@ sap.ui.define([
 		bUseAnimations = sAnimationMode !== Configuration.AnimationMode.none && sAnimationMode !== Configuration.AnimationMode.minimal;
 
 		if (exists(this.$contentFitContainer)) {
-			if (this.getDomRef()) {
-				var oContentFitContainer = this.getDomRef().querySelector("[id$='contentFitContainer']");
-				if (oContentFitContainer) {
-					oContentFitContainer.classList.toggle("sapFDynamicPageContentFitContainerFooterVisible", bShow);
-				}
-			}
+			this.getDomRef("contentFitContainer").classList.toggle("sapFDynamicPageContentFitContainerFooterVisible", bShow);
 		}
 
 		if (bUseAnimations) {
 			this._toggleFooterAnimation(bShow, oFooter);
 		} else {
-			if (this.getDomRef()) {
-				var oFooterWrapper = this.getDomRef().querySelector("[id$='footerWrapper']");
-				if (oFooterWrapper) {
-					oFooterWrapper.classList.toggle("sapUiHidden", !bShow);
-				}
+			var oFooterWrapper = this.getDomRef("footerWrapper");
+			if (oFooterWrapper) {
+				oFooterWrapper.classList.toggle("sapUiHidden", !bShow);
 			}
 		}
 
@@ -901,13 +894,11 @@ sap.ui.define([
 	 * @private
 	 */
 	DynamicPage.prototype._toggleHeaderBackground = function (bShow) {
-		if (this.getDomRef()) {
-			var oHeaderInContentWrapper = this.getDomRef().querySelector("[id$='headerWrapper']");
-			if (oHeaderInContentWrapper) {
-				oHeaderInContentWrapper.classList.toggle("sapFDynamicPageHeaderSolid", bShow);
-			}
+		var oHeaderInContentWrapper = this.getDomRef("headerWrapper");
+		if (oHeaderInContentWrapper) {
+			oHeaderInContentWrapper.classList.toggle("sapFDynamicPageHeaderSolid", bShow);
 		}
-};
+	};
 
 	/**
 	 * Appends header to content area.
@@ -1439,11 +1430,9 @@ sap.ui.define([
 			bFitContent = this.getFitContent(),
 			bToggleClass = bFitContent || bNoScrollBar;
 
-		if (this.getDomRef()) {
-			var oContentFitContainer = this.getDomRef().querySelector("[id$='contentFitContainer']");
-			if (oContentFitContainer) {
-				oContentFitContainer.classList.toggle("sapFDynamicPageContentFitContainer", bToggleClass);
-			}
+		var oContentFitContainer = this.getDomRef("contentFitContainer");
+		if (oContentFitContainer) {
+			oContentFitContainer.classList.toggle("sapFDynamicPageContentFitContainer", bToggleClass);
 		}
 	};
 

--- a/src/sap.f/src/sap/f/DynamicPage.js
+++ b/src/sap.f/src/sap/f/DynamicPage.js
@@ -699,13 +699,23 @@ sap.ui.define([
 		bUseAnimations = sAnimationMode !== Configuration.AnimationMode.none && sAnimationMode !== Configuration.AnimationMode.minimal;
 
 		if (exists(this.$contentFitContainer)) {
-			this.$contentFitContainer.toggleClass("sapFDynamicPageContentFitContainerFooterVisible", bShow);
+			if (this.getDomRef()) {
+				var oContentFitContainer = this.getDomRef().querySelector("[id$='contentFitContainer']");
+				if (oContentFitContainer) {
+					oContentFitContainer.classList.toggle("sapFDynamicPageContentFitContainerFooterVisible", bShow);
+				}
+			}
 		}
 
 		if (bUseAnimations) {
 			this._toggleFooterAnimation(bShow, oFooter);
 		} else {
-			this.$footerWrapper.toggleClass("sapUiHidden", !bShow);
+			if (this.getDomRef()) {
+				var oFooterWrapper = this.getDomRef().querySelector("[id$='footerWrapper']");
+				if (oFooterWrapper) {
+					oFooterWrapper.classList.toggle("sapUiHidden", !bShow);
+				}
+			}
 		}
 
 		this._updateScrollBar();
@@ -874,7 +884,7 @@ sap.ui.define([
 		}
 
 		if (exists(oDynamicPageHeader)) {
-			oDynamicPageHeader.$().toggleClass("sapFDynamicPageHeaderHidden", !bShow);
+			oDynamicPageHeader.getDomRef().classList.toggle("sapFDynamicPageHeaderHidden", !bShow);
 			this._updateScrollBar();
 		}
 	};
@@ -891,8 +901,13 @@ sap.ui.define([
 	 * @private
 	 */
 	DynamicPage.prototype._toggleHeaderBackground = function (bShow) {
-		this.$headerInContentWrapper.toggleClass("sapFDynamicPageHeaderSolid", bShow);
-	};
+		if (this.getDomRef()) {
+			var oHeaderInContentWrapper = this.getDomRef().querySelector("[id$='headerWrapper']");
+			if (oHeaderInContentWrapper) {
+				oHeaderInContentWrapper.classList.toggle("sapFDynamicPageHeaderSolid", bShow);
+			}
+		}
+};
 
 	/**
 	 * Appends header to content area.
@@ -1424,7 +1439,12 @@ sap.ui.define([
 			bFitContent = this.getFitContent(),
 			bToggleClass = bFitContent || bNoScrollBar;
 
-		this.$contentFitContainer.toggleClass("sapFDynamicPageContentFitContainer", bToggleClass);
+		if (this.getDomRef()) {
+			var oContentFitContainer = this.getDomRef().querySelector("[id$='contentFitContainer']");
+			if (oContentFitContainer) {
+				oContentFitContainer.classList.toggle("sapFDynamicPageContentFitContainer", bToggleClass);
+			}
+		}
 	};
 
 	/**
@@ -1620,7 +1640,9 @@ sap.ui.define([
 		var oTitle = this.getTitle(),
 			bTitleActive = this._hasVisibleTitleAndHeader() && this.getToggleHeaderOnTitleClick();
 
-		this.$().toggleClass("sapFDynamicPageTitleClickEnabled", bTitleActive && !Device.system.phone);
+		if (this.getDomRef()) {
+			this.getDomRef().classList.toggle("sapFDynamicPageTitleClickEnabled", bTitleActive && !Device.system.phone);
+		}
 		if (exists(oTitle)) {
 			oTitle._toggleFocusableState(bTitleActive);
 		}

--- a/src/sap.f/src/sap/f/DynamicPageHeader.js
+++ b/src/sap.f/src/sap/f/DynamicPageHeader.js
@@ -158,7 +158,9 @@ sap.ui.define([
 		 * @private
 		 */
 		DynamicPageHeader.prototype._setShowPinBtn = function (bValue) {
-			this._getPinButton().$().toggleClass("sapUiHidden", !bValue);
+			if (this._getPinButton().getDomRef()) {
+				this._getPinButton().getDomRef().classList.toggle("sapUiHidden", !bValue);
+			}
 		};
 
 		/**
@@ -280,7 +282,9 @@ sap.ui.define([
 		 */
 		DynamicPageHeader.prototype._toggleCollapseButton = function (bToggle) {
 			this._setShowCollapseButton(bToggle);
-			this._getCollapseButton().$().toggleClass("sapUiHidden", !bToggle);
+			if (this._getCollapseButton().getDomRef()) {
+				this._getCollapseButton().getDomRef().classList.toggle("sapUiHidden", !bToggle);
+			}
 		};
 
 		/**

--- a/src/sap.f/src/sap/f/DynamicPageTitle.js
+++ b/src/sap.f/src/sap/f/DynamicPageTitle.js
@@ -426,6 +426,7 @@ sap.ui.define([
 	};
 
 	DynamicPageTitle.prototype.onAfterRendering = function () {
+		window.thisXXX = this;
 		this._cacheDomElements();
 		this._attachFocusSpanHandlers();
 		this._toggleState(this._bExpandedState);
@@ -990,11 +991,9 @@ sap.ui.define([
 	 * @private
 	 */
 	DynamicPageTitle.prototype._toggleTopAreaVisibility = function(bShoudShowTopArea) {
-		if (this.getDomRef()) {
-			var oTopArea = this.getDomRef().querySelector("[id$='top']");
-			if (oTopArea) {
-				oTopArea.classList.toggle("sapUiHidden", !bShoudShowTopArea);
-			}
+		var oTopArea = this.getDomRef("top");
+		if (oTopArea) {
+			oTopArea.classList.toggle("sapUiHidden", !bShoudShowTopArea);
 		}
 	};
 
@@ -1092,9 +1091,9 @@ sap.ui.define([
 		}
 
 		if (Device.system.phone && this.getSnappedTitleOnMobile()) {
-			var oSnappedTitleOnMobileWrapper = this.getDomRef().querySelector("[id$='snapped-title-on-mobile-wrapper']");
-			var oTopArea = this.getDomRef().querySelector("[id$='top']");
-			var oMainArea = this.getDomRef().querySelector("[id$='main']");
+			var oSnappedTitleOnMobileWrapper = this.getDomRef("snapped-title-on-mobile-wrapper");
+			var oTopArea = this.getDomRef("top");
+			var oMainArea = this.getDomRef("main");
 			if (oSnappedTitleOnMobileWrapper) {
 				oSnappedTitleOnMobileWrapper.classList.toggle("sapUiHidden", bExpanded);
 			}
@@ -1108,7 +1107,7 @@ sap.ui.define([
 		} else {
 			// Snapped heading
 			if (exists(this.getSnappedHeading())) {
-				var oSnappedHeadingWrapper = this.getDomRef().querySelector("[id$='snapped-heading-wrapper']");
+				var oSnappedHeadingWrapper = this.getDomRef("snapped-heading-wrapper");
 				if (oSnappedHeadingWrapper) {
 					oSnappedHeadingWrapper.classList.toggle("sapUiHidden", bExpanded);
 				}
@@ -1116,7 +1115,7 @@ sap.ui.define([
 
 			// Expanded heading
 			if (exists(this.getExpandedHeading())) {
-				var oExpandHeadingWrapper = this.getDomRef().querySelector("[id$='expand-heading-wrapper']");
+				var oExpandHeadingWrapper = this.getDomRef("expand-heading-wrapper");
 				if (oExpandHeadingWrapper) {
 					oExpandHeadingWrapper.classList.toggle("sapUiHidden", !bExpanded);
 				}
@@ -1130,7 +1129,7 @@ sap.ui.define([
 
 		// Snapped content
 		if (exists(this.getSnappedContent())) {
-			var oSnappedWrapper = this.getDomRef().querySelector("[id$='snapped-wrapper']");
+			var oSnappedWrapper = this.getDomRef("snapped-wrapper");
 			if (oSnappedWrapper) {
 				oSnappedWrapper.classList.toggle("sapUiHidden", bExpanded);
 				oSnappedWrapper.parentNode.classList.toggle("sapFDynamicPageTitleMainSnapContentVisible", !bExpanded);
@@ -1139,7 +1138,7 @@ sap.ui.define([
 
 		// Expanded content
 		if (exists(this.getExpandedContent())) {
-			var oExpandWrapper = this.getDomRef().querySelector("[id$='expand-wrapper']");
+			var oExpandWrapper = this.getDomRef("expand-wrapper");
 			if (oExpandWrapper) {
 				oExpandWrapper.classList.toggle("sapUiHidden", !bExpanded);
 				oExpandWrapper.parentNode.classList.toggle("sapFDynamicPageTitleMainExpandContentVisible", bExpanded);

--- a/src/sap.f/src/sap/f/DynamicPageTitle.js
+++ b/src/sap.f/src/sap/f/DynamicPageTitle.js
@@ -991,7 +991,10 @@ sap.ui.define([
 	 */
 	DynamicPageTitle.prototype._toggleTopAreaVisibility = function(bShoudShowTopArea) {
 		if (this.getDomRef()) {
-			this.$("top").toggleClass("sapUiHidden", !bShoudShowTopArea);
+			var oTopArea = this.getDomRef().querySelector("[id$='top']");
+			if (oTopArea) {
+				oTopArea.classList.toggle("sapUiHidden", !bShoudShowTopArea);
+			}
 		}
 	};
 
@@ -1089,19 +1092,34 @@ sap.ui.define([
 		}
 
 		if (Device.system.phone && this.getSnappedTitleOnMobile()) {
-			this.$snappedTitleOnMobileWrapper.toggleClass("sapUiHidden", bExpanded);
-			this.$topArea.toggleClass("sapUiHidden", !bExpanded);
-			this.$mainArea.toggleClass("sapUiHidden", !bExpanded);
-			this.$().toggleClass("sapContrast", !bExpanded);
+			var oSnappedTitleOnMobileWrapper = this.getDomRef().querySelector("[id$='snapped-title-on-mobile-wrapper']");
+			var oTopArea = this.getDomRef().querySelector("[id$='top']");
+			var oMainArea = this.getDomRef().querySelector("[id$='main']");
+			if (oSnappedTitleOnMobileWrapper) {
+				oSnappedTitleOnMobileWrapper.classList.toggle("sapUiHidden", bExpanded);
+			}
+			if (oTopArea) {
+				oTopArea.classList.toggle("sapUiHidden", !bExpanded);
+			}
+			if (oMainArea) {
+				oMainArea.classList.toggle("sapUiHidden", !bExpanded);
+			}
+			this.getDomRef().classList.toggle("sapContrast", !bExpanded);
 		} else {
 			// Snapped heading
 			if (exists(this.getSnappedHeading())) {
-				this.$snappedHeadingWrapper.toggleClass("sapUiHidden", bExpanded);
+				var oSnappedHeadingWrapper = this.getDomRef().querySelector("[id$='snapped-heading-wrapper']");
+				if (oSnappedHeadingWrapper) {
+					oSnappedHeadingWrapper.classList.toggle("sapUiHidden", bExpanded);
+				}
 			}
 
 			// Expanded heading
 			if (exists(this.getExpandedHeading())) {
-				this.$expandHeadingWrapper.toggleClass("sapUiHidden", !bExpanded);
+				var oExpandHeadingWrapper = this.getDomRef().querySelector("[id$='expand-heading-wrapper']");
+				if (oExpandHeadingWrapper) {
+					oExpandHeadingWrapper.classList.toggle("sapUiHidden", !bExpanded);
+				}
 			}
 
 			if (bUserInteraction && oldExpandedState !== bExpanded) {
@@ -1112,14 +1130,20 @@ sap.ui.define([
 
 		// Snapped content
 		if (exists(this.getSnappedContent())) {
-			this.$snappedWrapper.toggleClass("sapUiHidden", bExpanded);
-			this.$snappedWrapper.parent().toggleClass("sapFDynamicPageTitleMainSnapContentVisible", !bExpanded);
+			var oSnappedWrapper = this.getDomRef().querySelector("[id$='snapped-wrapper']");
+			if (oSnappedWrapper) {
+				oSnappedWrapper.classList.toggle("sapUiHidden", bExpanded);
+				oSnappedWrapper.parentNode.classList.toggle("sapFDynamicPageTitleMainSnapContentVisible", !bExpanded);
+			}
 		}
 
 		// Expanded content
 		if (exists(this.getExpandedContent())) {
-			this.$expandWrapper.toggleClass("sapUiHidden", !bExpanded);
-			this.$expandWrapper.parent().toggleClass("sapFDynamicPageTitleMainExpandContentVisible", bExpanded);
+			var oExpandWrapper = this.getDomRef().querySelector("[id$='expand-wrapper']");
+			if (oExpandWrapper) {
+				oExpandWrapper.classList.toggle("sapUiHidden", !bExpanded);
+				oExpandWrapper.parentNode.classList.toggle("sapFDynamicPageTitleMainExpandContentVisible", bExpanded);
+			}
 		}
 	};
 
@@ -1177,7 +1201,9 @@ sap.ui.define([
 	 */
 	DynamicPageTitle.prototype._toggleExpandButton = function (bToggle) {
 		this._setShowExpandButton(bToggle);
-		this._getExpandButton().$().toggleClass("sapUiHidden", !bToggle);
+		if (this._getExpandButton() && this._getExpandButton().getDomRef()) {
+			this._getExpandButton().getDomRef().classList.toggle("sapUiHidden", !bToggle);
+		}
 	};
 
 	/**

--- a/src/sap.f/src/sap/f/FlexibleColumnLayout.js
+++ b/src/sap.f/src/sap/f/FlexibleColumnLayout.js
@@ -1168,11 +1168,10 @@ sap.ui.define([
 			bInsetMidColumn,
 			bRestoreFocusOnBackNavigation,
 			oPendingAnimationEnd = {};
-		var oDomRef = this.getDomRef();
 		var mColumnsDomRef = {
-			begin: oDomRef ? oDomRef.querySelector("[id$='beginColumn']") : null,
-			mid: oDomRef ? oDomRef.querySelector("[id$='midColumn']") : null,
-			end: oDomRef ? oDomRef.querySelector("[id$='endColumn']") : null
+			begin: this.getDomRef("beginColumn"),
+			mid: this.getDomRef("midColumn"),
+			end: this.getDomRef("endColumn")
 		};
 
 		// Stop here if the control isn't rendered yet
@@ -1356,11 +1355,10 @@ sap.ui.define([
 			bShouldConcealColumn = oOptions.shouldConcealColumn,
 			iNewWidth = oOptions.iNewWidth,
 			bShouldRestoreFocus = oOptions.shouldRestoreFocus;
-		var oDomRef = this.getDomRef();
 		var mColumnsDomRef = {
-			begin: oDomRef ? oDomRef.querySelector("[id$='beginColumn']") : null,
-			mid: oDomRef ? oDomRef.querySelector("[id$='midColumn']") : null,
-			end: oDomRef ? oDomRef.querySelector("[id$='endColumn']") : null
+			begin: this.getDomRef("beginColumn"),
+			mid: this.getDomRef("midColumn"),
+			end: this.getDomRef("endColumn")
 		};
 
 		if (mColumnsDomRef[sColumn]) {

--- a/src/sap.f/src/sap/f/FlexibleColumnLayout.js
+++ b/src/sap.f/src/sap/f/FlexibleColumnLayout.js
@@ -1168,6 +1168,12 @@ sap.ui.define([
 			bInsetMidColumn,
 			bRestoreFocusOnBackNavigation,
 			oPendingAnimationEnd = {};
+		var oDomRef = this.getDomRef();
+		var mColumnsDomRef = {
+			begin: oDomRef ? oDomRef.querySelector("[id$='beginColumn']") : null,
+			mid: oDomRef ? oDomRef.querySelector("[id$='midColumn']") : null,
+			end: oDomRef ? oDomRef.querySelector("[id$='endColumn']") : null
+		};
 
 		// Stop here if the control isn't rendered yet
 		if (!this.isActive()) {
@@ -1198,10 +1204,11 @@ sap.ui.define([
 
 			aColumns.forEach(function (sColumn) {
 				var bShouldConcealColumn = this._shouldConcealColumn(iDefaultVisibleColumnsCount, sColumn),
-					bShouldRevealColumn = this._shouldRevealColumn(iDefaultVisibleColumnsCount, sColumn === sLastVisibleColumn),
-					oColumn = this._$columns[sColumn];
+					bShouldRevealColumn = this._shouldRevealColumn(iDefaultVisibleColumnsCount, sColumn === sLastVisibleColumn);
 
-				oColumn.toggleClass(FlexibleColumnLayout.PINNED_COLUMN_CLASS_NAME, bShouldConcealColumn || bShouldRevealColumn);
+				if (mColumnsDomRef[sColumn]) {
+					mColumnsDomRef[sColumn].classList.toggle(FlexibleColumnLayout.PINNED_COLUMN_CLASS_NAME, bShouldConcealColumn || bShouldRevealColumn);
+				}
 
 			}, this);
 
@@ -1258,10 +1265,14 @@ sap.ui.define([
 
 			if (!bShouldConcealColumn) { // do not remove the active class of the concealed column for now (it should remain visible until the end of animations for other columns)
 				// Add the active class to the column if it shows something
-				oColumn.toggleClass("sapFFCLColumnActive", iPercentWidth > 0);
+				if (mColumnsDomRef[sColumn]) {
+					mColumnsDomRef[sColumn].classList.toggle("sapFFCLColumnActive", iPercentWidth > 0);
+				}
 			}
 
-			oColumn.toggleClass("sapFFCLColumnInset", bInsetMidColumn && (sColumn === "mid"));
+			if (mColumnsDomRef[sColumn]) {
+				mColumnsDomRef[sColumn].classList.toggle("sapFFCLColumnInset", bInsetMidColumn && (sColumn === "mid"));
+			}
 
 			// Remove all the classes that are used for HCB theme borders, they will be set again later
 			oColumn.removeClass("sapFFCLColumnHidden");
@@ -1345,8 +1356,16 @@ sap.ui.define([
 			bShouldConcealColumn = oOptions.shouldConcealColumn,
 			iNewWidth = oOptions.iNewWidth,
 			bShouldRestoreFocus = oOptions.shouldRestoreFocus;
+		var oDomRef = this.getDomRef();
+		var mColumnsDomRef = {
+			begin: oDomRef ? oDomRef.querySelector("[id$='beginColumn']") : null,
+			mid: oDomRef ? oDomRef.querySelector("[id$='midColumn']") : null,
+			end: oDomRef ? oDomRef.querySelector("[id$='endColumn']") : null
+		};
 
-		oColumn.toggleClass(FlexibleColumnLayout.PINNED_COLUMN_CLASS_NAME, false);
+		if (mColumnsDomRef[sColumn]) {
+			mColumnsDomRef[sColumn].classList.toggle(FlexibleColumnLayout.PINNED_COLUMN_CLASS_NAME, false);
+		}
 
 		if (bShouldConcealColumn) {
 			// The column does not show anything anymore, so we can remove the active class
@@ -1354,7 +1373,9 @@ sap.ui.define([
 		}
 
 		//BCP: 1980006195
-		oColumn.toggleClass("sapFFCLColumnHidden", iNewWidth === 0);
+		if (mColumnsDomRef[sColumn]) {
+			mColumnsDomRef[sColumn].classList.toggle("sapFFCLColumnHidden", iNewWidth === 0);
+		}
 
 		this._cacheColumnWidth(sColumn, iNewWidth);
 		if (bShouldRestoreFocus) {

--- a/src/sap.f/src/sap/f/shellBar/ResponsiveHandler.js
+++ b/src/sap.f/src/sap/f/shellBar/ResponsiveHandler.js
@@ -109,9 +109,9 @@ sap.ui.define([
 		if (oCurrentRange) {
 			bPhoneRange = this.sCurrentRange === "Phone";
 
-			$Control.toggleClass("sapFShellBarSizeDesktop", this.sCurrentRange === "Desktop");
-			$Control.toggleClass("sapFShellBarSizeTablet", this.sCurrentRange === "Tablet");
-			$Control.toggleClass("sapFShellBarSizePhone", bPhoneRange);
+			this._oDomRef.classList.toggle("sapFShellBarSizeDesktop", this.sCurrentRange === "Desktop");
+			this._oDomRef.classList.toggle("sapFShellBarSizeTablet", this.sCurrentRange === "Tablet");
+			this._oDomRef.classList.toggle("sapFShellBarSizePhone", bPhoneRange);
 		}
 
 		/**


### PR DESCRIPTION
Just replacing jQuery `.toggleClass` by vanilla js `classList.toggle` in `sap.f` library. Hopefully more people can help tackling other libraries, then other jQuery features, until we don't have jQuery in the code base anymore.

jQuery `.toggleClass` can be replaced by `classList.toggle` and it's supported by IE11, not just modern browsers.

`sap.f.DynamicPageTitle` still have 2 references to `.toggleClass` due to method `._setContentAreaFlexBasis` using parameter $node, it's not locally defined.

https://github.com/mauriciolauffer/openui5/blob/6d0303f509537763dd321a3d4f48a10be23bf998/src/sap.f/src/sap/f/DynamicPageTitle.js#L1441
https://github.com/mauriciolauffer/openui5/blob/6d0303f509537763dd321a3d4f48a10be23bf998/src/sap.f/src/sap/f/DynamicPageTitle.js#L1445