### PR TITLE
refactor: deepClone with std API structuredClone

### DIFF
--- a/src/sap.ui.core/src/sap/base/util/deepClone.js
+++ b/src/sap.ui.core/src/sap/base/util/deepClone.js
@@ -49,12 +49,13 @@ sap.ui.define(["./isPlainObject"], function(isPlainObject) {
 	 * @param {int} [maxDepth=10] Maximum recursion depth for the clone operation, deeper structures will throw an error
 	 * @returns {any} A clone of the source value
 	 * @throws {TypeError} When a non-plain object is encountered or when the max structure depth is exceeded
+	 * @deprecated as of version XXX. Use the standard API <code>structuredClone</code> instead.
 	 */
 	var fnDeepClone = function(src, maxDepth) {
 		if (!maxDepth) {
 			maxDepth = 10;
 		}
-		return clone(src, 0, maxDepth);
+		return structuredClone ? structuredClone(src) : clone(src, 0, maxDepth);
 	};
 
 	function clone(src, depth, maxDepth) {


### PR DESCRIPTION
The idea here is to deprecate `sap/base/util/deepClone` and replace it with the standard js API `structuredClone`.

`deepClone` is limited to a few types and doesn't support circular reference.

The first step, done in this PR, simply returns `structuredClone` from `deepClone` when available. No changes are required in the code using `deepClone`.

The next step, at some point in the future, replaces `deepClone` with `structuredClone` and removes `sap/base/util/deepClone` from the codebase. The `sap/base/util/deepClone.js` file shouldn't be deleted to avoid breaking custom code using it.