### PR TITLE
Fixes https://github.com/SAP/openui5/issues/3376

### DIFF
--- a/src/sap.m/src/sap/m/DatePicker.js
+++ b/src/sap.m/src/sap/m/DatePicker.js
@@ -421,6 +421,9 @@ sap.ui.define([
 			} else {
 				_open.call(this);
 			}
+			
+			this._openByFocusIn = false;
+			this._openByClick = false;
 		}
 	};
 
@@ -532,16 +535,45 @@ sap.ui.define([
 			InputBase.prototype.applyFocusInfo.apply(this, arguments);
 		}
 
+		this._openByFocusIn = false;
+		this._openByClick = false;
 	};
 
 	DatePicker.prototype.onfocusin = function(oEvent) {
 
+		if (this._openByClick) {
+			this._openByClick = false;
+			return;
+		}
+		
 		if (!jQuery(oEvent.target).hasClass("sapUiIcon")) {
-			DateTimeField.prototype.onfocusin.apply(this, arguments);
+			
+			if (this.getValueHelpOnly()) {
+				this.toggleOpen(this._bShouldClosePicker);
+				this._openByFocusIn = true;
+			} else{
+				DateTimeField.prototype.onfocusin.apply(this, arguments);
+			}
 		}
 
 		this._bFocusNoPopup = undefined;
-
+	};
+	
+	/**
+	 * Onclick handler assures opening/closing of the numeric picker.
+	 *
+	 * @private
+	 */
+	 DatePicker.prototype.onclick = function (oEvent) {
+		if (this._openByFocusIn) {
+			this._openByFocusIn = false;
+			return;
+		}
+		
+		if (this.getValueHelpOnly()) {
+			this.toggleOpen(this._bShouldClosePicker);
+			this._openByClick = true;
+		}
 	};
 
 	DatePicker.prototype.onsapshow = function(oEvent) {

--- a/src/sap.m/src/sap/m/DatePickerRenderer.js
+++ b/src/sap.m/src/sap/m/DatePickerRenderer.js
@@ -33,12 +33,10 @@ sap.ui.define(['sap/ui/core/Renderer', './DateTimeFieldRenderer', 'sap/ui/core/l
 	 * @param {sap.m.DatePicker} oDP An object representation of the control that should be rendered.
 	 */
 	DatePickerRenderer.writeInnerAttributes = function(oRm, oDP) {
+		
+		DateTimeFieldRenderer.writeInnerAttributes.apply(this, arguments);
+		
 		oRm.attr("type", "text");
-
-		if (oDP._bMobile) {
-			// prevent keyboard in mobile devices
-			oRm.attr("readonly", "readonly");
-		}
 	};
 
 	DatePickerRenderer.getAccessibilityState = function(oDP) {

--- a/src/sap.m/src/sap/m/DateTimeField.js
+++ b/src/sap.m/src/sap/m/DateTimeField.js
@@ -20,6 +20,7 @@ sap.ui.define([
 	"sap/ui/core/Configuration",
 	'sap/ui/core/date/UI5Date',
 	'sap/ui/unified/calendar/CalendarUtils',
+	'sap/ui/Device',
 	// jQuery Plugin "cursorPos"
 	"sap/ui/dom/jquery/cursorPos"
 ], function(
@@ -38,7 +39,8 @@ sap.ui.define([
 	jQuery,
 	Configuration,
 	UI5Date,
-	CalendarUtils
+	CalendarUtils,
+	Device
 ) {
 	"use strict";
 
@@ -110,7 +112,13 @@ sap.ui.define([
 				 * </ul>
 				 * @since 1.54
 				 */
-				initialFocusedDateValue: {type: "object", group: "Data", defaultValue: null}
+				initialFocusedDateValue: {type: "object", group: "Data", defaultValue: null},
+				
+				/**
+				 * If set to true, direct text input is disabled.
+				 * @since 
+				 */
+				valueHelpOnly : {type : "boolean", group : "Behavior", defaultValue : false}
 			},
 			events : {
 
@@ -620,6 +628,27 @@ sap.ui.define([
 		}
 
 		return sText;
+	};
+	
+	/**
+	 * Returns whether the icon for opening the clock picker is clicked or not.
+	 *
+	 * @private
+	 * @returns {boolean} true if the icon is clicked.
+	 */
+	 DateTimeField.prototype._isIconClicked = function (oEvent) {
+		return jQuery(oEvent.target).hasClass("sapUiIcon") || jQuery(oEvent.target).hasClass("sapMInputBaseIconContainer")
+			 || jQuery(oEvent.target).hasClass("sapUiIconTitle");
+	};
+	
+	/**
+	 * Returns whether the device is mobile or not.
+	 *
+	 * @private
+	 * @returns {boolean} true if the device is mobile.
+	 */
+	 DateTimeField.prototype._isMobileDevice = function() {
+		return !Device.system.desktop && (Device.system.phone || Device.system.tablet);
 	};
 
 	return DateTimeField;

--- a/src/sap.m/src/sap/m/DateTimeFieldRenderer.js
+++ b/src/sap.m/src/sap/m/DateTimeFieldRenderer.js
@@ -24,6 +24,19 @@ sap.ui.define(['sap/ui/core/Renderer', './InputBaseRenderer'], function(Renderer
 	DateTimeFieldRenderer.getAriaRole = function (oControl) {
 		return "";
 	};
+	
+	/**
+	 * add extra attributes to Picker's Input
+	 *
+	 * @overrides sap.m.InputBaseRenderer.writeInnerAttributes
+	 * @param {sap.ui.core.RenderManager} oRm the RenderManager that can be used for writing to the render output buffer
+	 * @param {sap.m.DateTimeField} oControl an object representation of the control that should be rendered
+	 */
+	DateTimeFieldRenderer.writeInnerAttributes = function (oRm, oControl) {
+		if (oControl._isMobileDevice() || oControl.getValueHelpOnly()) {
+			oRm.attr("readonly", "readonly"); // readonly for mobile devices
+		}
+	};	
 
 	return DateTimeFieldRenderer;
 

--- a/src/sap.m/src/sap/m/TimePicker.js
+++ b/src/sap.m/src/sap/m/TimePicker.js
@@ -545,7 +545,7 @@ function(
 				oNumericPicker = this._getNumericPicker(),
 				bOpen = oNumericPicker && oNumericPicker.isOpen();
 
-			if (!this._isMobileDevice()) {
+			if (!this._isMobileDevice() && !this.getValueHelpOnly()) {
 				DateTimeField.prototype.onfocusin.apply(this, arguments);
 				MaskEnabler.onfocusin.apply(this, arguments);
 			}
@@ -557,6 +557,12 @@ function(
 				this._openByClick = false;
 				return;
 			}
+			
+			if(this.getValueHelpOnly()){
+				this.toggleOpen(false);
+				return;
+			}
+			
 			if (!this._isMobileDevice()) {
 				return;
 			}
@@ -565,7 +571,7 @@ function(
 			}
 			this._openByFocusIn = true;
 		};
-
+		
 		/**
 		 * Onclick handler assures opening/closing of the numeric picker.
 		 *
@@ -580,6 +586,12 @@ function(
 				this._openByFocusIn = false;
 				return;
 			}
+			
+			if(this.getValueHelpOnly()){
+				this.toggleOpen(false);
+				return;
+			}
+			
 			if (!this._isMobileDevice()) {
 				return;
 			}
@@ -587,17 +599,6 @@ function(
 				this.toggleNumericOpen(bOpen);
 			}
 			this._openByClick = true;
-		};
-
-		/**
-		 * Returns whether the icon for opening the clock picker is clicked or not.
-		 *
-		 * @private
-		 * @returns {boolean} true if the icon is clicked.
-		 */
-		 TimePicker.prototype._isIconClicked = function (oEvent) {
-			return jQuery(oEvent.target).hasClass("sapUiIcon") || jQuery(oEvent.target).hasClass("sapMInputBaseIconContainer")
-				 || jQuery(oEvent.target).hasClass("sapUiIconTitle");
 		};
 
 		/**
@@ -658,16 +659,6 @@ function(
 			this.$().removeClass(InputBase.ICON_PRESSED_CSS_CLASS);
 			this._getClocks().showFirstClock(); // prepare for the next opening
 			this.fireAfterValueHelpClose();
-		};
-
-		/**
-		 * Returns whether the device is mobile or not.
-		 *
-		 * @private
-		 * @returns {boolean} true if the device is mobile.
-		 */
-		 TimePicker.prototype._isMobileDevice = function() {
-			return !Device.system.desktop && (Device.system.phone || Device.system.tablet);
 		};
 
 		/**

--- a/src/sap.m/src/sap/m/TimePickerRenderer.js
+++ b/src/sap.m/src/sap/m/TimePickerRenderer.js
@@ -87,9 +87,9 @@ sap.ui.define(['sap/ui/core/Renderer', './DateTimeFieldRenderer', 'sap/ui/core/l
 		 * @param {sap.m.TimePicker} oControl an object representation of the control that should be rendered
 		 */
 		TimePickerRenderer.writeInnerAttributes = function (oRm, oControl) {
-			if (oControl._isMobileDevice()) {
-				oRm.attr("readonly", "readonly"); // readonly for mobile devices
-			}
+			
+			DateTimeFieldRenderer.writeInnerAttributes.apply(this, arguments);
+			
 			if (oControl.getShowValueStateMessage()) {
 				oRm.attr("autocomplete", "off"); // autocomplete="off" needed so the native browser autocomplete is not shown?
 			}

--- a/src/sap.m/test/sap/m/DatePicker.html
+++ b/src/sap.m/test/sap/m/DatePicker.html
@@ -230,6 +230,8 @@
 					change: handleChange
 				}),
 				new sap.m.DatePicker("DP16"),
+				new sap.m.Label({text: "DatePicker, valueHelpOnly", labelFor: "DP17"}),
+				new sap.m.DatePicker("DP17", { fieldGroupIds: ["group1"], valueHelpOnly : true }),
 				new sap.m.Button("btnEtcGMT-12", {
 					text: "Etc/GMT-12",
 					press: handleTimezoneButtonPress

--- a/src/sap.m/test/sap/m/DateTimePicker.js
+++ b/src/sap.m/test/sap/m/DateTimePicker.js
@@ -186,7 +186,9 @@ sap.ui.define([
 			new Label({text: "DateTimePicker events display", labelFor: "I2"}),
 			new Input("I2", {value: "Content of events DateTimePicker", editable: false}),
 			new Label({text: "DateTimePicker with minutesStep: 3, secondsStep: 5", labelFor: "DP9"}),
-			new DateTimePicker("DP9", { minutesStep: 3, secondsStep: 5 })
+			new DateTimePicker("DP9", { minutesStep: 3, secondsStep: 5 }),
+			new Label({text: "DateTimePicker - valueHelpOnly", labelFor: "DTP10"}),
+			new DateTimePicker("DTP10", { fieldGroupIds: ["group1"], valueHelpOnly : true }),
 		],
 		footer: createFooter()
 	});

--- a/src/sap.m/test/sap/m/TimePicker.html
+++ b/src/sap.m/test/sap/m/TimePicker.html
@@ -138,6 +138,11 @@
 				displayFormat: "HH:mm:ss",
 				support2400: true,
 				value: "24:00:00"
+			},
+			{
+				id: "TP21",
+				displayFormat: "HH:mm:ss",
+				valueHelpOnly : true
 			}
 		];
 


### PR DESCRIPTION
It fixes the issue 3376, providing a new property (valueHelpOnly) for the all DateTimeField-based pickers: DatePicker, TimePicker and DateTimePicker.

When the property is true, the manual input on the control is blocked and any click on it will open the picker. 