### PR TITLE
fix: change null aArgs to undefined

### DIFF
--- a/src/sap.m/src/sap/m/DynamicDateFormat.js
+++ b/src/sap.m/src/sap/m/DynamicDateFormat.js
@@ -268,7 +268,7 @@ sap.ui.define([
 			}
 
 			if (aFormattedParams.length === 0) {
-				aFormattedParams = null;
+				aFormattedParams = undefined;
 			}
 
 			return this._resourceBundle.getText("DYNAMIC_DATE_" + sKey.toUpperCase() + "_FORMAT", aFormattedParams);


### PR DESCRIPTION
The _formatValue function in ResourceBundle requires that aArgs be either undefined or an array.