### PR TITLE
refactor: Use performance rather than window.performance

### DIFF
--- a/src/sap.ui.core/src/jquery.sap.global.js
+++ b/src/sap.ui.core/src/jquery.sap.global.js
@@ -1227,8 +1227,8 @@ sap.ui.define([
 	 * @deprecated since 1.58 use native function <code>performance.getEntriesByType("resource")</code> instead
 	 */
 	jQuery.sap.measure.getRequestTimings = function() {
-		if (window.performance.getEntriesByType) {
-			return window.performance.getEntriesByType("resource");
+		if (performance.getEntriesByType) {
+			return performance.getEntriesByType("resource");
 		}
 		return [];
 	};
@@ -1242,8 +1242,8 @@ sap.ui.define([
 	 * @deprecated since 1.58 use native function <code>performance.clearResourceTimings()</code> where available
 	 */
 	jQuery.sap.measure.clearRequestTimings = function() {
-		if (window.performance.clearResourceTimings) {
-			window.performance.clearResourceTimings();
+		if (performance.clearResourceTimings) {
+			performance.clearResourceTimings();
 		}
 	};
 
@@ -1258,8 +1258,8 @@ sap.ui.define([
 	 * @deprecated since 1.58 use native function <code>performance.setResourceTimingBufferSize(iSize)</code> where available
 	 */
 	jQuery.sap.measure.setRequestBufferSize = function(iSize) {
-		if (window.performance.setResourceTimingBufferSize) {
-			window.performance.setResourceTimingBufferSize(iSize);
+		if (performance.setResourceTimingBufferSize) {
+			performance.setResourceTimingBufferSize(iSize);
 		}
 	};
 

--- a/src/sap.ui.core/src/jquery.sap.trace.js
+++ b/src/sap.ui.core/src/jquery.sap.trace.js
@@ -20,7 +20,7 @@ function(jQuery, Passport, Interaction, FESR, Log, BaseConfig/* ,Global */) {
 
 	function logSupportWarning() {
 		// in case we do not have this API measurement is superfluous due to insufficient performance data
-		if (!(window.performance && window.performance.getEntries)) {
+		if (!(performance && performance.getEntries)) {
 			Log.warning("Interaction tracking is not supported on browsers with insufficient performance API");
 		}
 	}

--- a/src/sap.ui.core/src/sap/ui/core/rules/Config.support.js
+++ b/src/sap.ui.core/src/sap/ui/core/rules/Config.support.js
@@ -124,7 +124,7 @@ sap.ui.define([
 			var sUI5ICFNode = "/sap/bc/ui5_ui5/";
 			var aAppNames = [];
 			var sAppName;
-			var aRequests = window.performance.getEntriesByType("resource");
+			var aRequests = performance.getEntriesByType("resource");
 			for (var i = 0; i < aRequests.length; i++) {
 				var sUrl = aRequests[i].name;
 				//We limit the check to requests under ICF node "/sap/bc/ui5_ui5/", only these are relevant here

--- a/src/sap.ui.core/src/sap/ui/core/support/plugins/Interaction.js
+++ b/src/sap.ui.core/src/sap/ui/core/support/plugins/Interaction.js
@@ -204,7 +204,7 @@ sap.ui.define([
 			if (bActive || jsonData) {
 				aMeasurements = jsonData || TraceInteraction.getAll(/*bFinalize=*/true);
 
-				var fetchStart = window.performance.getEntriesByType("navigation")?.[0]?.fetchStart;
+				var fetchStart = performance.getEntriesByType("navigation")?.[0]?.fetchStart;
 
 				for (var i = 0; i < aMeasurements.length; i++) {
 					var measurement = aMeasurements[i];

--- a/src/sap.ui.core/src/sap/ui/core/support/trace/E2eTraceLib.js
+++ b/src/sap.ui.core/src/sap/ui/core/support/trace/E2eTraceLib.js
@@ -273,7 +273,7 @@ sap.ui.define(['sap/ui/Device', 'sap/ui/performance/trace/Passport', 'sap/base/L
 					return tstmp;
 				};
 				//check if browser supports PerformanceTiming
-				if (window.performance && performance.timeOrigin) {
+				if (performance && performance.timeOrigin) {
 					// handle browser dependencies in (hires) time stamps
 					if (Device.browser.chrome && Device.browser.version >= 49) {
 						getTstmp = function(tstmp) {
@@ -352,7 +352,7 @@ sap.ui.define(['sap/ui/Device', 'sap/ui/performance/trace/Passport', 'sap/base/L
 
 						//add tracing attributes
 						this.xidx = idx;
-						if (window.performance && performance.timeOrigin && performance.now !== undefined) {
+						if (performance && performance.timeOrigin && performance.now !== undefined) {
 							this.xstartTimestamp = performance.timeOrigin + performance.now();
 						} else {
 							this.xstartTimestamp = Date.now();

--- a/src/sap.ui.core/src/sap/ui/events/jquery/EventTriggerHook.js
+++ b/src/sap.ui.core/src/sap/ui/events/jquery/EventTriggerHook.js
@@ -24,7 +24,7 @@ sap.ui.define([
 		var bIsLoggable = Log.isLoggable(Log.Level.DEBUG),
 			mEventInfo = mTriggerEventInfo[oEvent.type],
 			fnOriginalTriggerHook = mEventInfo.originalTriggerHook,
-			t0 = window.performance.now(),
+			t0 = performance.now(),
 			t1, sId, oDomInfo;
 
 		if (!oEvent.isPropagationStopped() && !oEvent.isSimulated) {
@@ -34,7 +34,7 @@ sap.ui.define([
 					oEvent.preventDefault();
 					oEvent.stopImmediatePropagation();
 					if (bIsLoggable) {
-						t1 = window.performance.now();
+						t1 = performance.now();
 						Log.debug("Perf: jQuery trigger suppression event handler " + oEvent.type + " took " + (t1 - t0) + " milliseconds.");
 					}
 					return false; //prevent further jQuery processing.

--- a/src/sap.ui.core/src/sap/ui/performance/trace/Interaction.js
+++ b/src/sap.ui.core/src/sap/ui/performance/trace/Interaction.js
@@ -102,7 +102,7 @@ sap.ui.define([
 			trigger: "undetermined", // control which triggered interaction
 			component: "undetermined", // component or app identifier
 			appVersion: "undetermined", // application version as from app descriptor
-			start: iTime || window.performance.timeOrigin, // interaction start - page timeOrigin if initial
+			start: iTime || performance.timeOrigin, // interaction start - page timeOrigin if initial
 			end: 0, // interaction end
 			navigation: 0, // sum over all navigation times
 			roundtrip: 0, // time from first request sent to last received response end - without gaps and ignored overlap
@@ -131,7 +131,7 @@ sap.ui.define([
 	/**
 	 * Check if request is initiated by XHR, comleted and timeframe of request is within timeframe of current interaction
 	 *
-	 * @param {object} oRequestTiming PerformanceResourceTiming as retrieved by window.performance.getEntryByType("resource")
+	 * @param {object} oRequestTiming PerformanceResourceTiming as retrieved by performance.getEntryByType("resource")
 	 * @return {boolean} true if the request is a completed XHR with started and ended within the current interaction
 	 * @private
 	 */
@@ -141,8 +141,8 @@ sap.ui.define([
 			oRequestTiming.startTime <= oRequestTiming.requestStart &&
 			oRequestTiming.requestStart <= oRequestTiming.responseEnd;
 
-		var bPartOfInteraction = oPendingInteraction.start <= (window.performance.timeOrigin + oRequestTiming.requestStart) &&
-			oPendingInteraction.end >= (window.performance.timeOrigin + oRequestTiming.responseEnd);
+		var bPartOfInteraction = oPendingInteraction.start <= (performance.timeOrigin + oRequestTiming.requestStart) &&
+			oPendingInteraction.end >= (performance.timeOrigin + oRequestTiming.responseEnd);
 
 		return bPartOfInteraction && bComplete && oRequestTiming.initiatorType === "xmlhttprequest";
 	}
@@ -196,7 +196,7 @@ sap.ui.define([
 
 	function finalizeInteraction(iTime) {
 		if (oPendingInteraction) {
-			var aAllRequestTimings = window.performance.getEntriesByType("resource");
+			var aAllRequestTimings = performance.getEntriesByType("resource");
 			var oFinshedInteraction;
 			oPendingInteraction.end = iTime;
 			oPendingInteraction.processing = iTime - oPendingInteraction.start;
@@ -398,7 +398,7 @@ sap.ui.define([
 				this.pendingInteraction.networkTime += sFesrec ? Math.round(parseFloat(sFesrec, 10) / 1000) : 0;
 				var sSapStatistics = this.getResponseHeader("sap-statistics");
 				if (sSapStatistics) {
-					var aTimings = window.performance.getEntriesByType("resource");
+					var aTimings = performance.getEntriesByType("resource");
 					this.pendingInteraction.sapStatistics.push({
 						// add response url for mapping purposes
 						url: this.responseURL,
@@ -520,8 +520,8 @@ sap.ui.define([
 			iInteractionCounter = 0;
 
 			// clear request timings for new interaction
-			if (window.performance.clearResourceTimings) {
-				window.performance.clearResourceTimings();
+			if (performance.clearResourceTimings) {
+				performance.clearResourceTimings();
 			}
 
 			var oComponentInfo = createOwnerComponentInfo(oSrcElement);

--- a/src/sap.ui.core/src/sap/ui/performance/trace/initTraces.js
+++ b/src/sap.ui.core/src/sap/ui/performance/trace/initTraces.js
@@ -37,7 +37,7 @@ sap.ui.define([
 			sUrl = ["true", "false", "x", "X", undefined].indexOf(sFesr) === -1 ? sFesr : undefined;
 		}
 
-		if (typeof window.performance.getEntriesByType === "function") {
+		if (typeof performance.getEntriesByType === "function") {
 			FESR.setActive(bActive, sUrl);
 		} else {
 			Log.debug("FESR is not supported in clients without support of window.Performance extensions.");

--- a/src/sap.ui.core/test/sap/ui/core/qunit/ThemeParameters.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/ThemeParameters.qunit.js
@@ -15,9 +15,9 @@ sap.ui.define([
 
 	QUnit.module("Parmeters.get", {
 		before: function() {
-			// For some reasons window.performance.getResourceByType does only return the first 250?!
+			// For some reasons performance.getResourceByType does only return the first 250?!
 			// entries therefore clear the resource timings upfront
-			window.performance.clearResourceTimings();
+			performance.clearResourceTimings();
 		}
 	});
 
@@ -51,7 +51,7 @@ sap.ui.define([
 	}
 
 	function checkLibraryParametersJsonRequestForLib(sLibNumber) {
-		return window.performance.getEntriesByType("resource").filter(function (oResource) {
+		return performance.getEntriesByType("resource").filter(function (oResource) {
 			return oResource.name.endsWith("themeParameters/lib" + sLibNumber + "/themes/sap_hcb/library-parameters.json");
 		});
 	}
@@ -74,9 +74,9 @@ sap.ui.define([
 
 	QUnit.module("Parmeters.get (async)", {
 		before: function() {
-			// For some reasons window.performance.getResourceByType does only return the first 250?!
+			// For some reasons performance.getResourceByType does only return the first 250?!
 			// entries therefore clear the resource timings upfront
-			window.performance.clearResourceTimings();
+			performance.clearResourceTimings();
 		}
 	});
 

--- a/src/sap.ui.core/test/sap/ui/core/qunit/ThemeParameters_legacyAPIs.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/ThemeParameters_legacyAPIs.qunit.js
@@ -15,9 +15,9 @@ sap.ui.define([
 
 	QUnit.module("Parmeters.get", {
 		before: function() {
-			// For some reasons window.performance.getResourceByType does only return the first 250?!
+			// For some reasons performance.getResourceByType does only return the first 250?!
 			// entries therefore clear the resource timings upfront
-			window.performance.clearResourceTimings();
+			performance.clearResourceTimings();
 		}
 	});
 
@@ -65,7 +65,7 @@ sap.ui.define([
 	}
 
 	function checkLibraryParametersJsonRequestForLib(sLibNumber) {
-		return window.performance.getEntriesByType("resource").filter(function (oResource) {
+		return performance.getEntriesByType("resource").filter(function (oResource) {
 			return oResource.name.endsWith("themeParameters/lib" + sLibNumber + "/themes/sap_hcb/library-parameters.json");
 		});
 	}
@@ -96,9 +96,9 @@ sap.ui.define([
 	 */
 	QUnit.module("Parmeters.get (sync)", {
 		before: function() {
-			// For some reasons window.performance.getResourceByType does only return the first 250?!
+			// For some reasons performance.getResourceByType does only return the first 250?!
 			// entries therefore clear the resource timings upfront
-			window.performance.clearResourceTimings();
+			performance.clearResourceTimings();
 
 			// test setup: load legacy.testlib (will be removed in 2.0, together with this QUnit module)
 			sap.ui.getCore().loadLibrary("sap.ui.legacy.testlib");
@@ -432,9 +432,9 @@ sap.ui.define([
 	 */
 	QUnit.module("Parmeters.get (async)", {
 		before: function() {
-			// For some reasons window.performance.getResourceByType does only return the first 250?!
+			// For some reasons performance.getResourceByType does only return the first 250?!
 			// entries therefore clear the resource timings upfront
-			window.performance.clearResourceTimings();
+			performance.clearResourceTimings();
 		}
 	});
 

--- a/src/sap.ui.core/test/sap/ui/core/qunit/base/util/now.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/base/util/now.qunit.js
@@ -12,7 +12,7 @@ sap.ui.define(["sap/base/util/now"], function(now) {
 	});
 
 	QUnit.test("tests for window performance object", function(assert) {
-		assert.ok(window.performance && performance.now && performance.timeOrigin, "check for presence of window.performance");
+		assert.ok(performance && performance.now && performance.timeOrigin, "check for presence of performance");
 		assert.ok(new Date(now()) instanceof Date, "should be a valid date");
 	});
 

--- a/src/sap.ui.core/test/sap/ui/core/qunit/bootstrap/DebugMode.beforeBootstrap.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/bootstrap/DebugMode.beforeBootstrap.qunit.js
@@ -1,8 +1,8 @@
 (function() {
 	"use strict";
 	// increase performance buffer size
-	if ( window.performance && window.performance.setResourceTimingBufferSize ) {
-		window.performance.setResourceTimingBufferSize(500);
+	if ( performance && performance.setResourceTimingBufferSize ) {
+		performance.setResourceTimingBufferSize(500);
 	}
 	// add debug mode to title
 	var mMatch = /(?:^|\?|&)sap-ui-debug=([^&]*)(?:&|$)/.exec(location.search),

--- a/src/sap.ui.core/test/sap/ui/core/qunit/bootstrap/DebugMode.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/bootstrap/DebugMode.qunit.js
@@ -35,9 +35,9 @@ sap.ui.require(["sap/base/util/fetch"], function (fetch) {
 		var off = 'skip';
 		if ( bDebugModules
 			 && !bInstrumentedCode
-			 && window.performance
-			 && typeof window.performance.getEntriesByType === 'function'
-			 && window.performance.getEntriesByType('resource').length > 0 ) {
+			 && performance
+			 && typeof performance.getEntriesByType === 'function'
+			 && performance.getEntriesByType('resource').length > 0 ) {
 			precondition = 'test';
 			if ( window['sap-ui-debug'] === true ) {
 				full = 'test';
@@ -59,7 +59,7 @@ sap.ui.require(["sap/base/util/fetch"], function (fetch) {
 		 * Checks whether the recorded resource requests contain a request for the given resource
 		 */
 		function hasRequest(vExpectedResource) {
-			var aResources = window.performance.getEntriesByType("resource");
+			var aResources = performance.getEntriesByType("resource");
 			var i = 0;
 			while ( i < aResources.length ) {
 				var oResource = aResources[i];
@@ -81,7 +81,7 @@ sap.ui.require(["sap/base/util/fetch"], function (fetch) {
 		 * in exactly the given order.
 		 */
 		function hasRequestSequence(aExpectedResources) {
-			var aResources = window.performance.getEntriesByType("resource");
+			var aResources = performance.getEntriesByType("resource");
 			var aResourcesToCheck = aExpectedResources.slice();
 			var i = 0;
 			while ( i < aResources.length && aResourcesToCheck.length > 0 ) {
@@ -106,9 +106,9 @@ sap.ui.require(["sap/base/util/fetch"], function (fetch) {
 
 		QUnit[precondition]("Productive Sources and Performance Web API", function(assert) {
 			assert.equal(bDebugModules, true, "existance of sap/ui/core/Core-dbg.js resource indicates productive + debug sources");
-			assert.ok(window.performance, "Performance API should be available");
-			assert.equal(typeof window.performance.getEntriesByType, 'function', "performance.getEntriesByType method is needed");
-			assert.notEqual(window.performance.getEntriesByType('resource').length, 0, "performance.getEntriesByType() should return non-empty array");
+			assert.ok(performance, "Performance API should be available");
+			assert.equal(typeof performance.getEntriesByType, 'function', "performance.getEntriesByType method is needed");
+			assert.notEqual(performance.getEntriesByType('resource').length, 0, "performance.getEntriesByType() should return non-empty array");
 		});
 
 		// ---- full debug mode -------------------------------------------

--- a/src/sap.ui.core/test/sap/ui/core/qunit/performance/trace/FESR.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/performance/trace/FESR.qunit.js
@@ -6,7 +6,7 @@ sap.ui.define(['sap/ui/performance/trace/FESR', 'sap/ui/performance/trace/Intera
 	QUnit.config.reorder = false;
 	var requestCounter = 0;
 
-	// window.performance is hijacked by sinon's fakeTimers (https://github.com/sinonjs/fake-timers/issues/374)
+	// performance is hijacked by sinon's fakeTimers (https://github.com/sinonjs/fake-timers/issues/374)
 	// and might be out of sync with the latest specs and APIs. Therefore, mock them further,
 	// so they won't affect tests.
 	//

--- a/src/sap.ui.core/test/sap/ui/core/qunit/performance/trace/Interaction.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/performance/trace/Interaction.qunit.js
@@ -9,7 +9,7 @@ sap.ui.define([
 ], function(Interaction, XMLView, FESRHelper, Press, Button, nextUIUpdate) {
 	"use strict";
 
-	// window.performance is hijacked by sinon's fakeTimers (https://github.com/sinonjs/fake-timers/issues/374)
+	// performance is hijacked by sinon's fakeTimers (https://github.com/sinonjs/fake-timers/issues/374)
 	// and might be out of sync with the latest specs and APIs. Therefore, mock them further,
 	// so they won't affect tests.
 	//

--- a/src/sap.ui.core/test/sap/ui/core/qunit/util/jQuery.sap.measure.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/util/jQuery.sap.measure.qunit.js
@@ -10,7 +10,7 @@ sap.ui.define([
 ], function(jQuery, Device, UIComponent, Button, createAndAppendDiv, Interaction) {
 	"use strict";
 
-	// window.performance is hijacked by sinon's fakeTimers (https://github.com/sinonjs/fake-timers/issues/374)
+	// performance is hijacked by sinon's fakeTimers (https://github.com/sinonjs/fake-timers/issues/374)
 	// and might be out of sync with the latest specs and APIs. Therefore, mock them further,
 	// so they won't affect tests.
 	//
@@ -474,7 +474,7 @@ sap.ui.define([
 
 	QUnit.test("filterInteractionMeasurements", function(assert) {
 		this.clock = mockPerformanceObject();
-		window.performance.getEntriesByType = function() { return []; };
+		performance.getEntriesByType = function() { return []; };
 
 		jQuery.sap.measure.startInteraction("click", this.oButton);
 		addFakeProcessingTime.apply(this);
@@ -539,7 +539,7 @@ sap.ui.define([
 	});
 
 	// do not test safari as it does not seem to work in testing environments
-	var bStablePerformanceAPI = window.performance && window.performance.getEntries && !Device.browser.safari;
+	var bStablePerformanceAPI = performance && performance.getEntries && !Device.browser.safari;
 
 	QUnit.test("Performance API depending measures", function(assert) {
 		jQuery.sap.measure.startInteraction("click", this.oButton);

--- a/src/sap.ui.core/test/sap/ui/core/qunit/util/jquery.sap.trace.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/util/jquery.sap.trace.qunit.js
@@ -118,7 +118,7 @@ sap.ui.define([
 	QUnit.module("FESR Header", {
 		beforeEach: function() {
 			this.spy = sinon.spy(window.XMLHttpRequest.prototype, "setRequestHeader");
-			this.stub = sinon.stub(window.performance, "getEntriesByType").returns([]);
+			this.stub = sinon.stub(performance, "getEntriesByType").returns([]);
 			this.start = function(aRequests) {
 				return new Promise(function (resolve) {
 					var iEndtimeOfLastRequest = 0;

--- a/src/sap.ui.dt/test/sap/ui/dt/internal/performance/DesignTimeApplyStyles.html
+++ b/src/sap.ui.dt/test/sap/ui/dt/internal/performance/DesignTimeApplyStyles.html
@@ -57,14 +57,14 @@
 					var oRootOverlay = OverlayRegistry.getOverlay("Panel");
 
 					oRootOverlay.attachEventOnce("geometryChanged", function () {
-						window.performance.mark("applyStyles.stop");
-						window.performance.measure("ApplyStylesSync", "applyStyles.start", "applyStyles.stop");
-						window.wpp.customMetrics.applyStylesSync = window.performance.getEntriesByName("ApplyStylesSync")[0].duration;
+						performance.mark("applyStyles.stop");
+						performance.measure("ApplyStylesSync", "applyStyles.start", "applyStyles.stop");
+						window.wpp.customMetrics.applyStylesSync = performance.getEntriesByName("ApplyStylesSync")[0].duration;
 						BaseLog.info("ApplyStylesSync = ", window.wpp.customMetrics.applyStylesSync + "ms");
 					});
 
 					oRootOverlay.attachEventOnce("beforeGeometryChanged", function () {
-						window.performance.mark("applyStyles.start");
+						performance.mark("applyStyles.start");
 					});
 
 					oRootOverlay.getElement().setWidth("2500px");
@@ -82,14 +82,14 @@
 					var oRootOverlay = OverlayRegistry.getOverlay("Panel");
 					oRootOverlay.attachEventOnce("geometryChanged", function () {
 						oRootOverlay.attachEventOnce("beforeGeometryChanged", function () {
-							window.performance.mark("applyStyles.start");
+							performance.mark("applyStyles.start");
 						});
 						oRootOverlay.getElement().$('content').get(0).scrollTop = 200;
 						oRootOverlay.getElement().setWidth("2100px");
 						oRootOverlay.attachEventOnce("geometryChanged", function() {
-							window.performance.mark("applyStyles.stop");
-							window.performance.measure("ApplyStylesAsync", "applyStyles.start", "applyStyles.stop");
-							window.wpp.customMetrics.applyStylesAsync = window.performance.getEntriesByName("ApplyStylesAsync")[0].duration;
+							performance.mark("applyStyles.stop");
+							performance.measure("ApplyStylesAsync", "applyStyles.start", "applyStyles.stop");
+							window.wpp.customMetrics.applyStylesAsync = performance.getEntriesByName("ApplyStylesAsync")[0].duration;
 							BaseLog.info("ApplyStylesAsync = ", window.wpp.customMetrics.applyStylesAsync + "ms");
 						});
 					});

--- a/src/sap.ui.dt/test/sap/ui/dt/internal/performance/DesignTimeDragAndDropTest.html
+++ b/src/sap.ui.dt/test/sap/ui/dt/internal/performance/DesignTimeDragAndDropTest.html
@@ -95,7 +95,7 @@
 					OverlayRegistry,
 					BaseLog
 				) {
-					window.performance.mark("drag.starts");
+					performance.mark("drag.starts");
 					//get overlays
 					var oLayout1Overlay = OverlayRegistry.getOverlay("Layout1");
 					var oControlInLayout1Overlay = OverlayRegistry.getOverlay("Control1");
@@ -164,9 +164,9 @@
 						oLayout1Overlay.$().trigger("dragend");
 					}).then(function(){
 						//measure time
-						window.performance.mark("drag.ends");
-						window.performance.measure("DragAndDrop", "drag.starts", "drag.ends");
-						window.wpp.customMetrics.dragDropTime = window.performance.getEntriesByName("DragAndDrop")[0].duration;
+						performance.mark("drag.ends");
+						performance.measure("DragAndDrop", "drag.starts", "drag.ends");
+						window.wpp.customMetrics.dragDropTime = performance.getEntriesByName("DragAndDrop")[0].duration;
 						BaseLog.info("Drag and Drop took ", window.wpp.customMetrics.dragDropTime + "ms");
 
 						//mark something as done

--- a/src/sap.ui.dt/test/sap/ui/dt/internal/performance/PerformanceTestUtil.js
+++ b/src/sap.ui.dt/test/sap/ui/dt/internal/performance/PerformanceTestUtil.js
@@ -106,7 +106,7 @@ sap.ui.define([
 			// Create DesignTime in other tick
 			return new Promise(function(resolve) {
 				// will result in custom timer in webPageTest
-				window.performance.mark("dt.starts");
+				performance.mark("dt.starts");
 
 				var MOVABLE_TYPES = ["sap.ui.layout.VerticalLayout", "sap.m.Button", "sap.m.Label", "sap.m.DatePicker", "sap.m.Slider", "sap.m.RatingIndicator"];
 
@@ -119,7 +119,7 @@ sap.ui.define([
 					movableTypes: MOVABLE_TYPES
 				});
 				var oContextMenuPlugin = new ContextMenu();
-				window.performance.mark("dt.plugins.created");
+				performance.mark("dt.plugins.created");
 
 				var oDesignTime = new DesignTime({
 					plugins: [
@@ -132,9 +132,9 @@ sap.ui.define([
 				});
 				oDesignTime.attachEventOnce("synced", function() {
 					// will result in custom timer in webPageTest
-					window.performance.mark("dt.synced");
-					window.performance.measure("Create DesignTime and Overlays", "dt.starts", "dt.synced");
-					window.wpp.customMetrics.creationTime = window.performance.getEntriesByName("Create DesignTime and Overlays")[0].duration;
+					performance.mark("dt.synced");
+					performance.measure("Create DesignTime and Overlays", "dt.starts", "dt.synced");
+					window.wpp.customMetrics.creationTime = performance.getEntriesByName("Create DesignTime and Overlays")[0].duration;
 					Log.info("Create DesignTime and Overlays", `${window.wpp.customMetrics.creationTime}ms`);
 					// visual change at the end
 					var oOverlay = OverlayRegistry.getOverlay(sSelectedOverlayId || "Control2");

--- a/src/sap.ui.fl/test/sap/ui/fl/internal/performance/utils/FlexPerformanceTestUtil.js
+++ b/src/sap.ui.fl/test/sap/ui/fl/internal/performance/utils/FlexPerformanceTestUtil.js
@@ -56,8 +56,8 @@ sap.ui.define([
 		var sDurationText = `${sMassiveLabel} = ${window.wpp.customMetrics[sMassiveLabel]} ms`;
 		Log.info(sDurationText);
 		_addLabel(oLayout, sControlId, sDurationText);
-		window.performance.clearMarks();
-		window.performance.clearMeasures();
+		performance.clearMarks();
+		performance.clearMeasures();
 	}
 
 	function _addLabel(oLayout, sControlId, sText) {
@@ -205,13 +205,13 @@ sap.ui.define([
 
 	FlexPerformanceTestUtil.stopMeasurement = function(sMeasure) {
 		sMeasure ||= sMassiveLabel;
-		window.performance.measure(sMeasure, `${sMeasure}.start`);
-		window.wpp.customMetrics[sMeasure] = window.performance.getEntriesByName(sMeasure)[0].duration;
+		performance.measure(sMeasure, `${sMeasure}.start`);
+		window.wpp.customMetrics[sMeasure] = performance.getEntriesByName(sMeasure)[0].duration;
 	};
 
 	FlexPerformanceTestUtil.startMeasurement = function(sMeasure) {
 		sMeasure ||= sMassiveLabel;
-		window.performance.mark(`${sMeasure}.start`);
+		performance.mark(`${sMeasure}.start`);
 	};
 
 	FlexPerformanceTestUtil.startMeasurementForXmlPreprocessing = function() {

--- a/src/sap.ui.rta/test/sap/ui/rta/internal/performance/RtaPerformanceTestUtil.js
+++ b/src/sap.ui.rta/test/sap/ui/rta/internal/performance/RtaPerformanceTestUtil.js
@@ -25,15 +25,15 @@ sap.ui.define([
 			}
 
 			// will result in custom timer in webPageTest
-			window.performance.mark("rta.start.starts");
+			performance.mark("rta.start.starts");
 
 			return oRuntimeAuthoring.start()
 			.then(function() {
 				var sMeasureName = "RTA start function called";
 				// will result in custom timer in webPageTest
-				window.performance.mark("rta.start.ends");
-				window.performance.measure(sMeasureName, "rta.start.starts", "rta.start.ends");
-				window.wpp.customMetrics.startTime = window.performance.getEntriesByName(sMeasureName)[0].duration;
+				performance.mark("rta.start.ends");
+				performance.measure(sMeasureName, "rta.start.starts", "rta.start.ends");
+				window.wpp.customMetrics.startTime = performance.getEntriesByName(sMeasureName)[0].duration;
 				Log.info(sMeasureName, `${window.wpp.customMetrics.startTime}ms`);
 				// visual change at the end
 				var oOverlay = OverlayRegistry.getOverlay(oHorizontalLayout);
@@ -51,15 +51,15 @@ sap.ui.define([
 			oRuntimeAuthoring.setPlugins(mPlugins);
 
 			// will result in custom timer in webPageTest
-			window.performance.mark("rta.start.starts");
+			performance.mark("rta.start.starts");
 
 			return oRuntimeAuthoring.start()
 			.then(function() {
 				var sMeasureName = "RTA start function called";
 				// will result in custom timer in webPageTest
-				window.performance.mark("rta.start.ends");
-				window.performance.measure(sMeasureName, "rta.start.starts", "rta.start.ends");
-				window.wpp.customMetrics.startTime = window.performance.getEntriesByName(sMeasureName)[0].duration;
+				performance.mark("rta.start.ends");
+				performance.measure(sMeasureName, "rta.start.starts", "rta.start.ends");
+				window.wpp.customMetrics.startTime = performance.getEntriesByName(sMeasureName)[0].duration;
 				Log.info(sMeasureName, `${window.wpp.customMetrics.startTime}ms`);
 				// visual change at the end
 				var oOverlay = OverlayRegistry.getOverlay(oRootControl);
@@ -70,10 +70,10 @@ sap.ui.define([
 		startRtaConstructorOnly(oHorizontalLayout) {
 			var iRtaStartCounter = 1000;
 			var sMeasureName = `RTA init function called ${iRtaStartCounter} times`;
-			window.performance.clearMeasures();
+			performance.clearMeasures();
 
 			// will result in custom timer in webPageTest
-			window.performance.mark("rta.init.starts");
+			performance.mark("rta.init.starts");
 
 			for (var i = 0; i < iRtaStartCounter; i++) {
 				/* eslint no-new: 0 */
@@ -83,9 +83,9 @@ sap.ui.define([
 			}
 
 			// will result in custom timer in webPageTest
-			window.performance.mark("rta.init.ends");
-			window.performance.measure(sMeasureName, "rta.init.starts", "rta.init.ends");
-			window.wpp.customMetrics.creationTime = window.performance.getEntriesByName(sMeasureName)[0].duration;
+			performance.mark("rta.init.ends");
+			performance.measure(sMeasureName, "rta.init.starts", "rta.init.ends");
+			window.wpp.customMetrics.creationTime = performance.getEntriesByName(sMeasureName)[0].duration;
 			Log.info(sMeasureName, `${window.wpp.customMetrics.creationTime}ms`);
 		}
 	};

--- a/src/sap.ui.table/test/sap/ui/table/mvc/Performance.controller.js
+++ b/src/sap.ui.table/test/sap/ui/table/mvc/Performance.controller.js
@@ -263,7 +263,7 @@ sap.ui.define([
 		},
 
 		createTestResult: function() {
-			var aPerformanceEntries = window.performance.getEntriesByType("measure");
+			var aPerformanceEntries = performance.getEntriesByType("measure");
 			var oResultContainer = document.getElementById("results");
 
 			aPerformanceEntries.forEach(function(oPerformanceEntry) {
@@ -272,21 +272,21 @@ sap.ui.define([
 		},
 
 		clearTestResult: function() {
-			window.performance.clearMarks();
-			window.performance.clearMeasures();
+			performance.clearMarks();
+			performance.clearMeasures();
 			document.getElementById("results").innerHTML = "";
 		},
 
 		createMark: function(sName) {
-			if (window.performance.getEntriesByName(sName, "mark").length === 0) {
-				window.performance.mark(sName);
+			if (performance.getEntriesByName(sName, "mark").length === 0) {
+				performance.mark(sName);
 			}
 		},
 
 		createMeasure: function(sMeasureName, sStartMark, bKeepMark) {
-			window.performance.measure(sMeasureName, sStartMark);
+			performance.measure(sMeasureName, sStartMark);
 			if (bKeepMark !== true) {
-				window.performance.clearMarks(sStartMark);
+				performance.clearMarks(sStartMark);
 			}
 		},
 


### PR DESCRIPTION
We have `window.performance` and `performance` being used all over the place. They're the same.

I'm proposing to use only the `performance` form. It's shorter and consistent with JavaScript in all contexts: Node.js, browser window and browser worker.