### PR TITLE
Min and Max constraints are ignored when zero

### DIFF
--- a/src/sap.m/src/sap/m/StepInput.js
+++ b/src/sap.m/src/sap/m/StepInput.js
@@ -1542,17 +1542,17 @@ function(
 		StepInput.prototype._getMin = function() {
 			var oBinding = this.getBinding("value"),
 				oBindingType = oBinding && oBinding.getType && oBinding.getType(),
-				sBindingConstraintMin = oBindingType && oBindingType.oConstraints && oBindingType.oConstraints.minimum;
+				sBindingConstraintMin = (oBindingType && oBindingType.oConstraints) ? oBindingType.oConstraints.minimum : undefined;
 
-			return sBindingConstraintMin ? parseFloat(sBindingConstraintMin) : this.getMin();
+			return sBindingConstraintMin !== undefined ? parseFloat(sBindingConstraintMin) : this.getMin();
 		};
 
 		StepInput.prototype._getMax = function() {
 			var oBinding = this.getBinding("value"),
 				oBindingType = oBinding && oBinding.getType && oBinding.getType(),
-				sBindingConstraintMax = oBindingType && oBindingType.oConstraints && oBindingType.oConstraints.maximum;
+				sBindingConstraintMax = (oBindingType && oBindingType.oConstraints) ? oBindingType.oConstraints.maximum : undefined;
 
-			return sBindingConstraintMax ? parseFloat(sBindingConstraintMax) : this.getMax();
+			return sBindingConstraintMax !== undefined ? parseFloat(sBindingConstraintMax) : this.getMax();
 		};
 
 		/**


### PR DESCRIPTION
constraints minimum and maximum are ignored and set to undefinend when 0 (zero) is used.
Because zero equals to false the comparison for _getMin and _getMax fails to see the zero as an actuale number and tread it as an false.