### PR TITLE
Replace jQuery $().toggleClass by vanilla js classList.toggle in sap.tnt library

### DIFF
--- a/src/sap.tnt/src/sap/tnt/NavigationListItem.js
+++ b/src/sap.tnt/src/sap/tnt/NavigationListItem.js
@@ -392,8 +392,9 @@ sap.ui.define(["sap/ui/thirdparty/jquery", "./library", 'sap/ui/core/Core', "sap
 			expandIconControl.setTooltip(this._getExpandIconTooltip(false));
 
 			var $container = this.$().find('.sapTntNavLIGroupItems');
+			var oDomRef = this.getDomRef();
 			$container.stop(true, true).slideDown(duration || 'fast', function () {
-				$container.toggleClass('sapTntNavLIHiddenGroupItems');
+				oDomRef.querySelector(".sapTntNavLIGroupItems").classList.toggle('sapTntNavLIHiddenGroupItems');
 			});
 
 			this.getNavigationList()._updateNavItems();
@@ -418,8 +419,9 @@ sap.ui.define(["sap/ui/thirdparty/jquery", "./library", 'sap/ui/core/Core', "sap
 			expandIconControl.setTooltip(this._getExpandIconTooltip(true));
 
 			var $container = this.$().find('.sapTntNavLIGroupItems');
+			var oDomRef = this.getDomRef();
 			$container.stop(true, true).slideUp(duration || 'fast', function () {
-				$container.toggleClass('sapTntNavLIHiddenGroupItems');
+				oDomRef.querySelector(".sapTntNavLIGroupItems").classList.toggle('sapTntNavLIHiddenGroupItems');
 			});
 
 			this.getNavigationList()._updateNavItems();

--- a/src/sap.tnt/src/sap/tnt/SideNavigation.js
+++ b/src/sap.tnt/src/sap/tnt/SideNavigation.js
@@ -174,7 +174,7 @@ sap.ui.define([
 			}
 
 			if (isExpanded) {
-				$this.toggleClass('sapTntSideNavigationNotExpanded', !isExpanded);
+				this.getDomRef().classList.toggle('sapTntSideNavigationNotExpanded', !isExpanded);
 
 				if (itemAggregation) {
 					itemAggregation.setExpanded(isExpanded);
@@ -213,10 +213,10 @@ sap.ui.define([
 				return;
 			}
 
-			this.$().toggleClass('sapTntSideNavigationNotExpandedWidth', !isExpanded);
+			this.getDomRef().classList.toggle('sapTntSideNavigationNotExpandedWidth', !isExpanded);
 
 			if (!isExpanded) {
-				this.$().toggleClass('sapTntSideNavigationNotExpanded', !isExpanded);
+				this.getDomRef().classList.toggle('sapTntSideNavigationNotExpanded', !isExpanded);
 
 				if (this.getAggregation('item')) {
 					this.getAggregation('item').setExpanded(isExpanded);


### PR DESCRIPTION
Just replacing jQuery `.toggleClass` by vanilla js `classList.toggle` in `sap.tnt` library. Hopefully more people can help tackling other libraries, then other jQuery features, until we don't have jQuery in the code base anymore.

jQuery `.toggleClass` can be replaced by `classList.toggle` and it's supported by IE11, not just modern browsers.
