### PR TITLE
Replace jQuery $().toggleClass by vanilla js classList.toggle in sap.ui.unified library

### DIFF
--- a/src/sap.ui.unified/src/sap/ui/unified/ContentSwitcher.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/ContentSwitcher.js
@@ -106,16 +106,13 @@ sap.ui.define([
 	 * sapUiUnifiedCSwitcherVisible
 	 */
 	ContentSwitcher.prototype._showActiveContent = function(iNumber) {
-		var oDomRef = this.getDomRef();
-		if (oDomRef) {
-			var oContents1 = oDomRef.querySelector("[id$='content1']");
-			var oContents2 = oDomRef.querySelector("[id$='content2']");
-			if (oContents1) {
-				oContents1.classList.toggle("sapUiUfdCSwitcherVisible", iNumber === 1);
-			}
-			if (oContents2) {
-				oContents2.classList.toggle("sapUiUfdCSwitcherVisible", iNumber === 2);
-			}
+		var oContents1 = this.getDomRef("content1");
+		var oContents2 = this.getDomRef("content2");
+		if (oContents1) {
+			oContents1.classList.toggle("sapUiUfdCSwitcherVisible", iNumber === 1);
+		}
+		if (oContents2) {
+			oContents2.classList.toggle("sapUiUfdCSwitcherVisible", iNumber === 2);
 		}
 	};
 

--- a/src/sap.ui.unified/src/sap/ui/unified/ContentSwitcher.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/ContentSwitcher.js
@@ -106,9 +106,16 @@ sap.ui.define([
 	 * sapUiUnifiedCSwitcherVisible
 	 */
 	ContentSwitcher.prototype._showActiveContent = function(iNumber) {
-		if (this._$Contents) {
-			this._$Contents[0].toggleClass("sapUiUfdCSwitcherVisible", iNumber === 1);
-			this._$Contents[1].toggleClass("sapUiUfdCSwitcherVisible", iNumber === 2);
+		var oDomRef = this.getDomRef();
+		if (oDomRef) {
+			var oContents1 = oDomRef.querySelector("[id$='content1']");
+			var oContents2 = oDomRef.querySelector("[id$='content2']");
+			if (oContents1) {
+				oContents1.classList.toggle("sapUiUfdCSwitcherVisible", iNumber === 1);
+			}
+			if (oContents2) {
+				oContents2.classList.toggle("sapUiUfdCSwitcherVisible", iNumber === 2);
+			}
 		}
 	};
 
@@ -165,14 +172,12 @@ sap.ui.define([
 			return this;
 		}
 
-		var $Dom = this.$();
-		if ($Dom[0]) {
+		var oDomRef = this.getDomRef();
+		if (oDomRef) {
 			// We are already rendered - so we have to change the class on the fly...
-			$Dom.toggleClass("sapUiUfdCSwitcherAnimation" + sCurrentAnimation, false);
-			$Dom.toggleClass("sapUiUfdCSwitcherAnimation" + sAnimation, true);
-		}/* else {
-			// The renderer will take care of it.
-		}/**/
+			oDomRef.classList.toggle("sapUiUfdCSwitcherAnimation" + sCurrentAnimation, false);
+			oDomRef.classList.toggle("sapUiUfdCSwitcherAnimation" + sAnimation, true);
+		}
 
 		return this.setProperty("animation", sAnimation, bSuppressInvalidate);
 	};

--- a/src/sap.ui.unified/src/sap/ui/unified/Menu.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/Menu.js
@@ -1227,9 +1227,15 @@ sap.ui.define([
 		}
 
 		if ($Menu.outerHeight(true) > iMaxHeight) {
-			$Menu.css("max-height", iMaxHeight + "px").toggleClass("sapUiMnuScroll", true);
+			$Menu.css("max-height", iMaxHeight + "px");
+			if (oMenu.getDomRef()) {
+				oMenu.getDomRef().classList.toggle("sapUiMnuScroll", true);
+			}
 		} else {
-			$Menu.css("max-height", "").toggleClass("sapUiMnuScroll", false);
+			$Menu.css("max-height", "");
+			if (oMenu.getDomRef()) {
+				oMenu.getDomRef().classList.toggle("sapUiMnuScroll", false);
+			}
 		}
 	}
 

--- a/src/sap.ui.unified/src/sap/ui/unified/MenuItem.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/MenuItem.js
@@ -153,7 +153,9 @@ sap.ui.define(['sap/ui/core/IconPool', './MenuItemBase', './library', 'sap/ui/co
 	};
 
 	MenuItem.prototype.hover = function(bHovered, oMenu){
-		this.$().toggleClass("sapUiMnuItmHov", bHovered);
+		if (this.getDomRef()) {
+			this.getDomRef().classList.toggle("sapUiMnuItmHov", bHovered);
+		}
 	};
 
 	MenuItem.prototype.focus = function(oMenu){

--- a/src/sap.ui.unified/src/sap/ui/unified/MenuItemBase.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/MenuItemBase.js
@@ -135,7 +135,9 @@ sap.ui.define(['sap/ui/core/Element', './library'],
 	 */
 	MenuItemBase.prototype.onSubmenuToggle = function(bOpened){
 		// Subclasses may override this: Called when the items submenu is opend or closed
-		this.$().toggleClass("sapUiMnuItmSubMnuOpen", bOpened);
+		if (this.getDomRef()) {
+			this.getDomRef().classList.toggle("sapUiMnuItmSubMnuOpen", bOpened);
+		}
 	};
 
 	/**

--- a/src/sap.ui.unified/src/sap/ui/unified/MenuTextFieldItem.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/MenuTextFieldItem.js
@@ -316,12 +316,10 @@ sap.ui.define([
 
 	MenuTextFieldItem.prototype.setValueState = function(sValueState){
 		this.setProperty("valueState", sValueState, true);
-		if (this.getDomRef()) {
-			var oTf = this.getDomRef().querySelector("[id$='tf']");
-			if (oTf) {
-				oTf.classList.toggle("sapUiMnuTfItemTfErr", sValueState == ValueState.Error);
-				oTf.classList.toggle("sapUiMnuTfItemTfWarn", sValueState == ValueState.Warning);
-			}
+		var oTf = this.getDomRef("tf");
+		if (oTf) {
+			oTf.classList.toggle("sapUiMnuTfItemTfErr", sValueState == ValueState.Error);
+			oTf.classList.toggle("sapUiMnuTfItemTfWarn", sValueState == ValueState.Warning);
 		}
 		var sTooltip = ValueStateSupport.enrichTooltip(this, this.getTooltip_AsString());
 		if (sTooltip) {

--- a/src/sap.ui.unified/src/sap/ui/unified/MenuTextFieldItem.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/MenuTextFieldItem.js
@@ -170,7 +170,9 @@ sap.ui.define([
 	};
 
 	MenuTextFieldItem.prototype.hover = function(bHovered, oMenu){
-		this.$().toggleClass("sapUiMnuItmHov", bHovered);
+		if (this.getDomRef()) {
+			this.getDomRef().classList.toggle("sapUiMnuItmHov", bHovered);
+		}
 
 		if (bHovered && oMenu.checkEnabled(this)) {
 			oMenu.closeSubmenu(false, true);
@@ -314,9 +316,13 @@ sap.ui.define([
 
 	MenuTextFieldItem.prototype.setValueState = function(sValueState){
 		this.setProperty("valueState", sValueState, true);
-		var $tf = this.$("tf");
-		$tf.toggleClass("sapUiMnuTfItemTfErr", sValueState == ValueState.Error);
-		$tf.toggleClass("sapUiMnuTfItemTfWarn", sValueState == ValueState.Warning);
+		if (this.getDomRef()) {
+			var oTf = this.getDomRef().querySelector("[id$='tf']");
+			if (oTf) {
+				oTf.classList.toggle("sapUiMnuTfItemTfErr", sValueState == ValueState.Error);
+				oTf.classList.toggle("sapUiMnuTfItemTfWarn", sValueState == ValueState.Warning);
+			}
+		}
 		var sTooltip = ValueStateSupport.enrichTooltip(this, this.getTooltip_AsString());
 		if (sTooltip) {
 			this.$().attr("title", sTooltip);

--- a/src/sap.ui.unified/src/sap/ui/unified/ShellHeadItem.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/ShellHeadItem.js
@@ -115,7 +115,9 @@ sap.ui.define([
 	ShellHeadItem.prototype.setStartsSection = function(bStartsSection){
 		bStartsSection = !!bStartsSection;
 		this.setProperty("startsSection", bStartsSection, true);
-		this.$().toggleClass("sapUiUfdShellHeadItmDelim", bStartsSection);
+		if (this.getDomRef()) {
+			this.getDomRef().classList.toggle("sapUiUfdShellHeadItmDelim", bStartsSection);
+		}
 		return this;
 	};
 
@@ -123,7 +125,9 @@ sap.ui.define([
 	ShellHeadItem.prototype.setShowSeparator = function(bShowSeparator){
 		bShowSeparator = !!bShowSeparator;
 		this.setProperty("showSeparator", bShowSeparator, true);
-		this.$().toggleClass("sapUiUfdShellHeadItmSep", bShowSeparator);
+		if (this.getDomRef()) {
+			this.getDomRef().classList.toggle("sapUiUfdShellHeadItmSep", bShowSeparator);
+		}
 		return this;
 	};
 
@@ -137,7 +141,7 @@ sap.ui.define([
 		}
 
 		if (bToggleEnabled) {
-			$This.toggleClass("sapUiUfdShellHeadItmSel", bSelected);
+			this.getDomRef().classList.toggle("sapUiUfdShellHeadItmSel", bSelected);
 			$This.attr("aria-pressed", bSelected);
 		} else {
 			$This.removeClass("sapUiUfdShellHeadItmSel");
@@ -168,7 +172,9 @@ sap.ui.define([
 	ShellHeadItem.prototype.setShowMarker = function(bMarker){
 		bMarker = !!bMarker;
 		this.setProperty("showMarker", bMarker, true);
-		this.$().toggleClass("sapUiUfdShellHeadItmMark", bMarker);
+		if (this.getDomRef()) {
+			this.getDomRef().classList.toggle("sapUiUfdShellHeadItmMark", bMarker);
+		}
 		return this;
 	};
 

--- a/src/sap.ui.unified/src/sap/ui/unified/ShellHeadUserItem.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/ShellHeadUserItem.js
@@ -120,7 +120,9 @@ sap.ui.define([
 		var $Ref = this.$(),
 			$NameRef = this.$("name");
 		var iBeforeWidth = $Ref.width();
-		$Ref.toggleClass("sapUiUfdShellHeadUsrItmLimit", false);
+		if (this.getDomRef()) {
+			this.getDomRef().classList.toggle("sapUiUfdShellHeadUsrItmLimit", false);
+		}
 		//User name cannot be larger than 240px
 		//(if a search field is shown in the shell this max size decreases depending on the screen width)
 		var iMax = 240;
@@ -128,7 +130,9 @@ sap.ui.define([
 			iMax = Math.min(iMax, 0.5 * document.documentElement.clientWidth - 225);
 		}
 		if (iMax < $NameRef.width()) {
-			$Ref.toggleClass("sapUiUfdShellHeadUsrItmLimit", true);
+			if (this.getDomRef()) {
+				this.getDomRef().classList.toggle("sapUiUfdShellHeadUsrItmLimit", true);
+			}
 		}
 		return iBeforeWidth != $Ref.width();
 	};

--- a/src/sap.ui.unified/src/sap/ui/unified/ShellHeader.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/ShellHeader.js
@@ -208,11 +208,9 @@ sap.ui.define([
 
 	ShellHeader.prototype.onAfterRendering = function(){
 		this._refresh();
-		if (this.getDomRef()) {
-			var oHdrCenter = this.getDomRef().querySelector("[id$='hdr-center']");
-				if (oHdrCenter) {
-				oHdrCenter.classList.toggle("sapUiUfdShellAnim", !this._noHeadCenterAnim);
-			}
+		var oHdrCenter = this.getDomRef("hdr-center");
+		if (oHdrCenter) {
+			oHdrCenter.classList.toggle("sapUiUfdShellAnim", !this._noHeadCenterAnim);
 		}
 	};
 
@@ -249,11 +247,9 @@ sap.ui.define([
 			oUser._checkAndAdaptWidth(searchVisible && !!this.getSearch());
 		}
 
-		if (this.getDomRef()) {
-			var oIcon = this.getDomRef().querySelector("[id$='icon']");
-				if (oIcon) {
-				oIcon.parentNode.classList.toggle("sapUiUfdShellHidden", isPhoneSize && searchVisible && !!this.getSearch());
-			}
+		var oIcon = this.getDomRef("icon");
+		if (oIcon) {
+			oIcon.parentNode.classList.toggle("sapUiUfdShellHidden", isPhoneSize && searchVisible && !!this.getSearch());
 		}
 
 		var	we = this.$("hdr-end").outerWidth(),

--- a/src/sap.ui.unified/src/sap/ui/unified/ShellHeader.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/ShellHeader.js
@@ -208,7 +208,12 @@ sap.ui.define([
 
 	ShellHeader.prototype.onAfterRendering = function(){
 		this._refresh();
-		this.$("hdr-center").toggleClass("sapUiUfdShellAnim", !this._noHeadCenterAnim);
+		if (this.getDomRef()) {
+			var oHdrCenter = this.getDomRef().querySelector("[id$='hdr-center']");
+				if (oHdrCenter) {
+				oHdrCenter.classList.toggle("sapUiUfdShellAnim", !this._noHeadCenterAnim);
+			}
+		}
 	};
 
 	ShellHeader.prototype.onThemeChanged = function(){
@@ -237,15 +242,19 @@ sap.ui.define([
 
 		var oUser = this.getUser(),
 			isPhoneSize = jQuery("html").hasClass("sapUiMedia-Std-Phone"),
-			searchVisible = !this.$("hdr-search").hasClass("sapUiUfdShellHidden"),
-			$logo = this.$("icon");
+			searchVisible = !this.$("hdr-search").hasClass("sapUiUfdShellHidden");
 
 		if (oUser) {
 			oUser._refreshImage();
 			oUser._checkAndAdaptWidth(searchVisible && !!this.getSearch());
 		}
 
-		$logo.parent().toggleClass("sapUiUfdShellHidden", isPhoneSize && searchVisible && !!this.getSearch());
+		if (this.getDomRef()) {
+			var oIcon = this.getDomRef().querySelector("[id$='icon']");
+				if (oIcon) {
+				oIcon.parentNode.classList.toggle("sapUiUfdShellHidden", isPhoneSize && searchVisible && !!this.getSearch());
+			}
+		}
 
 		var	we = this.$("hdr-end").outerWidth(),
 			wb = this.$("hdr-begin").outerWidth(),

--- a/src/sap.ui.unified/src/sap/ui/unified/ShellLayout.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/ShellLayout.js
@@ -282,7 +282,9 @@ sap.ui.define([
 	ShellLayout.prototype.setHeaderVisible = function(bHeaderVisible){
 		bHeaderVisible = !!bHeaderVisible;
 		this.setProperty("headerVisible", bHeaderVisible, true);
-		this.$().toggleClass("sapUiUfdShellNoHead", !bHeaderVisible);
+		if (this.getDomRef()) {
+			this.getDomRef().classList.toggle("sapUiUfdShellNoHead", !bHeaderVisible);
+		}
 		return this;
 	};
 
@@ -295,14 +297,19 @@ sap.ui.define([
 			return this;
 		}, function(){
 			this.$("main-focusDummyOut").attr("tabindex", bShowCurtain ? 0 : -1);
-			this.$().toggleClass("sapUiUfdShellCurtainHidden", !bShowCurtain).toggleClass("sapUiUfdShellCurtainVisible", bShowCurtain);
+			if (this.getDomRef()) {
+				this.getDomRef().classList.toggle("sapUiUfdShellCurtainHidden", !bShowCurtain);
+				this.getDomRef().classList.toggle("sapUiUfdShellCurtainVisible", bShowCurtain);
+			}
 
 			if (bShowCurtain) {
 				var zIndex = Popup.getNextZIndex();
 				this.$("curt").css("z-index", zIndex + 1);
 				this.$("hdr").css("z-index", zIndex + 3);
 				this.$("brand").css("z-index", zIndex + 7);
-				this.$().toggleClass("sapUiUfdShellCurtainClosed", false);
+				if (this.getDomRef()) {
+					this.getDomRef().classList.toggle("sapUiUfdShellCurtainClosed", false);
+				}
 			}
 
 			this._timedCurtainClosed(bShowCurtain);
@@ -396,7 +403,12 @@ sap.ui.define([
 	/*Restricted API for Launchpad to set a Strong BG style*/
 	ShellLayout.prototype._setStrongBackground = function(bUseStongBG){
 		this._useStrongBG = !!bUseStongBG;
-		this.$("strgbg").toggleClass("sapUiStrongBackgroundColor", this._useStrongBG);
+		if (this.getDomRef()) {
+			var oStrongBg = this.getDomRef().querySelector("[id$='strgbg']");
+			if (oStrongBg) {
+				oStrongBg.classList.toggle("sapUiStrongBackgroundColor", this._useStrongBG);
+			}
+		}
 	};
 
 
@@ -419,7 +431,10 @@ sap.ui.define([
 		var bWasVisible = this._showHeader;
 		this._showHeader = this._isHeaderHidingActive() ? !!bShow : true;
 
-		this.$().toggleClass("sapUiUfdShellHeadHidden", !this._showHeader).toggleClass("sapUiUfdShellHeadVisible", this._showHeader);
+		if (this.getDomRef()) {
+			this.getDomRef().classList.toggle("sapUiUfdShellHeadHidden", !this._showHeader);
+			this.getDomRef().classList.toggle("sapUiUfdShellHeadVisible", this._showHeader);
+		}
 
 		if (this._showHeader) {
 			this._timedHideHeader();
@@ -475,7 +490,9 @@ sap.ui.define([
 			this.$("curt").css("z-index", "");
 			this.$("hdr").css("z-index", "");
 			this.$("brand").css("z-index", "");
-			this.$().toggleClass("sapUiUfdShellCurtainClosed", true);
+			if (this.getDomRef()) {
+				this.getDomRef().classList.toggle("sapUiUfdShellCurtainClosed", true);
+			}
 		}.bind(this), duration);
 	};
 

--- a/src/sap.ui.unified/src/sap/ui/unified/ShellLayout.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/ShellLayout.js
@@ -403,11 +403,9 @@ sap.ui.define([
 	/*Restricted API for Launchpad to set a Strong BG style*/
 	ShellLayout.prototype._setStrongBackground = function(bUseStongBG){
 		this._useStrongBG = !!bUseStongBG;
-		if (this.getDomRef()) {
-			var oStrongBg = this.getDomRef().querySelector("[id$='strgbg']");
-			if (oStrongBg) {
-				oStrongBg.classList.toggle("sapUiStrongBackgroundColor", this._useStrongBG);
-			}
+		var oStrongBg = this.getDomRef("strgbg");
+		if (oStrongBg) {
+			oStrongBg.classList.toggle("sapUiStrongBackgroundColor", this._useStrongBG);
 		}
 	};
 

--- a/src/sap.ui.unified/src/sap/ui/unified/ShellOverlay.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/ShellOverlay.js
@@ -110,12 +110,17 @@ sap.ui.define([
 
 		if (this._getAnimActive()) {
 			setTimeout(function(){
-				jQuery(document.getElementById("sap-ui-blocklayer-popup")).toggleClass("sapUiUfdShellOvrlyBlyTp", false);
+				var oBlockLayer = document.getElementById("sap-ui-blocklayer-popup");
+				if (oBlockLayer) {
+					oBlockLayer.classList.toggle("sapUiUfdShellOvrlyBlyTp", false);
+				}
 			}, 50);
 		}
 
 		setTimeout(function(){
-			this.$().toggleClass("sapUiUfdShellOvrlyOpening", false);
+			if (this.getDomRef()) {
+				this.getDomRef().classList.toggle("sapUiUfdShellOvrlyOpening", false);
+			}
 		}.bind(this), this._getAnimDuration(true));
 	};
 
@@ -129,14 +134,20 @@ sap.ui.define([
 			return;
 		}
 
-		this.$().toggleClass("sapUiUfdShellOvrlyCntntHidden", true).toggleClass("sapUiUfdShellOvrlyClosing", true);
+		if (this.getDomRef()) {
+			this.getDomRef().classList.toggle("sapUiUfdShellOvrlyCntntHidden", true);
+			this.getDomRef().classList.toggle("sapUiUfdShellOvrlyClosing", true);
+		}
 
 		this._setSearchWidth();
 
 		setTimeout(function(){
 			var $Bl = jQuery(document.getElementById("sap-ui-blocklayer-popup"));
 			if (Popup.blStack.length == 1 && this._getAnimActive() && $Bl.hasClass("sapUiUfdShellOvrlyBly")) {
-				$Bl.toggleClass("sapUiUfdShellOvrlyBlyTp", true);
+				var oBlockLayer = document.getElementById("sap-ui-blocklayer-popup");
+				if (oBlockLayer) {
+					oBlockLayer.classList.toggle("sapUiUfdShellOvrlyBlyTp", true);
+				}
 			}
 		}.bind(this), Math.max(this._getAnimDuration(false) - this._getBLAnimDuration(), 0));
 
@@ -236,7 +247,9 @@ sap.ui.define([
 		}
 
 		setTimeout(function(){
-			this.$().toggleClass("sapUiUfdShellOvrlyCntntHidden", false);
+			if (this.getDomRef()) {
+				this.getDomRef().classList.toggle("sapUiUfdShellOvrlyCntntHidden", false);
+			}
 			this.$("search").css("width", "");
 		}.bind(this), 10);
 	};

--- a/src/sap.ui.unified/src/sap/ui/unified/SplitContainer.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/SplitContainer.js
@@ -186,7 +186,7 @@ sap.ui.define([
 			var sDir, sOtherDir;
 			var sSizeValue = this.getSecondaryContentSize();
 			var bShow = this.getShowSecondaryContent();
-			var oSecondaryContentContainer = null;
+			var oSecondaryContentContainer = this.getDomRef("pane");
 
 			if (bVertical) {
 				// Vertical mode
@@ -219,9 +219,6 @@ sap.ui.define([
 				this._contentContainer.css(sDir, "0");
 			}
 
-			if (this.getDomRef()) {
-				oSecondaryContentContainer = this.getDomRef().querySelector("[id$='pane']");
-			}
 			if (!bShow) {
 				// The theming parameter is something along the lines of "500ms", the "ms"-part is
 				// ignored by parseInt.

--- a/src/sap.ui.unified/src/sap/ui/unified/SplitContainer.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/SplitContainer.js
@@ -186,6 +186,7 @@ sap.ui.define([
 			var sDir, sOtherDir;
 			var sSizeValue = this.getSecondaryContentSize();
 			var bShow = this.getShowSecondaryContent();
+			var oSecondaryContentContainer = null;
 
 			if (bVertical) {
 				// Vertical mode
@@ -218,6 +219,9 @@ sap.ui.define([
 				this._contentContainer.css(sDir, "0");
 			}
 
+			if (this.getDomRef()) {
+				oSecondaryContentContainer = this.getDomRef().querySelector("[id$='pane']");
+			}
 			if (!bShow) {
 				// The theming parameter is something along the lines of "500ms", the "ms"-part is
 				// ignored by parseInt.
@@ -227,10 +231,14 @@ sap.ui.define([
 				// Maybe we could also allow "s"-values and then multiply everything below 20 with 1000...?
 
 				this._closeContentDelayId = setTimeout(function() {
-					this._secondaryContentContainer.toggleClass("sapUiUfdSplitContSecondClosed", true);
-				}.bind(this), iHideDelay);
+					if (oSecondaryContentContainer) {
+						oSecondaryContentContainer.classList.toggle("sapUiUfdSplitContSecondClosed", true);
+					}
+				}, iHideDelay);
 			} else {
-				this._secondaryContentContainer.toggleClass("sapUiUfdSplitContSecondClosed", false);
+				if (oSecondaryContentContainer) {
+					oSecondaryContentContainer.classList.toggle("sapUiUfdSplitContSecondClosed", false);
+				}
 			}
 
 		}


### PR DESCRIPTION
Just replacing `jQuery .toggleClass` by vanilla js `classList.toggle` in `sap.ui.unified` library. Hopefully more people can help tackling other libraries, then other jQuery features, until we don't have jQuery in the code base anymore.

`jQuery .toggleClass` can be replaced by `classList.toggle` and it's supported by IE11, not just modern browsers.