### PR TITLE
Update RowSettings.js

### DIFF
--- a/src/sap.ui.table/src/sap/ui/table/RowSettings.js
+++ b/src/sap.ui.table/src/sap/ui/table/RowSettings.js
@@ -67,7 +67,10 @@ sap.ui.define([
 				 *
 				 * @since 1.72
 				 */
-				navigated: {type: "boolean", group: "Appearance", defaultValue: false}
+				navigated: {type: "boolean", group: "Appearance", defaultValue: false},
+
+				// the text to be shown in the browser tooltip. If not set, default SAP tooltip is applied. If set to empty string, no tooltip is shown.
+				title: {type: "string", defaultValue: ""}
 			}
 		}
 	});
@@ -177,6 +180,24 @@ sap.ui.define([
 
 		return this;
 	};
+
+	// set title property to the control and title attribute to the highlight div
+	RowSettings.prototype.setTitle = function (sTitle) {
+        	var oRow;
+        	var oHighlightElement;
+        	this.setProperty("title", sTitle, true);
+        	oRow = this._getRow();
+        	if (!oRow) {
+            		return this;
+        	}
+        	oHighlightElement = oRow.getDomRef("highlight");
+        	if (!oHighlightElement) {
+            		return this;
+        	}
+        	oHighlightElement.title = sTitle;
+
+        	return this;
+    	};
 
 	/**
 	 * Gets the css class name representation for the current highlight state.


### PR DESCRIPTION
[FEATURE] sap.ui.table.RowSettings: title added to be shown as browser tooltip

- although in documentation tooltip is listed as aggregation of RowSettings, it is not part of the control definition and there is no functionality for showing a tooltip on the highlight div. (showing the reason for highlighting for example) 

- Now browser tooltip can be shown when hovering on the highlight div.
 
- Added property 'title' to be used to set the title attribute of the rendered div.