### PR TITLE
fix return type of `Metadata.getParent`

### DIFF
--- a/src/sap.ui.core/src/sap/ui/base/Metadata.js
+++ b/src/sap.ui.core/src/sap/ui/base/Metadata.js
@@ -181,9 +181,9 @@ sap.ui.define([
 
 	/**
 	 * Returns the metadata object of the base class of the described class
-	 * or null if the class has no (documented) base class.
+	 * or undefined if the class has no (documented) base class.
 	 *
-	 * @return {sap.ui.base.Metadata} metadata of the base class
+	 * @return {sap.ui.base.Metadata | undefined} metadata of the base class
 	 * @public
 	 */
 	Metadata.prototype.getParent = function() {


### PR DESCRIPTION
fixes #3849 