### PR TITLE
refactor: Replace innerHTML by textContent

### DIFF
--- a/src/sap.m/src/sap/m/TimePickerSlider.js
+++ b/src/sap.m/src/sap/m/TimePickerSlider.js
@@ -977,8 +977,8 @@ sap.ui.define([
 			$aItems.eq(this._iSelectedItemIndex).addClass("sapMTimePickerItemSelected");
 			//WAI-ARIA region
 			oDescriptionElement = this.getDomRef("valDescription");
-			if (oDescriptionElement.innerHTML !== sAriaLabel) {
-				oDescriptionElement.innerHTML = sAriaLabel;
+			if (oDescriptionElement.textContent !== sAriaLabel) {
+				oDescriptionElement.textContent = sAriaLabel;
 			}
 		};
 


### PR DESCRIPTION
`innerHTML` operations are unsafe and slow (especially inside a loop), `textContent` is preferred whenever possible.

Similar to this previous issue: https://github.com/SAP/openui5/pull/2875

Splitting into 2 PRs as requested: https://github.com/SAP/openui5/pull/3821#issuecomment-1680097104