### PR TITLE
Improve JSDoc in NotificationListRenderer

### DIFF
--- a/src/sap.m/src/sap/m/NotificationListRenderer.js
+++ b/src/sap.m/src/sap/m/NotificationListRenderer.js
@@ -9,7 +9,7 @@ sap.ui.define(['sap/ui/core/Renderer',
 		"use strict";
 
 		/**
-		 * Tree renderer.
+		 * NotificationList renderer.
 		 * @namespace
 		 *
 		 */


### PR DESCRIPTION
Previously, the NotificationListRenderer took over a JSDoc comment from TreeRenderer. This is corrected with this commit.