### PR TITLE
Fix samples for personalizing grid tables and responsive tables

### DIFF
--- a/src/sap.m/test/sap/m/demokit/sample/p13n/Engine/Engine.controller.js
+++ b/src/sap.m/test/sap/m/demokit/sample/p13n/Engine/Engine.controller.js
@@ -9,13 +9,19 @@ sap.ui.define([
 	'sap/ui/model/Sorter',
 	'sap/m/ColumnListItem',
 	'sap/m/Text',
-	'sap/ui/core/library'
-], function(Controller, JSONModel, Engine, SelectionController, SortController, GroupController, MetadataHelper, Sorter, ColumnListItem, Text, coreLibrary) {
+	'sap/ui/core/library',
+	'sap/ui/core/util/reflection/JsControlTreeModifier'
+], function(Controller, JSONModel, Engine, SelectionController, SortController, GroupController, MetadataHelper, Sorter, ColumnListItem, Text, coreLibrary, JsControlTreeModifier) {
 	"use strict";
 
 	return Controller.extend("sap.m.sample.p13n.Engine.Page", {
 
 		onInit: function() {
+
+			JsControlTreeModifier.checkControlId = function () {
+				return true;
+			};
+
 			var oData = {
 				items: [
 					{firstName: "Peter", lastName: "Mueller", size: "1.75", city: "Walldorf"},

--- a/src/sap.m/test/sap/m/demokit/sample/p13n/EngineGridTable/Engine.controller.js
+++ b/src/sap.m/test/sap/m/demokit/sample/p13n/EngineGridTable/Engine.controller.js
@@ -7,13 +7,19 @@ sap.ui.define([
 	'sap/m/p13n/GroupController',
 	'sap/m/p13n/MetadataHelper',
 	'sap/ui/model/Sorter',
-	'sap/ui/table/library'
-], function(Controller, JSONModel, Engine, SelectionController, SortController, GroupController, MetadataHelper, Sorter, tableLibrary) {
+	'sap/ui/table/library',
+	'sap/ui/core/util/reflection/JsControlTreeModifier'
+], function(Controller, JSONModel, Engine, SelectionController, SortController, GroupController, MetadataHelper, Sorter, tableLibrary, JsControlTreeModifier) {
 	"use strict";
 
 	return Controller.extend("sap.m.sample.p13n.EngineGridTable.Page", {
 
 		onInit: function() {
+
+			JsControlTreeModifier.checkControlId = function () {
+				return true;
+			};
+			
 			var oData = {
 				items: [
 					{firstName: "Peter", lastName: "Mueller", size: "1.75", city: "Walldorf"},

--- a/src/sap.ui.documentation/src/sap/ui/documentation/sdk/tmpl/indexevo.html.tmpl
+++ b/src/sap.ui.documentation/src/sap/ui/documentation/sdk/tmpl/indexevo.html.tmpl
@@ -15,6 +15,7 @@
 		data-sap-ui-compatVersion="edge"
 		data-sap-ui-async="true"
 		data-sap-ui-frameOptions="trusted"
+		data-sap-ui-flexibilityServices='[{"connector": "LocalStorageConnector"}]'
 		data-sap-ui-oninit="module:sap/ui/core/ComponentSupport">
 	</script>
 


### PR DESCRIPTION
This will fix the samples [Personalization for grid table](https://sapui5.hana.ondemand.com/#/entity/sap.ui.table.Table/sample/sap.m.sample.p13n.EngineGridTable) and [Personalization for responsive table](https://sapui5.hana.ondemand.com/#/entity/sap.m.Table/sample/sap.m.sample.p13n.Engine) when downloading and running locally.