### PR TITLE
[FIX] sap.m.ColumnListItemRenderer: Add ARIA role for accessibility support

### DIFF
--- a/src/sap.m/src/sap/m/ColumnListItemRenderer.js
+++ b/src/sap.m/src/sap/m/ColumnListItemRenderer.js
@@ -110,7 +110,7 @@ sap.ui.define([
 
 	// Returns aria accessibility role
 	ColumnListItemRenderer.getAriaRole = function(oLI) {
-		return "";
+		return "row";
 	};
 
 	ColumnListItemRenderer.renderLIAttributes = function(rm, oLI) {


### PR DESCRIPTION
- Missing role attribute meant screen readers were not reading aria-selected value when using spacebar.

- Now using row role, screen readers should read aria-selected value when using spacebar.