### PR TITLE
Patch 1

### DIFF
--- a/src/themelib_sap_fiori_3/src/sap/uxap/themes/sap_fiori_3/ObjectPageHeaderContent.less
+++ b/src/themelib_sap_fiori_3/src/sap/uxap/themes/sap_fiori_3/ObjectPageHeaderContent.less
@@ -21,7 +21,7 @@
 	padding: 0;
 }
 
-html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
+html .sapUxAPObjectPageLayout-Std-Desktop-XL, html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
 	.sapUxAPObjectPageHeaderContent .sapUxAPObjectPageHeaderObjectImage-Circle .sapUxAPObjectPageHeaderObjectImage {
 		margin-right: 2rem;
 		margin-bottom: 1rem;
@@ -40,7 +40,8 @@ html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tab
 }
 
 .sapUxAPObjectPageLayout-Std-Tablet,
-.sapUxAPObjectPageLayout-Std-Desktop {
+.sapUxAPObjectPageLayout-Std-Desktop,
+.sapUxAPObjectPageLayout-Std-Desktop-XL {
 	.sapUxAPObjectPageHeaderContentCellRight {
 		padding-right: 2rem;
 	}
@@ -74,6 +75,7 @@ html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tab
 	}
 
 	&:empty {
+		.sapUxAPObjectPageLayout-Std-Desktop-XL &,
 		.sapUxAPObjectPageLayout-Std-Desktop &,
 		.sapUxAPObjectPageLayout-Std-Tablet &,
 		.sapUxAPObjectPageLayout-Std-Phone &

--- a/src/themelib_sap_fiori_3/src/sap/uxap/themes/sap_fiori_3_dark/ObjectPageHeaderContent.less
+++ b/src/themelib_sap_fiori_3/src/sap/uxap/themes/sap_fiori_3_dark/ObjectPageHeaderContent.less
@@ -5,6 +5,7 @@
 
 @sapUiFiori3AnchorBarBottomShadow: inset 0 -0.0625rem @sapUiObjectHeaderBorderColor;
 @sapUiFiori3AnchorBarTopShadow: inset 0 0.0625rem @sapUiObjectHeaderBorderColor;
+@sapUiFiori3AnchorBarShadow: @sapUiFiori3AnchorBarBottomShadow, 0 0.125rem 0.25rem 0 fade(@sapUiContentShadowColor, 7.5);
 
 .sapUxAPObjectPageHeaderContent .sapMObjStatus, .sapUxAPObjectPageContainer .sapMObjStatus {
 	font-size: @sapMFontMediumSize;
@@ -20,7 +21,7 @@
 	padding: 0;
 }
 
-html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
+html .sapUxAPObjectPageLayout-Std-Desktop-XL, html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
 	.sapUxAPObjectPageHeaderContent .sapUxAPObjectPageHeaderObjectImage-Circle .sapUxAPObjectPageHeaderObjectImage {
 		margin-right: 2rem;
 		margin-bottom: 1rem;
@@ -39,7 +40,8 @@ html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tab
 }
 
 .sapUxAPObjectPageLayout-Std-Tablet,
-.sapUxAPObjectPageLayout-Std-Desktop {
+.sapUxAPObjectPageLayout-Std-Desktop,
+.sapUxAPObjectPageLayout-Std-Desktop-XL {
 	.sapUxAPObjectPageHeaderContentCellRight {
 		padding-right: 2rem;
 	}
@@ -69,6 +71,6 @@ html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tab
 	> .sapUiSimpleForm {
 		.sapMText, .sapMLabel, .sapMLnk {
 			font-size: @sapMFontMediumSize;
+			}
 		}
 	}
-}

--- a/src/themelib_sap_fiori_3/src/sap/uxap/themes/sap_fiori_3_hcb/ObjectPageHeaderContent.less
+++ b/src/themelib_sap_fiori_3/src/sap/uxap/themes/sap_fiori_3_hcb/ObjectPageHeaderContent.less
@@ -21,7 +21,7 @@
 	padding: 0;
 }
 
-html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
+html .sapUxAPObjectPageLayout-Std-Desktop-XL, html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
 	.sapUxAPObjectPageHeaderContent .sapUxAPObjectPageHeaderObjectImage-Circle .sapUxAPObjectPageHeaderObjectImage {
 		margin-right: 2rem;
 		margin-bottom: 1rem;
@@ -40,7 +40,8 @@ html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tab
 }
 
 .sapUxAPObjectPageLayout-Std-Tablet,
-.sapUxAPObjectPageLayout-Std-Desktop {
+.sapUxAPObjectPageLayout-Std-Desktop,
+.sapUxAPObjectPageLayout-Std-Desktop-XL {
 	.sapUxAPObjectPageHeaderContentCellRight {
 		padding-right: 2rem;
 	}

--- a/src/themelib_sap_fiori_3/src/sap/uxap/themes/sap_fiori_3_hcw/ObjectPageHeaderContent.less
+++ b/src/themelib_sap_fiori_3/src/sap/uxap/themes/sap_fiori_3_hcw/ObjectPageHeaderContent.less
@@ -21,7 +21,7 @@
 	padding: 0;
 }
 
-html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
+html .sapUxAPObjectPageLayout-Std-Desktop-XL, html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
 	.sapUxAPObjectPageHeaderContent .sapUxAPObjectPageHeaderObjectImage-Circle .sapUxAPObjectPageHeaderObjectImage {
 		margin-right: 2rem;
 		margin-bottom: 1rem;
@@ -40,7 +40,8 @@ html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tab
 }
 
 .sapUxAPObjectPageLayout-Std-Tablet,
-.sapUxAPObjectPageLayout-Std-Desktop {
+.sapUxAPObjectPageLayout-Std-Desktop,
+.sapUxAPObjectPageLayout-Std-Desktop-XL {
 	.sapUxAPObjectPageHeaderContentCellRight {
 		padding-right: 2rem;
 	}

--- a/src/themelib_sap_horizon/src/sap/uxap/themes/sap_horizon/ObjectPageHeaderContent.less
+++ b/src/themelib_sap_horizon/src/sap/uxap/themes/sap_horizon/ObjectPageHeaderContent.less
@@ -40,7 +40,8 @@ html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tab
 }
 
 .sapUxAPObjectPageLayout-Std-Tablet,
-.sapUxAPObjectPageLayout-Std-Desktop {
+.sapUxAPObjectPageLayout-Std-Desktop,
+.sapUxAPObjectPageLayout-Std-Desktop-XL {
 	.sapUxAPObjectPageHeaderContentCellRight {
 		padding-right: 2rem;
 	}

--- a/src/themelib_sap_horizon/src/sap/uxap/themes/sap_horizon/ObjectPageHeaderContent.less
+++ b/src/themelib_sap_horizon/src/sap/uxap/themes/sap_horizon/ObjectPageHeaderContent.less
@@ -21,7 +21,7 @@
 	padding: 0;
 }
 
-html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
+html .sapUxAPObjectPageLayout-Std-Desktop-XL, html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
 	.sapUxAPObjectPageHeaderContent .sapUxAPObjectPageHeaderObjectImage-Circle .sapUxAPObjectPageHeaderObjectImage {
 		margin-right: 2rem;
 		margin-bottom: 1rem;
@@ -72,6 +72,7 @@ html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tab
 	}
 
 	&:empty {
+		.sapUxAPObjectPageLayout-Std-Desktop-XL &,
 		.sapUxAPObjectPageLayout-Std-Desktop &,
 		.sapUxAPObjectPageLayout-Std-Tablet &,
 		.sapUxAPObjectPageLayout-Std-Phone &

--- a/src/themelib_sap_horizon/src/sap/uxap/themes/sap_horizon_dark/ObjectPageHeaderContent.less
+++ b/src/themelib_sap_horizon/src/sap/uxap/themes/sap_horizon_dark/ObjectPageHeaderContent.less
@@ -21,7 +21,7 @@
 	padding: 0;
 }
 
-html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
+html .sapUxAPObjectPageLayout-Std-Desktop-XL, html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
 	.sapUxAPObjectPageHeaderContent .sapUxAPObjectPageHeaderObjectImage-Circle .sapUxAPObjectPageHeaderObjectImage {
 		margin-right: 2rem;
 		margin-bottom: 1rem;
@@ -40,7 +40,8 @@ html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tab
 }
 
 .sapUxAPObjectPageLayout-Std-Tablet,
-.sapUxAPObjectPageLayout-Std-Desktop {
+.sapUxAPObjectPageLayout-Std-Desktop,
+.sapUxAPObjectPageLayout-Std-Desktop-XL {
 	.sapUxAPObjectPageHeaderContentCellRight {
 		padding-right: 2rem;
 	}
@@ -71,6 +72,7 @@ html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tab
 	}
 
 	&:empty {
+		.sapUxAPObjectPageLayout-Std-Desktop-XL &,
 		.sapUxAPObjectPageLayout-Std-Desktop &,
 		.sapUxAPObjectPageLayout-Std-Tablet &,
 		.sapUxAPObjectPageLayout-Std-Phone &

--- a/src/themelib_sap_horizon/src/sap/uxap/themes/sap_horizon_hcb/ObjectPageHeaderContent.less
+++ b/src/themelib_sap_horizon/src/sap/uxap/themes/sap_horizon_hcb/ObjectPageHeaderContent.less
@@ -21,7 +21,7 @@
 	padding: 0;
 }
 
-html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
+html .sapUxAPObjectPageLayout-Std-Desktop-XL, html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
 	.sapUxAPObjectPageHeaderContent .sapUxAPObjectPageHeaderObjectImage-Circle .sapUxAPObjectPageHeaderObjectImage {
 		margin-right: 2rem;
 		margin-bottom: 1rem;
@@ -40,7 +40,8 @@ html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tab
 }
 
 .sapUxAPObjectPageLayout-Std-Tablet,
-.sapUxAPObjectPageLayout-Std-Desktop {
+.sapUxAPObjectPageLayout-Std-Desktop,
+.sapUxAPObjectPageLayout-Std-Desktop-XL {
 	.sapUxAPObjectPageHeaderContentCellRight {
 		padding-right: 2rem;
 	}

--- a/src/themelib_sap_horizon/src/sap/uxap/themes/sap_horizon_hcw/ObjectPageHeaderContent.less
+++ b/src/themelib_sap_horizon/src/sap/uxap/themes/sap_horizon_hcw/ObjectPageHeaderContent.less
@@ -21,7 +21,7 @@
 	padding: 0;
 }
 
-html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
+html .sapUxAPObjectPageLayout-Std-Desktop-XL, html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tablet {
 	.sapUxAPObjectPageHeaderContent .sapUxAPObjectPageHeaderObjectImage-Circle .sapUxAPObjectPageHeaderObjectImage {
 		margin-right: 2rem;
 		margin-bottom: 1rem;
@@ -40,7 +40,8 @@ html .sapUxAPObjectPageLayout-Std-Desktop, html .sapUxAPObjectPageLayout-Std-Tab
 }
 
 .sapUxAPObjectPageLayout-Std-Tablet,
-.sapUxAPObjectPageLayout-Std-Desktop {
+.sapUxAPObjectPageLayout-Std-Desktop,
+.sapUxAPObjectPageLayout-Std-Desktop-XL {
 	.sapUxAPObjectPageHeaderContentCellRight {
 		padding-right: 2rem;
 	}


### PR DESCRIPTION
When ObjectPageLayout is set to `showTitleInHeaderContent` and the header is displayed with on a screen of class `Desktop-XL` the content area (and especially noticeable: the image) don't have a top padding.

This can be observed here: https://jsfiddle.net/395hrpye/  (the padding from the icon to top goes away when entering the Desktop-XL layout)

https://github.com/SAP/openui5/assets/66731536/1f0dd13d-586b-4223-bcfa-3f4011c96f9a

This PR applies the padding from Tablet and Desktop also for Desktop-XL in both the theme "horizon" as well as "quartz".
