### PR TITLE
Add missing withResolvers method to PromiseWaiter

### DIFF
--- a/src/sap.ui.core/src/sap/ui/test/autowaiter/_promiseWaiter.js
+++ b/src/sap.ui.core/src/sap/ui/test/autowaiter/_promiseWaiter.js
@@ -12,7 +12,7 @@ sap.ui.define([
 
 	var aPromises = [];
 	var OriginalPromise = window.Promise; // save it to avoid 'max call stack exceeded'
-	var aStaticMethods = ["resolve", "reject", "all", "any", "race", "allSettled"];
+	var aStaticMethods = ["resolve", "reject", "all", "any", "race", "allSettled", "withResolvers"];
 	var thenMicrotaskPromise;	// defined only during .then() call
 
 	var PromiseWaiter = WaiterBase.extend("sap.ui.test.autowaiter._promiseWaiter", {


### PR DESCRIPTION
Promise.withResolvers() is missing on WrappedPromise leading to errors when code uses is in tests, for example pdfjs:
<img width="584" alt="image" src="https://github.com/user-attachments/assets/778d5d54-d730-48f3-8c6a-39bbdb150251">
