### PR TITLE
chore: Eslint cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ src/sap.ui.documentation/src/sap/ui/documentation/sdk/model/data/guide/
 .reuse/spdx.txt
 .reuse/dep5_test
 .reuse/THIRDPARTY_test.txt
+
+# Ignore eslint cache file
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build-sdk": "npm run build-sdk --workspace src/testsuite",
     "serve-sdk": "npm run serve-sdk --workspace src/testsuite",
     "test": "npm run lint",
-    "lint": "eslint ./src --quiet",
+    "lint": "eslint ./src --quiet --cache",
     "link-all": "wsrun --serial link",
     "unlink-all": "wsrun --serial unlink",
     "karma": "karma start lib/test/karma.conf.js",


### PR DESCRIPTION
Due to the project size, running ESLint `npm run lint` takes too long. I've added the option to cache the results and speed up the process on subsequent runs as it'd only consider changed files.

This will likely have no performance improvements on CI/CD as the cache file is not pushed to git. It impacts only local development, bringing 

The first run shows the top 10 slowest rules and the time taken:
<img width="329" alt="image" src="https://github.com/SAP/openui5/assets/443888/a30fcff6-b076-4e89-90aa-15fa4dfae124">

`.eslintcache` file is created. Change some files and run `npm run lint` again.
<img width="91" alt="image" src="https://github.com/SAP/openui5/assets/443888/8f7d983d-75b7-4f26-a10b-c8e04187ff65">

The second run shows the top 10 slowest rules and the time taken:
<img width="378" alt="image" src="https://github.com/SAP/openui5/assets/443888/9bb63999-d2ae-461f-b321-88c0262317f5">
