### PR TITLE
[FIX] `sap.ui.layout.VerticalLayout`: Skip rendering of wrapper tags for invisible child controls

### DIFF
--- a/src/sap.ui.layout/src/sap/ui/layout/VerticalLayoutRenderer.js
+++ b/src/sap.ui.layout/src/sap/ui/layout/VerticalLayoutRenderer.js
@@ -40,6 +40,10 @@ sap.ui.define([],
 		var aContent = oVerticalLayout.getContent();
 
 		for ( var i = 0; i < aContent.length; i++) {
+			// skip invisible controls
+			if(!aContent[i].getVisible()) {
+				continue;
+			}
 			// for compatibility keep the old, wrong class name
 			rm.openStart("div");
 			rm.class("sapUiVltCell");


### PR DESCRIPTION
fixes #3848 