### PR TITLE
fix(sap.ui.unified): provide fallback icon constructor for menu item in case custom image is provided

### DIFF
--- a/src/sap.ui.unified/src/sap/ui/unified/MenuItemBase.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/MenuItemBase.js
@@ -3,8 +3,8 @@
  */
 
 // Provides control sap.ui.unified.MenuItemBase.
-sap.ui.define(['sap/ui/core/Element', './library', 'sap/ui/core/IconPool'],
-	function(Element, library, IconPool) {
+sap.ui.define(['sap/ui/core/Element', './library', 'sap/ui/core/IconPool', 'sap/m/Image'],
+	function(Element, library, IconPool, Image) {
 	"use strict";
 
 
@@ -162,7 +162,7 @@ sap.ui.define(['sap/ui/core/Element', './library', 'sap/ui/core/IconPool'],
 		return IconPool.createControlByURI({
 			src: oItem.getIcon(),
 			useIconTooltip: false
-		});
+		}, Image);
 	};
 
 	MenuItemBase.prototype.onsaphide = MenuItemBase.prototype.onsapshow;


### PR DESCRIPTION
This change would provide a fallback constructor to the `createControlByURI` call, which will then be used in case the provided `src` is not in the icon pool.


Solves #3928 