### PR TITLE
[FIX] - sap.m.RadioButtonGroup throws unhandled exception

### DIFF
--- a/src/sap.m/src/sap/m/RadioButtonGroup.js
+++ b/src/sap.m/src/sap/m/RadioButtonGroup.js
@@ -331,8 +331,8 @@ sap.ui.define([
 				var iIndexOld = this.getSelectedIndex();
 				// if a radio button in the group is focused is true, otherwise - false
 				var hasFocusedRadioButton = this.getDomRef() && this.getDomRef().contains(document.activeElement);
-				// if radio button group has buttons and one of them is selected is true, otherwise - false
-				var isRadioGroupSelected = !!(this.aRBs && this.aRBs[iSelectedIndex]);
+				// if radio button group has buttons, one of them is selected, and it has a dom reference is true, otherwise - false
+				var isRadioGroupSelected = !!(this.aRBs && this.aRBs[iSelectedIndex] && this.aRBs[iSelectedIndex].getDomRef());
 				var iFocusedIndex;
 
 				if (iSelectedIndex < -1) {


### PR DESCRIPTION
- When adding a selection handler which modifies the RadioButtons and the selected radio button in the RadioButtonGroup, an unhandled exception occurs.

- The fix is to only focus the DOM reference if it exists.

Fixes: https://github.com/SAP/openui5/issues/3971