### PR TITLE
refactor: Getting rid of jQuery in sap.f

### DIFF
--- a/src/sap.f/src/sap/f/AvatarGroup.js
+++ b/src/sap.f/src/sap/f/AvatarGroup.js
@@ -255,13 +255,14 @@ sap.ui.define([
 			this._onResize();
 		}
 
-		if (this._shouldShowMoreButton()) {
-			this._oShowMoreButton.$().attr("role", "button");
+		if (this._shouldShowMoreButton() && this._oShowMoreButton.getDomRef()) {
+			var domRef = this._oShowMoreButton.getDomRef();
+			domRef.setAttribute("role", "button");
 
 			if (this.getGroupType() === AvatarGroupType.Group) {
-				this._oShowMoreButton.$().attr("tabindex", "-1");
+				domRef.setAttribute("tabindex", "-1");
 			} else {
-				this._oShowMoreButton.$().attr("aria-label", this._getResourceBundle().getText("AVATARGROUP_POPUP"));
+				domRef.setAttribute("aria-label", this._getResourceBundle().getText("AVATARGROUP_POPUP"));
 			}
 		}
 
@@ -287,7 +288,7 @@ sap.ui.define([
 			sPopupMessage = oResourceBundle.getText("AVATARGROUP_POPUP");
 
 		if (this.getGroupType() === AvatarGroupType.Group) {
-			this.$().attr("aria-label", sPopupMessage + " " + sBaseMessage);
+			this.getDomRef().setAttribute("aria-label", sPopupMessage + " " + sBaseMessage);
 		}
 	};
 
@@ -542,7 +543,7 @@ sap.ui.define([
 	 * @private
 	 */
 	AvatarGroup.prototype._getWidth = function () {
-		return Math.ceil(this.$().width());
+		return Math.ceil(this.getDomRef().clientWidth);
 	};
 
 	/**
@@ -559,7 +560,7 @@ sap.ui.define([
 			iAvatarWidth = this._getAvatarWidth(sAvatarDisplaySize),
 			iAvatarMargin = this._getAvatarMargin(sAvatarDisplaySize),
 			iAvatarNetWidth = this._getAvatarNetWidth(iAvatarWidth, iAvatarMargin),
-			iRenderedAvatars = this.$().children(".sapFAvatarGroupItem").length;
+			iRenderedAvatars = this.getDomRef().querySelectorAll(".sapFAvatarGroupItem").length;
 
 		if (iWidth === 0) {
 			return;

--- a/src/sap.f/src/sap/f/CalendarAppointmentInCard.js
+++ b/src/sap.f/src/sap/f/CalendarAppointmentInCard.js
@@ -54,10 +54,10 @@ sap.ui.define([
 
 	CalendarAppointmentInCard.prototype._firePress = function() {
 		if (this.getClickable()) {
-			this.$().addClass("sapUiCalendarAppSel");
+			this.addStyleClass("sapUiCalendarAppSel");
 			setTimeout(function() {
 				// remove active state
-				this.$().removeClass("sapUiCalendarAppSel");
+				this.removeStyleClass("sapUiCalendarAppSel");
 			}.bind(this), 180);
 			this.firePress({});
 		}

--- a/src/sap.f/src/sap/f/DynamicPageHeader.js
+++ b/src/sap.f/src/sap/f/DynamicPageHeader.js
@@ -173,7 +173,7 @@ sap.ui.define([
 		 * @private
 		 */
 		DynamicPageHeader.prototype._setShowPinBtn = function (bValue) {
-			this._getPinButton().$().toggleClass("sapUiHidden", !bValue);
+			this._getPinButton().toggleStyleClass("sapUiHidden", !bValue);
 		};
 
 		/**
@@ -214,9 +214,7 @@ sap.ui.define([
 		 * @private
 		 */
 		DynamicPageHeader.prototype._initARIAState = function () {
-			var $header = this.$();
-
-			$header.attr(DynamicPageHeader.ARIA.ARIA_LABEL, DynamicPageHeader.ARIA.LABEL_EXPANDED);
+			this.getDomRef()?.setAttribute?.(DynamicPageHeader.ARIA.ARIA_LABEL, DynamicPageHeader.ARIA.LABEL_EXPANDED);
 		};
 
 		/**
@@ -224,11 +222,8 @@ sap.ui.define([
 		 * @private
 		 */
 		DynamicPageHeader.prototype._initPinButtonARIAState = function () {
-			var $pinButton;
-
-			if (this.getPinnable()) {
-				$pinButton = this._getPinButtonJQueryRef();
-				$pinButton.attr(DynamicPageHeader.ARIA.ARIA_CONTROLS, this.getId());
+			if (this.getPinnable() && this._getPinButton() && this._getPinButton().getDomRef()) {
+				this._getPinButton().getDomRef().setAttribute(DynamicPageHeader.ARIA.ARIA_CONTROLS, this.getId());
 			}
 		};
 
@@ -238,12 +233,11 @@ sap.ui.define([
 		 * @private
 		 */
 		DynamicPageHeader.prototype._updateARIAState = function (bExpanded) {
-			var $header = this.$();
+			var header = this.getDomRef();
+			var ariaLabel = bExpanded ? DynamicPageHeader.ARIA.LABEL_EXPANDED : DynamicPageHeader.ARIA.LABEL_COLLAPSED;
 
-			if (bExpanded) {
-				$header.attr(DynamicPageHeader.ARIA.ARIA_LABEL, DynamicPageHeader.ARIA.LABEL_EXPANDED);
-			} else {
-				$header.attr(DynamicPageHeader.ARIA.ARIA_LABEL, DynamicPageHeader.ARIA.LABEL_COLLAPSED);
+			if (header) {
+				header.setAttribute(DynamicPageHeader.ARIA.ARIA_LABEL, ariaLabel);
 			}
 		};
 
@@ -332,16 +326,7 @@ sap.ui.define([
 		 * @private
 		 */
 		DynamicPageHeader.prototype._focusPinButton = function () {
-			this._getPinButtonJQueryRef().trigger("focus");
-		};
-
-		/**
-		 * Returns the <code>DynamicPageHeader</code> pin/unpin button DOM Ref.
-		 * @return {jQuery}
-		 * @private
-		 */
-		DynamicPageHeader.prototype._getPinButtonJQueryRef = function () {
-			return this._getPinButton().$();
+			this._getPinButton().$().trigger("focus");
 		};
 
 		/**

--- a/src/sap.f/src/sap/f/DynamicPageTitle.js
+++ b/src/sap.f/src/sap/f/DynamicPageTitle.js
@@ -749,16 +749,16 @@ sap.ui.define([
 	DynamicPageTitle.prototype._cacheDomElements = function () {
 		this.$topNavigationActionsArea = this.$("topNavigationArea");
 		this.$mainNavigationActionsArea = this.$("mainNavigationArea");
-		this.$beginArea = this.$("left-inner");
-		this.$topArea = this.$("top");
-		this.$mainArea = this.$("main");
-		this.$middleArea = this.$("content");
-		this.$snappedTitleOnMobileWrapper = this.$("snapped-title-on-mobile-wrapper");
-		this.$snappedHeadingWrapper = this.$("snapped-heading-wrapper");
-		this.$expandHeadingWrapper = this.$("expand-heading-wrapper");
-		this.$snappedWrapper = this.$("snapped-wrapper");
-		this.$expandWrapper = this.$("expand-wrapper");
 		this._$focusSpan = this.$("focusSpan");
+		this._beginAreaDom = this.getDomRef("left-inner");
+		this._topAreaDom = this.getDomRef("top");
+		this._mainAreaDom = this.getDomRef("main");
+		this._middleAreaDom = this.getDomRef("content");
+		this._snappedTitleOnMobileWrapperDom = this.getDomRef("snapped-title-on-mobile-wrapper");
+		this.snappedHeadingWrapperDom = this.getDomRef("snapped-heading-wrapper");
+		this.expandHeadingWrapperDom = this.getDomRef("expand-heading-wrapper");
+		this.snappedWrapperDom = this.getDomRef("snapped-wrapper");
+		this.expandWrapperDom = this.getDomRef("expand-wrapper");
 	};
 
 	/**
@@ -820,14 +820,14 @@ sap.ui.define([
 	 * @private
 	 */
 	DynamicPageTitle.prototype._toggleFocusableState = function (bFocusable) {
-		var $oTitleFocusSpan;
+		var oTitleFocusSpanDom;
 
 		this._bIsFocusable = bFocusable;
 
-		$oTitleFocusSpan = this._getFocusSpan();
+		oTitleFocusSpanDom = this.getFocusDomRef();
 
-		if ($oTitleFocusSpan) {
-			bFocusable ? $oTitleFocusSpan.show() : $oTitleFocusSpan.hide();
+		if (oTitleFocusSpanDom) {
+			oTitleFocusSpanDom.style.display = bFocusable ? "" : "none";
 		}
 	};
 
@@ -957,12 +957,11 @@ sap.ui.define([
 			bHasVisibleBreadcrumbs = this.getBreadcrumbs() && this.getBreadcrumbs().getVisible(),
 			bHasVisibleSnappedTitleOnMobile = Device.system.phone && this.getSnappedTitleOnMobile() && !this._bExpandedState,
 			bShouldShowTopArea = (bHasVisibleBreadcrumbs || bNavigationActionsShouldBeInTopArea) && !bHasVisibleSnappedTitleOnMobile,
-			bShouldChangeNavigationActionsPlacement = this.getNavigationActions().length > 0 && (bNavigationActionsShouldBeInTopArea ^ bNavigationActionsAreInTopArea),
-			$topArea = this.$topArea;
+			bShouldChangeNavigationActionsPlacement = this.getNavigationActions().length > 0 && (bNavigationActionsShouldBeInTopArea ^ bNavigationActionsAreInTopArea);
 
 		this._toggleTopAreaVisibility(bShouldShowTopArea);
 
-		$topArea && $topArea.toggleClass("sapFDynamicPageTitleTopBreadCrumbsOnly",
+		this._topAreaDom?.classList.toggle("sapFDynamicPageTitleTopBreadCrumbsOnly",
 			bHasVisibleBreadcrumbs && !bNavigationActionsShouldBeInTopArea);
 
 		if (bShouldChangeNavigationActionsPlacement) {
@@ -1050,7 +1049,7 @@ sap.ui.define([
 	 */
 	DynamicPageTitle.prototype._toggleTopAreaVisibility = function(bShoudShowTopArea) {
 		if (this.getDomRef()) {
-			this.$("top").toggleClass("sapUiHidden", !bShoudShowTopArea);
+			this.getDomRef("top")?.classList.toggle("sapUiHidden", !bShoudShowTopArea);
 		}
 	};
 
@@ -1103,9 +1102,19 @@ sap.ui.define([
 	 * @private
 	 */
 	DynamicPageTitle.prototype._setShrinkFactors = function(fHeadingFactor, fContentFactor, fActionsFactor) {
-		this.$("left-inner").css("flex-shrink", fHeadingFactor);
-		this.$("content").css("flex-shrink", fContentFactor);
-		this.$("mainActions").css("flex-shrink", fActionsFactor);
+		var leftInnerDom = this.getDomRef("left-inner"),
+			contentDom = this.getDomRef("content"),
+			mainActions = this.getDomRef("mainActions");
+
+		if (leftInnerDom) {
+			leftInnerDom.style["flex-shrink"] = fHeadingFactor;
+		}
+		if (contentDom) {
+			contentDom.style["flex-shrink"] = fContentFactor;
+		}
+		if (mainActions) {
+			mainActions.style["flex-shrink"] = fActionsFactor;
+		}
 	};
 
 	/**
@@ -1148,19 +1157,19 @@ sap.ui.define([
 		}
 
 		if (Device.system.phone && this.getSnappedTitleOnMobile()) {
-			this.$snappedTitleOnMobileWrapper.toggleClass("sapUiHidden", bExpanded);
-			this.$topArea.toggleClass("sapUiHidden", !bExpanded);
-			this.$mainArea.toggleClass("sapUiHidden", !bExpanded);
-			this.$().toggleClass("sapContrast", !bExpanded);
+			this._snappedTitleOnMobileWrapperDom?.classList.toggle("sapUiHidden", bExpanded);
+			this._topAreaDom?.classList.toggle("sapUiHidden", !bExpanded);
+			this._mainAreaDom?.classList.toggle("sapUiHidden", !bExpanded);
+			this.toggleStyleClass("sapContrast", !bExpanded);
 		} else {
 			// Snapped heading
 			if (exists(this.getSnappedHeading())) {
-				this.$snappedHeadingWrapper.toggleClass("sapUiHidden", bExpanded);
+				this.snappedHeadingWrapperDom?.classList.toggle("sapUiHidden", bExpanded);
 			}
 
 			// Expanded heading
 			if (exists(this.getExpandedHeading())) {
-				this.$expandHeadingWrapper.toggleClass("sapUiHidden", !bExpanded);
+				this.expandHeadingWrapperDom?.classList.toggle("sapUiHidden", !bExpanded);
 			}
 
 			if (bUserInteraction && oldExpandedState !== bExpanded) {
@@ -1171,14 +1180,14 @@ sap.ui.define([
 
 		// Snapped content
 		if (exists(this.getSnappedContent())) {
-			this.$snappedWrapper.toggleClass("sapUiHidden", bExpanded);
-			this.$snappedWrapper.parent().toggleClass("sapFDynamicPageTitleMainSnapContentVisible", !bExpanded);
+			this.snappedWrapperDom?.classList.toggle("sapUiHidden", bExpanded);
+			this.snappedWrapperDom?.parentNode.classList.toggle("sapFDynamicPageTitleMainSnapContentVisible", !bExpanded);
 		}
 
 		// Expanded content
 		if (exists(this.getExpandedContent())) {
-			this.$expandWrapper.toggleClass("sapUiHidden", !bExpanded);
-			this.$expandWrapper.parent().toggleClass("sapFDynamicPageTitleMainExpandContentVisible", bExpanded);
+			this.expandWrapperDom?.classList.toggle("sapUiHidden", !bExpanded);
+			this.expandWrapperDom?.parentNode.classList.toggle("sapFDynamicPageTitleMainExpandContentVisible", bExpanded);
 		}
 	};
 
@@ -1273,11 +1282,11 @@ sap.ui.define([
 	 * @private
 	 */
 	DynamicPageTitle.prototype._getWidth = function () {
-		return this.$().outerWidth();
+		return this.getDomRef()?.offsetWidth || null;
 	};
 
 	DynamicPageTitle.prototype.getFocusDomRef = function() {
-		return this._getFocusSpan()[0] || null;
+		return this._getFocusSpan()?.[0] || null;
 	};
 
 	/**
@@ -1404,12 +1413,13 @@ sap.ui.define([
 	DynamicPageTitle.prototype._observeContentChanges = function (oChanges) {
 		var oControl = oChanges.child,
 			sMutation = oChanges.mutation,
-			$node =  oControl.$().parent();
+			nodeDom;
 
 		// Only overflow toolbar is supported as of now
 		if (!(oControl instanceof OverflowToolbar)) {
 			return;
 		}
+		nodeDom = oControl.getDomRef?.()?.parentNode;
 
 		if (sMutation === "insert") {
 			oControl.attachEvent("_contentSizeChange", this._onContentSizeChange, this);
@@ -1417,8 +1427,10 @@ sap.ui.define([
 		} else if (sMutation === "remove") {
 			oControl.detachEvent("_contentSizeChange", this._onContentSizeChange, this);
 			oControl.detachEvent("_minWidthChange", this._onContentMinWidthChange, this);
-			this._setContentAreaFlexBasis(0, $node);
-			$node.css({ "min-width": "" });
+			this._setContentAreaFlexBasis(0, nodeDom);
+			if (nodeDom) {
+				nodeDom.style["min-width"] = "";
+			}
 		}
 	};
 
@@ -1430,7 +1442,7 @@ sap.ui.define([
 	 */
 	DynamicPageTitle.prototype._onContentSizeChange = function (oEvent) {
 		var iContentSize = oEvent.getParameter("contentSize");
-		this._setContentAreaFlexBasis(iContentSize, oEvent.getSource().$().parent());
+		this._setContentAreaFlexBasis(iContentSize, oEvent.getSource().getDomRef().parentNode);
 	};
 
 	/**
@@ -1442,13 +1454,13 @@ sap.ui.define([
 		DynamicPageTitle.prototype._onContentMinWidthChange = function (oEvent) {
 		var iMinWidth = oEvent.getParameter("minWidth"),
 			sMinWidth = iMinWidth > 0 ? iMinWidth + "px" : "",
-			$node = oEvent.getSource().$().parent();
+			sourceParent = oEvent.getSource().getDomRef().parentNode;
 
-		$node.css({ "min-width": sMinWidth });
+		sourceParent.style["min-width"] = sMinWidth;
 
-		if ($node.hasClass("sapFDynamicPageTitleMainContent")) {
+		if (sourceParent.classList.contains("sapFDynamicPageTitleMainContent")) {
 			this._sContentAreaMinWidth = sMinWidth;
-		} else if ($node.hasClass("sapFDynamicPageTitleMainActions")) {
+		} else if (sourceParent.classList.contains("sapFDynamicPageTitleMainActions")) {
 			this._sActionsAreaMinWidth = sMinWidth;
 		}
 	};
@@ -1456,32 +1468,31 @@ sap.ui.define([
 	/**
 	 * Sets (if iContentSize is non-zero) or resets (otherwise) the flex-basis of the HTML element where the
 	 * content aggregation is rendered.
-	 * @param iContentSize - the total width of the overflow toolbar's overflow-enabled content (items that can overflow)
-	 * @param $node - the DOM node to which flex-basis style will be set
+	 * @param {number} iContentSize - the total width of the overflow toolbar's overflow-enabled content (items that can overflow)
+	 * @param {HTMLElement} nodeDom - the DOM node to which flex-basis style will be set
 	 * @private
 	 */
-	DynamicPageTitle.prototype._setContentAreaFlexBasis = function (iContentSize, $node) {
+	DynamicPageTitle.prototype._setContentAreaFlexBasis = function (iContentSize, nodeDom) {
 		var bAreaHasContent;
 
 		iContentSize = parseInt(iContentSize);
 		bAreaHasContent = iContentSize && iContentSize > 1;
-
-		if ($node.hasClass("sapFDynamicPageTitleMainContent")) {
+		if (nodeDom?.classList.contains("sapFDynamicPageTitleMainContent")) {
 			this._bContentAreaHasContent = bAreaHasContent;
-			$node.toggleClass("sapFDynamicPageTitleMainContentHasContent", bAreaHasContent);
-		} else if ($node.hasClass("sapFDynamicPageTitleMainActions")) {
+			nodeDom.classList.toggle("sapFDynamicPageTitleMainContentHasContent", bAreaHasContent);
+		} else if (nodeDom?.classList.contains("sapFDynamicPageTitleMainActions")) {
 			this._bActionsAreaHasContent = bAreaHasContent;
-			$node.toggleClass("sapFDynamicPageTitleMainActionsHasContent", bAreaHasContent);
+			nodeDom.classList.toggle("sapFDynamicPageTitleMainActionsHasContent", bAreaHasContent);
 		}
 	};
 
 	DynamicPageTitle.prototype._updateARIAState = function (bExpanded) {
 		var sARIAText = this._getARIALabelReferences(bExpanded),
-			$oFocusSpan = this._getFocusSpan();
+			oFocusSpanDom = this.getFocusDomRef();
 
-		if ($oFocusSpan) {
-			$oFocusSpan.attr("aria-labelledby", sARIAText);
-			$oFocusSpan.attr("aria-expanded", bExpanded);
+		if (oFocusSpanDom) {
+			oFocusSpanDom.setAttribute("aria-labelledby", sARIAText);
+			oFocusSpanDom.setAttribute("aria-expanded", bExpanded);
 		}
 		return this;
 	};
@@ -1537,11 +1548,11 @@ sap.ui.define([
 	};
 
 	DynamicPageTitle.prototype._addFocusClass = function () {
-		this.$().addClass("sapFDynamicPageTitleFocus");
+		this.addStyleClass("sapFDynamicPageTitleFocus");
 	};
 
 	DynamicPageTitle.prototype._removeFocusClass = function () {
-		this.$().removeClass("sapFDynamicPageTitleFocus");
+		this.removeStyleClass("sapFDynamicPageTitleFocus");
 	};
 
 	return DynamicPageTitle;

--- a/src/sap.f/src/sap/f/GridContainer.js
+++ b/src/sap.f/src/sap/f/GridContainer.js
@@ -449,19 +449,18 @@ sap.ui.define([
 	 */
 	GridContainer.prototype._reflectItemVisibilityToWrapper = function (oItem) {
 
-		var oItemWrapper = GridContainerUtils.getItemWrapper(oItem),
-			$oItemWrapper;
+		var oItemWrapper = GridContainerUtils.getItemWrapper(oItem);
 
-		if (!oItemWrapper) {
+		if (!oItemWrapper || !oItemWrapper.getDomRef?.()) {
 			return;
 		}
 
-		$oItemWrapper = jQuery(oItemWrapper);
+		var oItemWrapperDom = oItemWrapper.getDomRef();
 
-		if (oItem.getVisible() && $oItemWrapper.hasClass("sapFGridContainerInvisiblePlaceholder")) {
-			$oItemWrapper.removeClass("sapFGridContainerInvisiblePlaceholder");
-		} else if (!oItem.getVisible() && !$oItemWrapper.hasClass("sapFGridContainerInvisiblePlaceholder")) {
-			$oItemWrapper.addClass("sapFGridContainerInvisiblePlaceholder");
+		if (oItem.getVisible() && oItemWrapperDom.classList.contains("sapFGridContainerInvisiblePlaceholder")) {
+			oItemWrapperDom.classList.remove("sapFGridContainerInvisiblePlaceholder");
+		} else if (!oItem.getVisible() && !oItemWrapperDom.classList.contains("sapFGridContainerInvisiblePlaceholder")) {
+			oItemWrapperDom.classList.add("sapFGridContainerInvisiblePlaceholder");
 		}
 	};
 
@@ -525,7 +524,8 @@ sap.ui.define([
 			that.addDelegate(this._oItemNavigation);
 		}
 
-		that.$().children().map(function (iIndex, oWrapperItem) {
+		var children = Array.from(that.getDomRef()?.children || []);
+		children.forEach(function (oWrapperItem, iIndex) {
 			if (oWrapperItem.getAttribute("class").indexOf("sapFGridContainerItemWrapper") > -1) {
 				aWrapperItemsDomRef.push(oWrapperItem);
 			}
@@ -575,7 +575,7 @@ sap.ui.define([
 	 */
 	GridContainer.prototype._detectColumnsChange = function () {
 		var oSettings = this.getActiveLayoutSettings(),
-			iWidth = this.$().innerWidth(),
+			iWidth = this.getDomRef()?.clientWidth || 0,
 			iColumns;
 
 		if (!oSettings) {
@@ -860,7 +860,7 @@ sap.ui.define([
 		}
 
 		if (bSettingsAreChanged) {
-			this.$().css(this._getActiveGridStyles());
+			Object.assign(this.getDomRef().style, this._getActiveGridStyles());
 			this.getItems().forEach(this._applyItemAutoRows.bind(this));
 		}
 
@@ -898,19 +898,17 @@ sap.ui.define([
 		}
 
 		if (hasItemAutoHeight(oItem)) {
-			var $item = oItem.$(),
+			var itemDomRef = oItem.getDomRef(),
 				oSettings = this.getActiveLayoutSettings(),
 				fHeight = oItem.getDomRef() ? oItem.getDomRef().getBoundingClientRect().height : 0,
 				iRows = oSettings.calculateRowsForItem(Math.round(fHeight));
 
-			if (!iRows) {
+			if (!iRows || !itemDomRef) {
 				// if the rows can not be calculated correctly, don't do anything
 				return;
 			}
 
-			$item.parent().css({
-				'grid-row': 'span ' + Math.max(iRows, getItemRowCount(oItem))
-			});
+			itemDomRef.parentNode.style['grid-row'] = 'span ' + Math.max(iRows, getItemRowCount(oItem));
 		}
 	};
 
@@ -927,7 +925,7 @@ sap.ui.define([
 			return;
 		}
 
-		iMaxColumns = oSettings.getComputedColumnsCount(this.$().innerWidth());
+		iMaxColumns = oSettings.getComputedColumnsCount(this.getDomRef().clientWidth);
 
 		if (!iMaxColumns) {
 			// if the max columns can not be calculated correctly, don't do anything
@@ -936,7 +934,7 @@ sap.ui.define([
 
 		this.getItems().forEach(function (oItem) {
 			// if item has more columns than total columns, it brakes the whole layout
-			oItem.$().parent().css("grid-column", "span " + Math.min(getItemColumnCount(oItem), iMaxColumns));
+			oItem.getDomRef().parentNode.style["grid-column"] = "span " + Math.min(getItemColumnCount(oItem), iMaxColumns);
 		});
 	};
 

--- a/src/sap.f/src/sap/f/ProductSwitch.js
+++ b/src/sap.f/src/sap/f/ProductSwitch.js
@@ -151,14 +151,14 @@ sap.ui.define([
 		ProductSwitch.prototype._setSelection = function (vItem) {
 			if (this._oCurrentSelectedItem) {
 				this._oCurrentSelectedItem.removeStyleClass("sapFPSItemSelected");
-				this._oCurrentSelectedItem.$().removeAttr("aria-checked");
+				this._oCurrentSelectedItem.getDomRef().removeAttribute("aria-checked");
 			}
 
 			this._oCurrentSelectedItem = vItem;
 
 			if (this._oCurrentSelectedItem) {
 				this._oCurrentSelectedItem.addStyleClass("sapFPSItemSelected");
-				this._oCurrentSelectedItem.$().attr("aria-checked", "true");
+				this._oCurrentSelectedItem.getDomRef().setAttribute("aria-checked", "true");
 			}
 		};
 

--- a/src/sap.f/src/sap/f/SidePanel.js
+++ b/src/sap.f/src/sap/f/SidePanel.js
@@ -481,7 +481,7 @@ sap.ui.define([
 	SidePanel.prototype.oncontextmenu = function(oEvent) {
 		var bSplitterFocused = document.activeElement === this.getDomRef().querySelector(".sapFSPSplitterBar");
 
-		if (bSplitterFocused || oEvent.target.closest(".sapFSPSide.sapFSPResizable")) {
+		if (bSplitterFocused || oEvent.target.getDomRef?.().closest(".sapFSPSide.sapFSPResizable")) {
 			// show the resize context menu only if there is a keyboard call ([Shift]+[F10] or [Context menu] keys)
 			// from focused splitter bar or right click somewhere within the side panel
 			oEvent.preventDefault();
@@ -787,9 +787,9 @@ sap.ui.define([
 					oItemDomRef.setAttribute("tabindex", "-1");
 					aItemsDomRef.push(oItemDomRef);
 				}
-				oItem.$().css("display", "flex");
+				oItem.getDomRef().style.display = "flex";
 			} else {
-				oItem.$().css("display", "none");
+				oItem.getDomRef().style.display = "none";
 				oMenuItem = new MenuItem({
 					text: oItem.getText(),
 					icon: oItem.getIcon(),
@@ -801,12 +801,12 @@ sap.ui.define([
 		}.bind(this));
 
 		if (bShowOverflowItem) {
-			oOverflowItem.$().css("visibility", "visible");
+			oOverflowItem.getDomRef().style.visibility = "visible";
 			oItemDomRef = this._getFocusDomRef(oOverflowItem);
 			oItemDomRef.setAttribute("tabindex", "-1");
 			aItemsDomRef.push(oItemDomRef);
 		} else {
-			oOverflowItem.$().css("visibility", "hidden");
+			oOverflowItem.getDomRef().style.visibility = "hidden";
 		}
 
 		// create the ItemNavigation
@@ -945,7 +945,7 @@ sap.ui.define([
 		// set the text of the overflow item separately via framework without invalidation
 		// and then directly in the DOM element in order to achieve correct screen reader announcement
 		oOverflowItem.setText(sOverflowItemText, false);
-		oOverflowItem.$().find(".sapFSPItemText").text(sOverflowItemText);
+		oOverflowItem.getDomRef().querySelector(".sapFSPItemText").textContent = sOverflowItemText;
 	};
 
 	SidePanel.prototype._getAriaLabelText = function() {

--- a/src/sap.f/src/sap/f/cards/loading/ObjectPlaceholder.js
+++ b/src/sap.f/src/sap/f/cards/loading/ObjectPlaceholder.js
@@ -74,10 +74,10 @@ sap.ui.define([
 	};
 
 	ObjectPlaceholder.prototype._handleResize = function () {
-		var iAvailableHeight = this.$().height();
+		var iAvailableHeight = this.getDomRef().clientHeight;
 		var iFitCnt = Math.floor(iAvailableHeight / PAIR_ROWS_HEIGHT);
 
-		var iColsCnt = this.$().width() >  SECOND_COLUMN_DISPLAY_THRESHOLD ? 2 : 1;
+		var iColsCnt = this.getDomRef().clientWidth >  SECOND_COLUMN_DISPLAY_THRESHOLD ? 2 : 1;
 
 		if (this._iRowsCnt !== iFitCnt || this._iColsCnt !== iColsCnt) {
 			this._iRowsCnt = iFitCnt;

--- a/src/sap.f/src/sap/f/delegate/GridContainerItemNavigation.js
+++ b/src/sap.f/src/sap/f/delegate/GridContainerItemNavigation.js
@@ -91,14 +91,14 @@ sap.ui.define([
 		// get the last focused element from the ItemNavigation
 		var aNavigationDomRefs = this.getItemDomRefs(),
 			iLastFocusedIndex = this.getFocusedIndex(),
-			$LastFocused = jQuery(aNavigationDomRefs[iLastFocusedIndex]),
+			lastFocusedDom = aNavigationDomRefs[iLastFocusedIndex],
 			Tabbables = [];
 
 		// Tabbable elements in wrapper
-		var $AllTabbables = $LastFocused.find(":sapTabbable");
+		var allTabbables = jQuery(lastFocusedDom).find(":sapTabbable");
 
 		// leave only real tabbable elements in the tab chain, GridContainer and List types have dummy areas
-		$AllTabbables.map(function(index, element) {
+		allTabbables.map(function(index, element) {
 			if (element.className.indexOf("DummyArea") === -1 && element.className.indexOf("sapMListUl") === -1) {
 				Tabbables.push(element);
 			}
@@ -149,18 +149,17 @@ sap.ui.define([
 	};
 
 	GridContainerItemNavigation.prototype.onmouseup = function(oEvent) {
-
-		var $listItem = jQuery(oEvent.target).closest('.sapFGridContainerItemWrapperNoVisualFocus'),
+		var listItemDom = oEvent.target.getDomRef?.().closest('.sapFGridContainerItemWrapperNoVisualFocus'),
 			oControl;
 
-		if ($listItem.length) {
-			oControl = Element.closestTo($listItem.children()[0]);
+		if (listItemDom) {
+			oControl = Element.closestTo(listItemDom.children[0]);
 
 			// if the list item visual focus is displayed by the currently focused control,
 			// move the focus to the list item
 			if (oControl && oControl.getFocusDomRef() === document.activeElement) {
 				this._lastFocusedElement = null;
-				$listItem.trigger("focus");
+				jQuery(listItemDom).trigger("focus");
 				doVirtualFocusin(oControl);
 			}
 		}
@@ -208,11 +207,11 @@ sap.ui.define([
 			return;
 		}
 
-		var $listItem = jQuery(oEvent.target).closest('.sapFGridContainerItemWrapperNoVisualFocus'),
+		var listItemDom = oEvent.target.getDomRef?.().closest('.sapFGridContainerItemWrapperNoVisualFocus'),
 			oControl;
 
-		if ($listItem.length) {
-			oControl = Element.closestTo($listItem.children()[0]);
+		if (listItemDom) {
+			oControl = Element.closestTo(listItemDom.children[0]);
 
 			if (oControl) {
 				doVirtualFocusin(oControl);
@@ -221,7 +220,7 @@ sap.ui.define([
 				// move the focus to the list item
 				if (!this._bIsMouseDown && oControl.getFocusDomRef() === oEvent.target) {
 					this._lastFocusedElement = null;
-					$listItem.trigger("focus");
+					jQuery(listItemDom).trigger("focus");
 					return;
 				}
 			}

--- a/src/sap.f/src/sap/f/designtime/DynamicPage.designtime.js
+++ b/src/sap.f/src/sap/f/designtime/DynamicPage.designtime.js
@@ -42,7 +42,7 @@ sap.ui.define([],
 			},
 			{
 				domRef : function(oElement) {
-					return oElement.$("vertSB-sb").get(0);
+					return oElement.getDomRef("vertSB-sb");
 				}
 			}],
 		templates: {

--- a/src/sap.f/src/sap/f/designtime/DynamicPageTitle.designtime.js
+++ b/src/sap.f/src/sap/f/designtime/DynamicPageTitle.designtime.js
@@ -17,7 +17,7 @@ sap.ui.define([],
 				},
 				expandedHeading: {
 					domRef: function (oElement) {
-						return oElement.$("expand-heading-wrapper").get(0);
+						return oElement.getDomRef("expand-heading-wrapper");
 					},
 					ignore: function (oElement) {
 						return oElement.getHeading() || !oElement.getExpandedHeading();
@@ -25,7 +25,7 @@ sap.ui.define([],
 				},
 				snappedHeading: {
 					domRef: function (oElement) {
-						return oElement.$("snapped-heading-wrapper").get(0);
+						return oElement.getDomRef("snapped-heading-wrapper");
 					},
 					ignore: function (oElement) {
 						return oElement.getHeading() || !oElement.getSnappedHeading();
@@ -55,7 +55,7 @@ sap.ui.define([],
 				},
 				snappedContent: {
 					domRef: function (oElement) {
-						return oElement.$("snapped-wrapper").get(0);
+						return oElement.getDomRef("snapped-wrapper");
 					},
 					actions: {
 						move: {
@@ -65,7 +65,7 @@ sap.ui.define([],
 				},
 				expandedContent: {
 					domRef: function (oElement) {
-						return oElement.$("expand-wrapper").get(0);
+						return oElement.getDomRef("expand-wrapper");
 					},
 					actions: {
 						move: {

--- a/src/sap.f/src/sap/f/designtime/SemanticPage.designtime.js
+++ b/src/sap.f/src/sap/f/designtime/SemanticPage.designtime.js
@@ -15,14 +15,13 @@ sap.ui.define([],
 		};
 
 		var fnIgnoreTitleActionsAggregation = function (oControl, sAggregationGetter) {
-			var $ControlDomRef;
 
 			if (!oControl) {
 				return true;
 			}
 
-			$ControlDomRef = oControl.$().find("sapFDynamicPageTitleActionsBar");
-			return !!($ControlDomRef.length > 0 && oControl[sAggregationGetter]().length > 0);
+			var oControlDomRef = oControl.getDomRef()?.querySelectorAll?.(".sapFDynamicPageTitleActionsBar") || [];
+			return !!(oControlDomRef.length > 0 && oControl[sAggregationGetter]().length > 0);
 		};
 
 		return {
@@ -327,7 +326,7 @@ sap.ui.define([],
 			},
 			{
 				domRef : function(oElement) {
-					return oElement.$("vertSB-sb").get(0);
+					return oElement.getDomRef("vertSB-sb");
 				}
 			}],
 			templates: {

--- a/src/sap.f/src/sap/f/shellBar/Accessibility.js
+++ b/src/sap.f/src/sap/f/shellBar/Accessibility.js
@@ -109,37 +109,37 @@ sap.ui.define([
 	};
 
 	Accessibility.prototype.onAfterRenderingSecondTitle = function () {
-		var $oSecondTitle = this._oControl._oSecondTitle.$();
+		var oSecondTitle = this._oControl._oSecondTitle.getDomRef();
 
-		$oSecondTitle.attr("role", "heading");
-		$oSecondTitle.attr("aria-level", "2");
+		oSecondTitle.setAttribute("role", "heading");
+		oSecondTitle.setAttribute("aria-level", "2");
 	};
 
 	Accessibility.prototype.onAfterRenderingSearch = function () {
-		this._oControl._oSearch.$().attr("aria-label", this.getEntityTooltip("SEARCH"));
+		this._oControl._oSearch.getDomRef().setAttribute("aria-label", this.getEntityTooltip("SEARCH"));
 	};
 
 	Accessibility.prototype.onAfterRenderingAvatar = function () {
-		var $oAvatar = this._oControl.getProfile().$();
+		var oAvatar = this._oControl.getProfile().getDomRef();
 
-		$oAvatar.attr("aria-label", this.getEntityTooltip("PROFILE"));
-		$oAvatar.attr("aria-haspopup", "menu");
+		oAvatar.setAttribute("aria-label", this.getEntityTooltip("PROFILE"));
+		oAvatar.setAttribute("aria-haspopup", "menu");
 	};
 
 	Accessibility.prototype.onAfterRenderingProducts = function () {
-		var $oProducts = this._oControl._oProductSwitcher.$();
+		var oProducts = this._oControl._oProductSwitcher.getDomRef();
 
-		$oProducts.attr("aria-label", this.getEntityTooltip("PRODUCTS"));
+		oProducts.setAttribute("aria-label", this.getEntityTooltip("PRODUCTS"));
 	};
 
 	Accessibility.prototype.onAfterRenderingNavButton = function () {
-		this._oControl._oNavButton.$().attr("aria-label", this.getEntityTooltip("BACK"));
+		this._oControl._oNavButton.getDomRef().setAttribute("aria-label", this.getEntityTooltip("BACK"));
 	};
 
 	Accessibility.prototype.onAfterRenderingMenuButton = function () {
-		var $oMenuButton = this._oControl._oMenuButton.$();
+		var oMenuButton = this._oControl._oMenuButton.getDomRef();
 
-		$oMenuButton.attr("aria-label", this.getEntityTooltip("MENU"));
+		oMenuButton.setAttribute("aria-label", this.getEntityTooltip("MENU"));
 	};
 
 	Accessibility.prototype.exit = function () {

--- a/src/sap.f/src/sap/f/shellBar/ControlSpacer.js
+++ b/src/sap.f/src/sap/f/shellBar/ControlSpacer.js
@@ -41,8 +41,8 @@ sap.ui.define(['sap/ui/core/Control', 'sap/f/shellBar/ControlSpacerRenderer'],
 		// Despite using the Semantic Rendering, we need to override this setter in order to set the width immediately on the DomRef.
 		// When width of ControlSpacer is changed, sometimes there is a race condition. If OverflowToolbar's
 		// doLayout function is executed before the ControlSpacer is rerendered, a wrong width value is cached.
-		if (this.$().length) {
-			this.$().width(sWidth);
+		if (this.getDomRef()) {
+			this.getDomRef().style.width = sWidth;
 		}
 
 		return this.setProperty("width", sWidth, true);

--- a/src/sap.f/src/sap/f/shellBar/ResponsiveHandler.js
+++ b/src/sap.f/src/sap/f/shellBar/ResponsiveHandler.js
@@ -58,10 +58,13 @@ sap.ui.define([
 	 * Lifecycle event handler for ShellBar onAfterRendering event
 	 */
 	ResponsiveHandler.prototype.onAfterRendering = function () {
-
-		var bPhoneRange = Device.media.getCurrentRange("StdExt", this._oControl.$().outerWidth(true)).name === "Phone";
+		var oControlDom = this._oControl.getDomRef();
+		var oControlStyles = window.getComputedStyle(oControlDom);
+		var iControlMargins = parseFloat(oControlStyles['marginLeft']) + parseFloat(oControlStyles['marginRight']);
+		var iControlFullWidth = Math.ceil(oControlDom.offsetWidth + iControlMargins);
+		var bPhoneRange = Device.media.getCurrentRange("StdExt", iControlFullWidth).name === "Phone";
 		this._oButton = this._oControl._oMegaMenu && this._oControl._oMegaMenu.getAggregation("_button");
-		this._oDomRef = this._oControl.getDomRef(); // Cache DOM Reference
+		this._oDomRef = oControlDom; // Cache DOM Reference
 		this.bIsMegaMenuConfigured = this._oControl._oTitleControl &&
 		this._oControl._oTitleControl === this._oControl._oMegaMenu;
 
@@ -99,8 +102,8 @@ sap.ui.define([
 	ResponsiveHandler.prototype._handleResize = function () {
 		if (!this._oDomRef) {return;}
 
-		var $Control = this._oControl.$(),
-			iWidth = $Control.outerWidth(),
+		var control = this._oControl.getDomRef(),
+			iWidth = control.offsetWidth,
 			oCurrentRange = Device.media.getCurrentRange("StdExt", iWidth),
 			bPhoneRange;
 
@@ -109,10 +112,10 @@ sap.ui.define([
 		if (oCurrentRange) {
 			bPhoneRange = this.sCurrentRange === "Phone";
 
-			$Control.toggleClass("sapFShellBarSizeLargeDesktop", this.sCurrentRange === "LargeDesktop");
-			$Control.toggleClass("sapFShellBarSizeDesktop", this.sCurrentRange === "Desktop");
-			$Control.toggleClass("sapFShellBarSizeTablet", this.sCurrentRange === "Tablet");
-			$Control.toggleClass("sapFShellBarSizePhone", bPhoneRange);
+			control.classList.toggle("sapFShellBarSizeLargeDesktop", this.sCurrentRange === "LargeDesktop");
+			control.classList.toggle("sapFShellBarSizeDesktop", this.sCurrentRange === "Desktop");
+			control.classList.toggle("sapFShellBarSizeTablet", this.sCurrentRange === "Tablet");
+			control.classList.toggle("sapFShellBarSizePhone", bPhoneRange);
 		}
 
 		/**
@@ -293,7 +296,7 @@ sap.ui.define([
 			return;
 		}
 
-		iSearchWidth = oSearch.$().width();
+		iSearchWidth = oSearch.getDomRef()?.clientWidth || 0;
 
 		if (this._oControl._bSearchPlaceHolder){
 			if (iSearchWidth >= this._iMinSearchWidth) {

--- a/src/sap.f/test/sap/f/qunit/DynamicPage.qunit.js
+++ b/src/sap.f/test/sap/f/qunit/DynamicPage.qunit.js
@@ -132,7 +132,8 @@ function(
 
 	QUnit.test("DynamicPage - backgroundDesign property", function(assert) {
 		var oDynamicPage = this.oDynamicPage,
-				$oDomRef = oDynamicPage.$wrapper;
+				//$oDomRef = oDynamicPage.$("contentWrapper");
+			$oDomRef = oDynamicPage.$("contentWrapper");
 
 		// assert
 		assert.strictEqual(oDynamicPage.getBackgroundDesign(), PageBackgroundDesign.Standard, "Should have backgroundDesign property = 'Standard'");
@@ -436,7 +437,7 @@ function(
 
 		assert.ok($oDynamicPageHeader.hasClass("sapFDynamicPageHeaderWithContent"),
 			"The DynamicPage Header is not empty - sapFDynamicPageHeaderWithContent is added");
-		assert.ok(!oDynamicPage.$titleArea.hasClass("sapFDynamicPageTitleOnly"),
+		assert.ok(!oDynamicPage.$("header").hasClass("sapFDynamicPageTitleOnly"),
 			"The DynamicPage Header is not empty - sapFDynamicPageTitleOnly is not added");
 	});
 
@@ -470,7 +471,7 @@ function(
 		this.oDynamicPage._updateFitContainer();
 
 		// Assert
-		assert.strictEqual(this.oDynamicPage.$contentFitContainer.hasClass("sapFDynamicPageContentFitContainer"), false,
+		assert.strictEqual(this.oDynamicPage.$("contentFitContainer").hasClass("sapFDynamicPageContentFitContainer"), false,
 		"'sapFDynamicPageContentFitContainer' class is not added");
 
 		// Clean up
@@ -503,11 +504,11 @@ function(
 		var oDynamicPage = this.oDynamicPage;
 
 		oDynamicPage._snapHeader();
-		assert.ok(oDynamicPage.$headerInContentWrapper.hasClass("sapFDynamicPageHeaderSolid"),
+		assert.ok(oDynamicPage.$("headerWrapper").hasClass("sapFDynamicPageHeaderSolid"),
 			"The snapped header in content has solid background");
 
 		oDynamicPage._expandHeader();
-		assert.notOk(oDynamicPage.$headerInContentWrapper.hasClass("sapFDynamicPageHeaderSolid"),
+		assert.notOk(oDynamicPage.$("headerWrapper").hasClass("sapFDynamicPageHeaderSolid"),
 			"The expanded header in content does not have solid background");
 	});
 
@@ -678,7 +679,7 @@ function(
 
 		// assert initial setup (in the context of which the final check is valid)
 		assert.notEqual(getComputedStyle( oHeader.getDomRef()).position, "static", "the header is css-positioned");
-		assert.notEqual(getComputedStyle( this.oDynamicPage.$wrapper.get(0)).position, "static", "the scroll-container is css-positioned");
+		assert.notEqual(getComputedStyle( this.oDynamicPage.$("contentWrapper").get(0)).position, "static", "the scroll-container is css-positioned");
 
 		// Act:
 		// scroll just before snap
@@ -687,7 +688,7 @@ function(
 
 		// Check:
 		// obtain the amount of top pixels that are in the overflow (i.e. pixels that are scrolled out of view)
-		iScrollTop = this.oDynamicPage.$wrapper.scrollTop();
+		iScrollTop = this.oDynamicPage.$("contentWrapper").scrollTop();
 		// obtain the distance of the expand button from the top of the scrollable content
 		iButtonOffsetTop = oHeader._getCollapseButton().getDomRef().offsetTop + oHeader.getDomRef().offsetTop;
 		assert.ok(iButtonOffsetTop >= iScrollTop, "snap button is not in the overflow");
@@ -860,7 +861,7 @@ function(
 			"The DynamicPage Header is empty - sapFDynamicPageHeaderWithContent not added");
 		assert.ok(!$oDynamicPageHeader.hasClass("sapFDynamicPageHeaderPinnable"),
 			"The DynamicPage Header is pinnable, but it`s empty - sapFDynamicPageHeaderPinnable not added");
-		assert.ok(oDynamicPage.$titleArea.hasClass("sapFDynamicPageTitleOnly"),
+		assert.ok(oDynamicPage.$("header").hasClass("sapFDynamicPageTitleOnly"),
 			"The DynamicPage Header is empty and has Title only - sapFDynamicPageTitleOnly is added");
 	});
 
@@ -902,7 +903,7 @@ function(
 
 	QUnit.test("DynamicPage Footer visibility", function (assert) {
 		// Arrange
-		var $footerWrapper = this.oDynamicPage.$footerWrapper,
+		var $footerWrapper = this.oDynamicPage.$("footerWrapper"),
 			oFooter = this.oDynamicPage.getFooter(),
 			$footer = oFooter.$();
 
@@ -991,7 +992,7 @@ function(
 		// Act: toggle to 'true'
 		this.oDynamicPage.setShowFooter(true);
 		// scroll to bottom
-		this.oDynamicPage.$wrapper.scrollTop(this.oDynamicPage._getMaxScrollPosition());
+		this.oDynamicPage.$("contentWrapper").scrollTop(this.oDynamicPage._getMaxScrollPosition());
 
 		// Check
 		oFooterBoundingClientRect = this.oDynamicPage.getFooter().getDomRef().getBoundingClientRect();
@@ -1024,14 +1025,14 @@ function(
 	QUnit.test("When footer is visible, CSS class is applied to the DynamicPage", function (assert) {
 		// Assert - when footer is visible, CSS class is applied
 		assert.ok(this.oDynamicPage.$().hasClass("sapFDynamicPageFooterVisible"), "DynamicPage has CSS class");
-		assert.strictEqual(this.oDynamicPage.$wrapper.css("scroll-padding-bottom"), "58px", "58px scroll padding bottom on the wrapper");
+		assert.strictEqual(this.oDynamicPage.$("contentWrapper").css("scroll-padding-bottom"), "58px", "58px scroll padding bottom on the wrapper");
 
 		// Act - toggle to 'false'
 		this.oDynamicPage.setShowFooter(false);
 
 		// Assert - when footer is not visible, CSS class is not applied
 		assert.notOk(this.oDynamicPage.$().hasClass("sapFDynamicPageFooterVisible"), "DynamicPage does not have CSS class");
-		assert.strictEqual(this.oDynamicPage.$wrapper.css("scroll-padding-bottom"), "auto", "No scroll padding bottom on the wrapper");
+		assert.strictEqual(this.oDynamicPage.$("contentWrapper").css("scroll-padding-bottom"), "auto", "No scroll padding bottom on the wrapper");
 	});
 
 
@@ -1841,7 +1842,7 @@ function(
 		var oDynamicPage = this.oDynamicPage,
 			oHeader = oDynamicPage.getHeader(),
 			$header = oHeader.$(),
-			$wrapper = oDynamicPage.$wrapper;
+			$wrapper = oDynamicPage.$("contentWrapper");
 
 		assert.equal($wrapper.find($header).length > 0, true, "Header is in content area initially");
 
@@ -1893,7 +1894,7 @@ function(
 			oMoveHeaderSpy = this.spy(),
 			oHeader = oDynamicPage.getHeader(),
 			$header = oHeader.$(),
-			$wrapper = oDynamicPage.$wrapper;
+			$wrapper = oDynamicPage.$("contentWrapper");
 
 		// Setup
 		this.oDynamicPage.attachEvent("_moveHeader", oMoveHeaderSpy);
@@ -1913,7 +1914,7 @@ function(
 			oHeader = oDynamicPage.getHeader(),
 			$titleWrapper = oDynamicPage.$("header"),
 			$header = oHeader.$(),
-			$wrapper = oDynamicPage.$wrapper;
+			$wrapper = oDynamicPage.$("contentWrapper");
 
 		assert.equal($wrapper.find($header).length > 0, true, "Header is in the content area initially");
 
@@ -1942,7 +1943,7 @@ function(
 
 	QUnit.test("DynamicPage _moveHeaderToTitleArea(true) should preserve the top scroll position of the content", function (assert) {
 		var oDynamicPage = this.oDynamicPage,
-			$wrapper = oDynamicPage.$wrapper,
+			$wrapper = oDynamicPage.$("contentWrapper"),
 			iScrollPositionBefore = 0,
 			iExpectedScrollPositionAfter = 0; // should remain 0 as the header is still expanded
 
@@ -1960,7 +1961,7 @@ function(
 			oMoveHeaderSpy = this.spy(),
 			oHeader = oDynamicPage.getHeader(),
 			$header = oHeader.$(),
-			$wrapper = oDynamicPage.$wrapper;
+			$wrapper = oDynamicPage.$("contentWrapper");
 
 		// Setup
 		oDynamicPage.attachEvent("_moveHeader", oMoveHeaderSpy);
@@ -2097,13 +2098,13 @@ function(
 
 		//arrange
 		oDynamicPage.setHeaderExpanded(false);
-		oDynamicPage.$wrapper.scrollTop(iExpectedScrollPosition);
+		oDynamicPage.$("contentWrapper").scrollTop(iExpectedScrollPosition);
 		//act
 		oDynamicPage.invalidate();
 		Core.applyChanges();
 
 		//assert
-		assert.ok(oDynamicPage.$wrapper.scrollTop, iExpectedScrollPosition,
+		assert.ok(oDynamicPage.$("contentWrapper").scrollTop, iExpectedScrollPosition,
 			"DynamicPage Scroll position is correct after rerender");
 	});
 
@@ -2112,7 +2113,7 @@ function(
 			oDynamicPage = this.oDynamicPage; // Scroll position of wrapper is set to 0 when navigating to another page
 
 		//arrange
-		oDynamicPage.$wrapper.scrollTop(iExpectedScrollPosition);
+		oDynamicPage.$("contentWrapper").scrollTop(iExpectedScrollPosition);
 		oDynamicPage.addStyleClass("sapMNavItem");
 
 		//act
@@ -2375,9 +2376,9 @@ function(
 
 	QUnit.test("DynamicPage _needsVerticalScrollBar() floors the current max scrollHeight", function (assert) {
 		// Arrange
-		var iScrollHeight = this.oDynamicPage.$wrapper[0].scrollHeight;
+		var iScrollHeight = this.oDynamicPage.$("contentWrapper")[0].scrollHeight;
 		// mock the conditions of the tested scenario:
-		this.oDynamicPage.$wrapper[0] = {
+		this.oDynamicPage.$("contentWrapper")[0] = {
 			scrollHeight: iScrollHeight,
 			// the browser returns a ceiled value for <code>clientHeight</code>
 			clientHeight: iScrollHeight - 1,
@@ -2408,9 +2409,9 @@ function(
 
 	QUnit.test("DynamicPage _getMaxScrollPosition() prevents 1px maxScrollPosition due to rounding", function (assert) {
 		// Arrange
-		var iScrollHeight = this.oDynamicPage.$wrapper[0].scrollHeight;
+		var iScrollHeight = this.oDynamicPage.$("contentWrapper")[0].scrollHeight;
 		// mock the conditions of the tested scenario:
-		this.oDynamicPage.$wrapper[0] = {
+		this.oDynamicPage.$("contentWrapper")[0] = {
 			scrollHeight: iScrollHeight,
 			// the browser returns a ceiled value for <code>clientHeight</code>
 			clientHeight: iScrollHeight,
@@ -2421,7 +2422,6 @@ function(
 				};
 			}
 		};
-
 		// Assert
 		assert.strictEqual(this.oDynamicPage._getMaxScrollPosition(), 0,
 			"no scrollbar needed");
@@ -2459,7 +2459,7 @@ function(
 	QUnit.test("DynamicPage _toggleHeaderOnScroll for position <= snapping height preserves expanded state", function (assert) {
 		var oDynamicPage = this.oDynamicPage,
 			$header = this.oDynamicPage.getHeader().$(),
-			$wrapper = oDynamicPage.$wrapper,
+			$wrapper = oDynamicPage.$("contentWrapper"),
 			iSnappingHeight = oDynamicPage._getSnappingHeight();
 
 		//arrange
@@ -2476,7 +2476,7 @@ function(
 	QUnit.test("DynamicPage _toggleHeaderOnScroll for position > snapping height snaps the header", function (assert) {
 		var oDynamicPage = this.oDynamicPage,
 			$header = this.oDynamicPage.getHeader().$(),
-			$wrapper = oDynamicPage.$wrapper,
+			$wrapper = oDynamicPage.$("contentWrapper"),
 			iSnappingHeight = oDynamicPage._getSnappingHeight();
 
 		//arrange
@@ -2493,7 +2493,7 @@ function(
 	QUnit.test("DynamicPage _toggleHeaderOnScroll for position <= snapping height when header in title preserves the expanded state", function (assert) {
 		var oDynamicPage = this.oDynamicPage,
 			$header = this.oDynamicPage.getHeader().$(),
-			$wrapper = oDynamicPage.$wrapper,
+			$wrapper = oDynamicPage.$("contentWrapper"),
 			iSnappingHeight = this.oDynamicPage._getSnappingHeight();
 
 		//setup
@@ -2513,7 +2513,7 @@ function(
 			oHeader = this.oDynamicPage.getHeader(),
 			$header = oHeader.$(),
 			$HeaderDom = oHeader.getDomRef(),
-			$wrapper = oDynamicPage.$wrapper,
+			$wrapper = oDynamicPage.$("contentWrapper"),
 			iHeaderHeight = getElementHeight($HeaderDom, true),
 			iTestScrollPosition = iHeaderHeight + 100, // pick position greater than snapping height => will require snap
 			iExpectedScrollPosition = iTestScrollPosition + iHeaderHeight;
@@ -2603,7 +2603,7 @@ function(
 		oUtil.renderObject(this.oDynamicPage);
 
 		assert.strictEqual(this.oDynamicPage.getHeaderExpanded(), false, "The DynamicPage getHeaderExpanded is still false");
-		assert.strictEqual(this.oDynamicPage.$titleArea.hasClass(sSnappedClass), true);
+		assert.strictEqual(this.oDynamicPage.$("header").hasClass(sSnappedClass), true);
 		assert.strictEqual(oHeader.$().hasClass("sapFDynamicPageHeaderHidden"), true, "Header is hidden");
 	});
 
@@ -2632,7 +2632,7 @@ function(
 			oHeader = oDynamicPage.getHeader(),
 			oTitle = oDynamicPage.getTitle(),
 			$header = oHeader.$(),
-			$wrapper = oDynamicPage.$wrapper,
+			$wrapper = oDynamicPage.$("contentWrapper"),
 			$titleWrapper = oDynamicPage.$("header"),
 			$oCollapseButton = oHeader.getAggregation("_collapseButton").$(),
 			$oExpandButton = oTitle.getAggregation("_expandButton").$(),
@@ -2641,7 +2641,7 @@ function(
 		iExpectedScrollPosition = iExpectedScrollPosition || 0;
 
 		assert.strictEqual(oDynamicPage.getHeaderExpanded(), false, "The DynamicPage getHeaderExpanded is false");
-		assert.ok(oDynamicPage.$titleArea.hasClass(sSnappedClass), "title has snapped css-class");
+		assert.ok(oDynamicPage.$("header").hasClass(sSnappedClass), "title has snapped css-class");
 		assert.strictEqual(oHeader.$().hasClass("sapFDynamicPageHeaderHidden"), !bExpectedHeaderInContent, "Header visibility is correct");
 		assert.equal($titleWrapper.find($header).length > 0, !bExpectedHeaderInContent, "Header in the title value is correct");
 		assert.equal($wrapper.find($header).length > 0, bExpectedHeaderInContent, "Header in the content value is correct");
@@ -2656,7 +2656,7 @@ function(
 			oHeader = oDynamicPage.getHeader(),
 			oTitle = oDynamicPage.getTitle(),
 			$header = oHeader.$(),
-			$wrapper = oDynamicPage.$wrapper,
+			$wrapper = oDynamicPage.$("contentWrapper"),
 			$titleWrapper = oDynamicPage.$("header"),
 			$oCollapseButton = oHeader.getAggregation("_collapseButton").$(),
 			$oExpandButton = oTitle.getAggregation("_expandButton").$(),
@@ -2665,7 +2665,7 @@ function(
 		iExpectedScrollPosition = iExpectedScrollPosition || 0;
 
 		assert.strictEqual(oDynamicPage.getHeaderExpanded(), true, "The DynamicPage getHeaderExpanded is true");
-		assert.strictEqual(oDynamicPage.$titleArea.hasClass(sSnappedClass), false, "title does not have snapped css-class");
+		assert.strictEqual(oDynamicPage.$("header").hasClass(sSnappedClass), false, "title does not have snapped css-class");
 		assert.strictEqual(oHeader.$().hasClass("sapFDynamicPageHeaderHidden"), false, "Header visibility is correct");
 		assert.equal($titleWrapper.find($header).length > 0, !bExpectedHeaderInContent, "Header in the title value is correct");
 		assert.equal($wrapper.find($header).length > 0, bExpectedHeaderInContent, "Header in the content value is correct");
@@ -2843,7 +2843,7 @@ function(
 					//check
 					assert.ok(oDynamicPage.getScrollDelegate().hasOwnProperty("_$Container"), "scroll delegate has property _$Container");
 					assert.strictEqual(oDynamicPage.getScrollDelegate()._$Container.length, 1, "scroll delegate obtained reference to page container");
-					assert.strictEqual(oDynamicPage.getScrollDelegate()._$Container[0], oDynamicPage.$wrapper[0], "scroll delegate container reference is wrapper reference");
+					assert.strictEqual(oDynamicPage.getScrollDelegate()._$Container[0], oDynamicPage.$("contentWrapper")[0], "scroll delegate container reference is wrapper reference");
 
 					//act
 					oDynamicPage._setScrollPosition(iNewScrollPosition);
@@ -3349,7 +3349,7 @@ function(
 		Core.applyChanges();
 
 		//Act
-		assert.equal(oDynamicPage.$wrapper.css("scroll-padding-top"), oDynamicPage.$wrapper.css("padding-top"),
+		assert.equal(oDynamicPage.$("contentWrapper").css("scroll-padding-top"), oDynamicPage.$("contentWrapper").css("padding-top"),
 		"Scroll padding is equal to visual padding of scrolling wrapper");
 		//Clean up
 		oDynamicPage.setContent(oContent);

--- a/src/sap.f/test/sap/f/qunit/DynamicPageHeader.qunit.js
+++ b/src/sap.f/test/sap/f/qunit/DynamicPageHeader.qunit.js
@@ -72,12 +72,12 @@ function(
 
 		assert.ok(oDynamicPage.getHeaderExpanded(), "initial value for the headerExpanded prop is true");
 		oUtil.testExpandedCollapsedARIA(assert, oDynamicPage, "true", sAriaLabelledBy, "Initial aria-labelledby references");
-		assert.ok(!oDynamicPage.$titleArea.hasClass(sSnappedClass));
+		assert.ok(!oDynamicPage.$("header").hasClass(sSnappedClass));
 
 		oDynamicPage.setHeaderExpanded(false);
 		assert.equal(oDynamicPage.getHeaderExpanded(), false, "setting it to false under regular conditions works");
 		oUtil.testExpandedCollapsedARIA(assert, oDynamicPage, "false", sAriaLabelledBy, "Header is now snapped");
-		assert.ok(oDynamicPage.$titleArea.hasClass(sSnappedClass));
+		assert.ok(oDynamicPage.$("header").hasClass(sSnappedClass));
 		assert.ok(oSetPropertySpy.calledWith("headerExpanded", false, true));
 		assert.strictEqual($oDynamicPageHeader.css("visibility"), "hidden", "Header should be excluded from the tab chain");
 		assert.strictEqual(parseInt($oDynamicPageHeader[0].style.height), iHeaderHeight, "Header height is fixed");
@@ -87,7 +87,7 @@ function(
 		oDynamicPage.setHeaderExpanded(true);
 		assert.ok(oDynamicPage.getHeaderExpanded(), "header converted to expanded");
 		oUtil.testExpandedCollapsedARIA(assert, oDynamicPage, "true", sAriaLabelledBy, "Header is expanded again");
-		assert.ok(!oDynamicPage.$titleArea.hasClass(sSnappedClass));
+		assert.ok(!oDynamicPage.$("header").hasClass(sSnappedClass));
 		assert.ok(oSetPropertySpy.calledWith("headerExpanded", true, true));
 		assert.strictEqual($oDynamicPageHeader.css("visibility"), "visible", "Header should be included in the tab chain again");
 		assert.strictEqual($oDynamicPageHeader[0].style.height, "", "Header height is restored to the default value");
@@ -96,7 +96,7 @@ function(
 
 		oDynamicPage._snapHeader();
 		assert.equal(oDynamicPage.getHeaderExpanded(), false, "setting it to false via user interaction");
-		assert.ok(oDynamicPage.$titleArea.hasClass(sSnappedClass));
+		assert.ok(oDynamicPage.$("header").hasClass(sSnappedClass));
 		assert.ok(oSetPropertySpy.calledWith("headerExpanded", false, true));
 		assert.strictEqual($oDynamicPageHeader.css("visibility"), "hidden", "Header should be excluded from the tab chain");
 		assert.strictEqual(parseInt($oDynamicPageHeader[0].style.height), iHeaderHeight, "Header height is fixed");

--- a/src/sap.f/test/sap/f/qunit/DynamicPageTitle.qunit.js
+++ b/src/sap.f/test/sap/f/qunit/DynamicPageTitle.qunit.js
@@ -1315,7 +1315,7 @@ function (
 
 				setTimeout(function () {
 					// Assert
-					assert.strictEqual(oSpy.firstCall.args[0], null,
+					assert.strictEqual(oSpy.firstCall?.args[0], null,
 						"_setContentAreaFlexBasis is called first with null value to reset the flex-basis");
 					// Clean up
 					fnDone();
@@ -1417,11 +1417,11 @@ function (
 		oUtil.toMobileMode();
 		oUtil.renderObject(this.oDynamicPage);
 
-		var $TopArea = this.oDynamicPageTitle.$topArea,
-			$MainArea = this.oDynamicPageTitle.$mainArea,
+		var $TopArea = this.oDynamicPageTitle.$("top"),
+			$MainArea = this.oDynamicPageTitle.$("main"),
 			bIsExpandButtonVisible = this.oDynamicPageTitle._getShowExpandButton(),
-			$STOMWrapper = this.oDynamicPageTitle.$snappedTitleOnMobileWrapper,
-			oSnappedWrapper = this.oDynamicPageTitle.$snappedWrapper.context,
+			$STOMWrapper = this.oDynamicPageTitle.$("snapped-title-on-mobile-wrapper"),
+			oSnappedWrapper = this.oDynamicPageTitle.$("snapped-wrapper").context,
 			oSnappedHeadingWrapper,
 			oTitle,
 			$titleWrapper = this.oDynamicPage.$("header");
@@ -1471,7 +1471,7 @@ function (
 		Core.applyChanges();
 
 		this.oDynamicPage.setHeaderExpanded(true);
-		oSnappedHeadingWrapper = this.oDynamicPageTitle.$snappedHeadingWrapper;
+		oSnappedHeadingWrapper = this.oDynamicPageTitle.$("snapped-heading-wrapper");
 
 		assert.ok(oSnappedHeadingWrapper.hasClass("sapUiHidden"), "Snapped content is hidden on mobile when SnappedTitleOnMobile " +
 		"is set");
@@ -1489,11 +1489,11 @@ function (
 		this.oDynamicPageTitle.setAggregation("snappedTitleOnMobile", null);
 		oUtil.renderObject(this.oDynamicPage);
 
-		var $TopArea = this.oDynamicPageTitle.$topArea,
-			$MainArea = this.oDynamicPageTitle.$mainArea,
+		var $TopArea = this.oDynamicPageTitle.$("top"),
+			$MainArea = this.oDynamicPageTitle.$("main"),
 			bIsExpandButtonVisible = this.oDynamicPageTitle._getShowExpandButton(),
-			oSTOMWrapper = this.oDynamicPageTitle.$snappedTitleOnMobileWrapper.context,
-			$SnappedWrapper = this.oDynamicPageTitle.$snappedWrapper,
+			oSTOMWrapper = this.oDynamicPageTitle.$("snapped-title-on-mobile-wrapper").context,
+			$SnappedWrapper = this.oDynamicPageTitle.$("snapped-wrapper"),
 			$titleWrapper = this.oDynamicPage.$("header");
 
 		// Assert
@@ -1537,11 +1537,11 @@ function (
 		oUtil.toTabletMode();
 		oUtil.renderObject(this.oDynamicPage);
 
-		var $TopArea = this.oDynamicPageTitle.$topArea,
-			$MainArea = this.oDynamicPageTitle.$mainArea,
+		var $TopArea = this.oDynamicPageTitle.$("top"),
+			$MainArea = this.oDynamicPageTitle.$("main"),
 			bIsExpandButtonVisible = this.oDynamicPageTitle._getShowExpandButton(),
-			oSTOMWrapper = this.oDynamicPageTitle.$snappedTitleOnMobileWrapper.context,
-			$SnappedWrapper = this.oDynamicPageTitle.$snappedWrapper,
+			oSTOMWrapper = this.oDynamicPageTitle.$("snapped-title-on-mobile-wrapper").context,
+			$SnappedWrapper = this.oDynamicPageTitle.$("snapped-wrapper"),
 			$titleWrapper = this.oDynamicPage.$("header");
 
 		// Assert
@@ -1584,11 +1584,11 @@ function (
 		// Arrange
 		oUtil.renderObject(this.oDynamicPage);
 
-		var $TopArea = this.oDynamicPageTitle.$topArea,
-			$MainArea = this.oDynamicPageTitle.$mainArea,
+		var $TopArea = this.oDynamicPageTitle.$("top"),
+			$MainArea = this.oDynamicPageTitle.$("main"),
 			bIsExpandButtonVisible = this.oDynamicPageTitle._getShowExpandButton(),
-			oSTOMWrapper = this.oDynamicPageTitle.$snappedTitleOnMobileWrapper.context,
-			$SnappedWrapper = this.oDynamicPageTitle.$snappedWrapper,
+			oSTOMWrapper = this.oDynamicPageTitle.$("snapped-title-on-mobile-wrapper").context,
+			$SnappedWrapper = this.oDynamicPageTitle.$("snapped-wrapper"),
 			$titleWrapper = this.oDynamicPage.$("header");
 
 		// Assert

--- a/src/sap.f/test/sap/f/qunit/DynamicPageWithStickySubheader.qunit.js
+++ b/src/sap.f/test/sap/f/qunit/DynamicPageWithStickySubheader.qunit.js
@@ -558,7 +558,7 @@ sap.ui.define([
 		QUnit.test("ScrollToElement correct when subHeader toggles", function(assert) {
 			var oIconTabBar = this.oDynamicPage.getContent(),
 				oElement = oIconTabBar.getItems()[0].getContent()[0].getContent()[20].getDomRef(),
-				$wrapper = this.oDynamicPage.$wrapper;
+				$wrapper = this.oDynamicPage.$("contentWrapper");
 
 			// Setup: an element in the context exists
 			assert.ok(oElement, "element is in dom");

--- a/src/sap.f/test/sap/f/qunit/FlexibleColumnLayout.qunit.js
+++ b/src/sap.f/test/sap/f/qunit/FlexibleColumnLayout.qunit.js
@@ -9,7 +9,8 @@ sap.ui.define([
 	"sap/m/Button",
 	"sap/ui/core/Core",
 	"sap/ui/core/ResizeHandler",
-	"sap/f/library"
+	"sap/f/library",
+	"sap/ui/thirdparty/jquery"
 ],
 function(
 	ControlBehavior,
@@ -21,7 +22,8 @@ function(
 	Button,
 	Core,
 	ResizeHandler,
-	library
+	library,
+	jQuery
 ) {
 	"use strict";
 
@@ -973,7 +975,7 @@ function(
 
 		// arrange
 		var fnDone = assert.async(),
-			oBeginColumn = this.oFCL._$columns["begin"],
+			oBeginColumn = jQuery(this.oFCL._columns["begin"]),
 			oBeginColumnDomRef = oBeginColumn.get(0),
 			oSuspendSpy = this.spy(ResizeHandler, "suspend"),
 			oResumeSpy = this.spy(ResizeHandler, "resume");
@@ -1101,7 +1103,7 @@ function(
 
 	QUnit.test("Conceal effect layout changes", function(assert) {
 		//arrange
-		var $endColumn = this.oFCL._$columns["end"],
+		var $endColumn = jQuery(this.oFCL._columns["end"]),
 		fnDone = assert.async();
 
 		this.stub(this.oFCL, "_getControlWidth").returns(parseInt(DESKTOP_SIZE));
@@ -1163,15 +1165,15 @@ function(
 		this.oFCL._oAnimationEndListener.waitForAllColumnsResizeEnd().then(function() {
 			// assert
 			assertColumnsVisibility(assert, this.oFCL, 0, 1, 0);
-			assert.ok(this.oFCL._$columns["begin"].hasClass('sapFFCLColumnHidden'));
-			assert.notOk(this.oFCL._$columns["mid"].hasClass('sapFFCLColumnHidden'));
-			assert.ok(this.oFCL._$columns["end"].hasClass('sapFFCLColumnHidden'));
+			assert.ok(jQuery(this.oFCL._columns["begin"]).hasClass('sapFFCLColumnHidden'));
+			assert.notOk(jQuery(this.oFCL._columns["mid"]).hasClass('sapFFCLColumnHidden'));
+			assert.ok(jQuery(this.oFCL._columns["end"]).hasClass('sapFFCLColumnHidden'));
 
 			// act
 			this.oFCL._afterColumnResize("end", 100);
 
 			// assert
-			assert.notOk(this.oFCL._$columns["end"].hasClass('sapFFCLColumnHidden'),
+			assert.notOk(jQuery(this.oFCL._columns["end"]).hasClass('sapFFCLColumnHidden'),
 				"When width is updated, 'sapFFCLColumnHidden' class should be removed");
 
 			fnDone();
@@ -1628,9 +1630,9 @@ function(
 					this.oFCL.detachColumnResize(fnCallback);
 					// assert
 					assert.equal(oResizeFunctionSpy.callCount, 3, "ResizeHandler.resume is called for all columns");
-					assert.ok(oResizeFunctionSpy.withArgs(this.oFCL._$columns['begin'].get(0)).calledOnce);
-					assert.ok(oResizeFunctionSpy.withArgs(this.oFCL._$columns['mid'].get(0)).calledOnce);
-					assert.ok(oResizeFunctionSpy.withArgs(this.oFCL._$columns['end'].get(0)).calledOnce);
+					assert.ok(oResizeFunctionSpy.withArgs(jQuery(this.oFCL._columns['begin']).get(0)).calledOnce);
+					assert.ok(oResizeFunctionSpy.withArgs(jQuery(this.oFCL._columns['mid']).get(0)).calledOnce);
+					assert.ok(oResizeFunctionSpy.withArgs(jQuery(this.oFCL._columns['end']).get(0)).calledOnce);
 					fnDone();
 				}
 			}.bind(this);
@@ -1839,7 +1841,7 @@ function(
 			this.oFCL.setLayout(sLayoutName);
 
 			FlexibleColumnLayout.COLUMN_ORDER.forEach(function(sColumn) {
-				var oColumn = this.oFCL._$columns[sColumn],
+				var oColumn = jQuery(this.oFCL._columns[sColumn]),
 					iExpectedColumnWidth = parseInt(oColumn.css("width")),
 					iActualColumnWidth = this.oFCL._getColumnWidth(sColumn);
 				assert.strictEqual(iActualColumnWidth, iExpectedColumnWidth, "correct with for " + sColumn);
@@ -1861,7 +1863,7 @@ function(
 		});
 
 		FlexibleColumnLayout.COLUMN_ORDER.forEach(function(sColumn) {
-			var oColumn = this.oFCL._$columns[sColumn],
+			var oColumn = jQuery(this.oFCL._columns[sColumn]),
 				iExpectedColumnWidth = oColumn.width(),
 				iActualColumnWidth = this.oFCL._getColumnWidth(sColumn);
 			assert.strictEqual(iActualColumnWidth, iExpectedColumnWidth, "correct with for " + sColumn);

--- a/src/sap.f/test/sap/f/qunit/SemanticPage.qunit.js
+++ b/src/sap.f/test/sap/f/qunit/SemanticPage.qunit.js
@@ -1036,13 +1036,13 @@ function(
 			oPage.getScrollDelegate().scrollTo(0, 2000);
 
 			//Assert
-			assert.equal(oPage.getTitle().$expandWrapper.hasClass("sapUiHidden"), true, "Header is snapped on scroll bottom");
+			assert.equal(oPage.getTitle().$("expand-wrapper").hasClass("sapUiHidden"), true, "Header is snapped on scroll bottom");
 			assert.equal(oPage.getTitle()._bExpandedState, false, "Header is in snapped state on scroll bottom");
 			//Act
 			oPage.getScrollDelegate().scrollTo(0, 0);
 			setTimeout(function () {
 				//Assert
-				assert.equal(oPage.getTitle().$expandWrapper.hasClass("sapUiHidden"), false, "Header is expanded on scroll top");
+				assert.equal(oPage.getTitle().$("expand-wrapper").hasClass("sapUiHidden"), false, "Header is expanded on scroll top");
 				assert.equal(oPage.getTitle()._bExpandedState, true, "Header is in expanded state on scroll top");
 				done();
 			});


### PR DESCRIPTION
`sap.f` is almost jQuery free now! I've removed most of its usage from the lib, the leftovers are mostly `jQuery data` and `jQuery events`.