### PR TITLE
feat: added width of column to TablePersoController save

### DIFF
--- a/src/sap.m/src/sap/m/TablePersoController.js
+++ b/src/sap.m/src/sap/m/TablePersoController.js
@@ -58,6 +58,7 @@ sap.ui.define([
 				 */
 				"componentName": {type: "string", since: "1.20.2"},
 				"hasGrouping": {type: "boolean", defaultValue: false, since: "1.22"},
+				"saveColumnWidth": {type: "boolean", defaultValue: false, since: "1.103"},
 				"showSelectAll": {type: "boolean", defaultValue: true, since: "1.22"},
 
 				/**
@@ -445,6 +446,9 @@ sap.ui.define([
 				if (oTableColumn) {
 					oTableColumn.setVisible(oNewSetting.visible);
 					oTableColumn.setOrder(oNewSetting.order);
+					if (oNewSetting.width) {
+						oTableColumn.setWidth(oNewSetting.width);
+					}
 				} else {
 					Log.warning("Personalization could not be applied to column " + oNewSetting.id + " - not found!");
 				}
@@ -805,7 +809,8 @@ sap.ui.define([
 		if (oPersoMap) {
 			var aColumns = oTable.getColumns(),
 				aColumnInfo = [],
-				oPersoService = this.getPersoService();
+				oPersoService = this.getPersoService(),
+				that = this;
 			aColumns.forEach(function(oColumn){
 				var sCaption = null;
 				if (oPersoService.getCaption) {
@@ -836,13 +841,17 @@ sap.ui.define([
 
 				// In this case, oColumn is one of our controls. Therefore, sap.ui.core.Element.toString()
 				// is called which delivers something like 'Element sap.m.Column#<sId>' where sId is the column's sId property
-				aColumnInfo.push({
+				var oColumnInfo = {
 					text : sCaption,
 					order : oColumn.getOrder(),
 					visible : oColumn.getVisible(),
 					id: oPersoMap[oColumn],
 					group : sGroup
-				});
+				};
+				if (that.getSaveColumnWidth()) {
+					oColumnInfo["width"] = oColumn.getWidth();
+				}
+				aColumnInfo.push(oColumnInfo);
 			});
 
 			// Sort to make sure they're presented in the right order

--- a/src/sap.m/test/sap/m/qunit/TablePersoControllerExtended.qunit.js
+++ b/src/sap.m/test/sap/m/qunit/TablePersoControllerExtended.qunit.js
@@ -1,0 +1,192 @@
+/*global QUnit */
+sap.ui.define([
+	"sap/ui/qunit/utils/createAndAppendDiv",
+	"sap/m/TablePersoController",
+	"sap/ui/model/json/JSONModel",
+	"sap/m/Table",
+	"sap/m/Label",
+	"sap/m/Toolbar",
+	"sap/m/ToolbarSpacer",
+	"sap/m/Button",
+	"sap/m/Column",
+	"sap/m/ColumnListItem",
+	"sap/m/Page",
+	"sap/m/App",
+	"sap/ui/thirdparty/jquery",
+	"sap/ui/core/Core"
+], function(createAndAppendDiv, TablePersoController, JSONModel, Table, Label, Toolbar, ToolbarSpacer, Button, Column, ColumnListItem, Page, App, jQuery, oCore) {
+	"use strict";
+
+
+	// prepare DOM
+	createAndAppendDiv("content");
+
+
+	var oList;
+
+	// Very simple page-context personalization
+	// persistence service, not for productive use!
+	var oPersoService = {
+		getPersData : function() {
+			var oDeferred = new jQuery.Deferred();
+			var oBundle = this._oBundle;
+			oDeferred.resolve(oBundle);
+			return oDeferred.promise();
+		},
+
+		setPersData : function(oBundle) {
+			var oDeferred = new jQuery.Deferred();
+			this._oBundle = oBundle;
+			oDeferred.resolve();
+			return oDeferred.promise();
+		},
+
+	resetPersData : function() {
+			var oDeferred = new jQuery.Deferred();
+
+			var oInitialData = {
+				_persoSchemaVersion : "1.0",
+				aColumns : [{
+					id : "QUnitTest-idRandomDataTable-idColor",
+					order : 0,
+					text : "Color",
+					visible : false
+				}, {
+					id : "QUnitTest-idRandomDataTable-idNumber",
+					order : 1,
+					text : "Number",
+					visible : true
+				}, {
+					id : "QUnitTest-idRandomDataTable-idName",
+					order : 2,
+					text : "Name",
+					visible : true
+				}]
+			};
+
+			this._oBundle = oInitialData;
+			oDeferred.resolve();
+			return oDeferred.promise();
+		}
+	};
+
+	/**
+	 * Set up a test data environment. Need a table for the perso dialog
+	 */
+	var oData = {
+		items : [{
+			name : "Michelle",
+			color : "orange",
+			number : 3.14
+		}, {
+			name : "Joseph",
+			color : "blue",
+			number : 1.618
+		}, {
+			name : "David",
+			color : "green",
+			number : 0
+		}],
+		cols : ["Name", "Color", "Number"]
+	};
+
+	var oTable = new Table("idRandomDataTable", {
+		inset : true,
+		headerText : "Random Data",
+		headerToolbar : new Toolbar({
+			content : [new Label({
+				text : "Random Data"
+			}), new ToolbarSpacer({}), new Button("idPersonalizationResetButton", {
+				icon : "sap-icon://refresh"
+			}), new Button("idPersonalizationButton", {
+				icon : "sap-icon://person-placeholder"
+			})]
+		}),
+		columns : oData.cols.map(function(colname) {
+			return new Column("id" + colname, {
+				header : new Label({
+					text : colname
+				})
+			});
+		})
+	});
+
+	oTable.setModel(new JSONModel(oData));
+	oTable.bindAggregation("items", "/items", new ColumnListItem({
+		cells : oData.cols.map(function(colname) {
+			return new Label({
+				text : "{" + colname.toLowerCase() + "}"
+			});
+		})
+	}));
+
+	var oTPC = new TablePersoController({
+		table : oTable,
+		componentName: "QUnitTest",
+		persoService : oPersoService,
+		saveColumnWidth : true
+	}).activate();
+
+	var sPersoDoneMsg = "Personalization Done!";
+	var fnPersoDone = function() {
+		throw sPersoDoneMsg;
+	};
+
+	oTPC.attachPersonalizationsDone(fnPersoDone);
+
+	oCore.byId("idPersonalizationButton").attachPress(function(oEvent) {
+		oTPC.openDialog();
+	});
+
+	oCore.byId("idPersonalizationResetButton").attachPress(function() {
+		//		Log.debug("TablePersoController resetRadioButton");
+		oPersoService.resetPersData();
+		oTPC.refresh();
+	});
+
+	var page = new Page("myFirstPage", {
+		title : "TablePersoController Test",
+		content : oTable
+	});
+
+	var app = new App("myApp", {
+		initialPage : "myFirstPage"
+	});
+
+	app.addPage(page).placeAt("content");
+
+	QUnit.module("Change & Reset");
+
+	QUnit.test("Original order and all visible", function(assert) {
+
+		//Change width of first column
+		oTable.getColumns()[0].setWidth("20em");
+
+		// Open dialog
+		oCore.byId("idPersonalizationButton").firePress();
+
+		// Get the privately aggregated TPD
+		var oTPD = oTPC.getAggregation("_tablePersoDialog");
+
+		// Status at this point should be initial, i.e.:
+		// Name   ON
+		// Color  ON
+		// Number ON
+
+		var oPersData = oTPD.retrievePersonalizations();
+		assert.strictEqual(oPersData.aColumns[0].id, "QUnitTest-idRandomDataTable-idName", "0 Name");
+		assert.strictEqual(oPersData.aColumns[1].id, "QUnitTest-idRandomDataTable-idColor", "1 Color");
+		assert.strictEqual(oPersData.aColumns[2].id, "QUnitTest-idRandomDataTable-idNumber", "2 Number");
+
+		assert.strictEqual(oPersData.aColumns[0].visible, true, "0 Name ON");
+		assert.strictEqual(oPersData.aColumns[1].visible, true, "1 Color ON");
+		assert.strictEqual(oPersData.aColumns[2].visible, true, "2 Number ON");
+
+		assert.strictEqual(oPersData.aColumns[0].width, "20em", "0 Width");
+
+		// Close dialog with "Cancel"
+		oCore.byId(oTPD._oDialog.getRightButton()).firePress();
+
+	});
+
+});

--- a/src/sap.m/test/sap/m/qunit/testsuite.mobile.qunit.js
+++ b/src/sap.m/test/sap/m/qunit/testsuite.mobile.qunit.js
@@ -1539,6 +1539,9 @@ sap.ui.define([
 					animationMode: "none"
 				}
 			},
+			TablePersoControllerExtended: {
+				title: "QUnit Page for sap.m.TablePersoDialog - Extended"
+			},
 			TableSelectDialog: {
 				title: "QUnit Page for sap.m.TableSelectDialog",
 				sinon: {


### PR DESCRIPTION
In a project I am using a sap.m.Table together with a sap.m.TablePersoController and the SmartVariantManagement.
Unfortunately the TablePersoController does not  save the width of a column. 
Since I added the ColumnResizer as well, it would be beneficial for the users to store the set width of a column as well.

Therefore I added the width of a column to the personalization save but it is only saved, if this is set explicitly to ensure compability.