### PR TITLE
make DynamicDateRange.js control available in forms

### DIFF
--- a/src/sap.m/src/sap/m/DynamicDateRange.js
+++ b/src/sap.m/src/sap/m/DynamicDateRange.js
@@ -266,6 +266,10 @@ sap.ui.define([
 		 */
 		var DynamicDateRange = Control.extend("sap.m.DynamicDateRange", /** @lends sap.m.DynamicDateRange.prototype */ {
 			metadata: {
+				interfaces : [
+					"sap.ui.core.IFormContent",
+					"sap.ui.core.ISemanticFormContent"
+				],
 				library: "sap.m",
 				properties: {
 					/**


### PR DESCRIPTION
## Change

This change will add support for forms (`sap.ui.layout.form.Form`) and form container (`sap.ui.layout.form.FormContainer`) on DynamicDateRange control.

## Motivation

The DynamicDateRange control is shown in the UI5 samples page mostly as a filter for a table. It would also be helpful to have this input control in a form as well. At least we tested this successfully in our app and haven't seen any issues so far.