### PR TITLE
Feature message box extendable action

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
 		"es6": true
 	},
 	"parserOptions": {
-		"ecmaVersion": 5,
+		"ecmaVersion": 6,
 		"sourceType": "script"
 	},
 	"globals": {

--- a/src/sap.m/src/sap/m/MessageBox.js
+++ b/src/sap.m/src/sap/m/MessageBox.js
@@ -166,6 +166,21 @@ sap.ui.define([
 	};
 
 	/**
+	 * An Extended action is a class holding an action plus the metadata related to the action
+	 *
+	 * @param {string} action or custom action that is extended
+	 * @param {object} actionMetaData that describes metadata about the action e.g. id
+	 *
+	 * @public
+	 */
+	MessageBox.ExtendedAction = class ExtendedAction {
+		constructor(action, actionMetaData){
+			this.action = action;
+			this.id = actionMetaData.id;
+		}
+	};
+
+	/**
 	 * Enumeration of the pre-defined icons that can be used in a MessageBox.
 	 * @enum {string}
 	 * @public
@@ -480,24 +495,42 @@ sap.ui.define([
 		}
 
 		/** creates a button for the given action */
-		function button(sAction, sButtonType) {
+		function button(action, sButtonType) {
 			var sText;
+			const extendedAction = extendAction(action);
 
 			// Don't check in ResourceBundle library if the button is with custom text
-			if (MessageBox.Action.hasOwnProperty(sAction)) {
-				sText = MessageBox._rb.getText("MSGBOX_" + sAction);
+			if (MessageBox.Action.hasOwnProperty(extendedAction.action)) {
+				sText = MessageBox._rb.getText("MSGBOX_" + extendedAction.action);
 			}
 
 			var oButton = new Button({
-				id: ElementMetadata.uid("mbox-btn-"),
-				text: sText || sAction,
+				id: extendedAction.id,
+				text: sText || extendedAction.action,
 				type: sButtonType,
 				press: function () {
-					oResult = sAction;
+					oResult = extendedAction.action;
 					oDialog.close();
 				}
 			});
 			return oButton;
+		}
+
+		/**
+		 * Takes an action / custom action (string value) or an already extended action and extends further by adding default metadata values where no metadata values are defined
+		 *
+		 * @param {string | sap.m.MessageBox.ExtendedAction} action can be either an already extended or a not extended action
+		 * @return {sap.m.MessageBox.ExtendedAction} extendedAction will contain default values where no values have been defined yet
+		 * */
+		function extendAction(action) {
+			const defaultActionMetadata = {
+				id: ElementMetadata.uid("mbox-btn-")
+			};
+			if (action instanceof MessageBox.ExtendedAction){
+				return jQuery.extend(new MessageBox.ExtendedAction(null, defaultActionMetadata), action);
+			} else {
+				return new MessageBox.ExtendedAction(action, defaultActionMetadata);
+			}
 		}
 
 		var sButtonType;

--- a/src/sap.m/test/sap/m/MessageBox.html
+++ b/src/sap.m/test/sap/m/MessageBox.html
@@ -128,6 +128,23 @@
 		}));
 
 		oVL.addContent(new sap.m.Button({
+			text: "Extended Action",
+			width: "270px",
+			ariaHasPopup: sap.ui.core.aria.HasPopup.Dialog,
+			press: function () {
+				sap.m.MessageBox.confirm("Initial button focus is set by attribute \n initialFocus: sap.m.MessageBox.Action.CANCEL", {
+					onClose: function (bConfirmed) {
+						jQuery.sap.log.info("Dialog is confirmed with" + bConfirmed);
+					},
+					icon: sap.m.MessageBox.Icon.INFORMATION,
+					title: "Set initial button focus",
+					actions: [new sap.m.MessageBox.ExtendedAction(sap.m.MessageBox.Action.YES, {id: 'testId1'}), new sap.m.MessageBox.ExtendedAction('NO', {id: 'testId2'})],
+					initialFocus: sap.m.MessageBox.Action.CANCEL
+				});
+			}
+		}));
+
+		oVL.addContent(new sap.m.Button({
 			text: "Custom button text",
 			width: "270px",
 			ariaHasPopup: sap.ui.core.aria.HasPopup.Dialog,

--- a/src/sap.m/test/sap/m/qunit/MessageBox.qunit.js
+++ b/src/sap.m/test/sap/m/qunit/MessageBox.qunit.js
@@ -276,6 +276,35 @@ sap.ui.define([
 		oMessageBox.destroy();
 	});
 
+	QUnit.test("extended action should contain custom id", function (assert) {
+		var oMessageBox, $TextArea,
+			sTextAreaId = "myTextArea",
+			oTextArea = new TextArea(sTextAreaId, {
+				value: sMessageText
+			});
+
+		MessageBox.show(oTextArea, {
+			title: sMessageTitle,
+			actions: [new MessageBox.ExtendedAction(MessageBox.Action.OK, {id: 'customId'}), MessageBox.Action.NO, "Custom Text"],
+			onClose: callback.bind(this, assert),
+			id: "messagebox1",
+			styleClass: sClassName
+		});
+		oCore.applyChanges();
+		oMessageBox = oCore.byId("messagebox1");
+		const extendedAction = oCore.byId("customId");
+		assert.equal(extendedAction.getId(), "customId");
+		assert.ok(oMessageBox, "Dialog should be created");
+		assert.equal(oMessageBox.getType(), DialogType.Message, "Dialog should have type Message");
+		assert.equal(oMessageBox.getButtons().length, 3, "All three buttons are added to dialog");
+		assert.equal(oMessageBox.getTitle(), sMessageTitle, "Title is assigned");
+		assert.ok(oMessageBox.$().hasClass(sClassName));
+		$TextArea = oCore.byId(sTextAreaId).$();
+		assert.equal($TextArea.length, 1, "TextArea should be created");
+
+		oMessageBox.destroy();
+	});
+
 	QUnit.test("show error", function (assert) {
 		var oResourceBundle = oCore.getLibraryResourceBundle("sap.m");
 		MessageBox.error(sMessageText, {


### PR DESCRIPTION
# Feature

In order to give the user the possibility to add metadata to a MessageBoxAction this feature introduces a new action type MessageBoxExtendedAction. This allows the user to give actions e.g. id's and make them directly selectable by a testing framework like wdi5. 

## Implementation

* To ensure downwards compatibility the old Actions can be used as before
* To add metadata the old actions can be optionally extended by wrapping them with the new ExtendedAction using composition to enable a loosely coupling
* To ensure future metadata extensions the metadata is defined as a generic object
* To ensure an intuitive usage for the user polymorphism is implemented and the user can pass an ExtendedAction the same way to the action list as an old Action

## Remarks

* To ensure esLint doesn't mark the class keyword (used in this PR) as reserved keyword the ecmaVersion got updated from 5 to 6