### PR TITLE
sap.ui.core: Replace deprecated JS API substr in

### DIFF
--- a/src/sap.ui.core/src/sap/base/security/encodeCSS.js
+++ b/src/sap.ui.core/src/sap/base/security/encodeCSS.js
@@ -15,7 +15,7 @@ sap.ui.define(["sap/base/strings/toHex"], function(toHex) {
 		if (sChar.length === 1) {
 			return "\\" + toHex(iChar);
 		} else {
-			return "\\" + toHex(iChar) + " " + sChar.substr(1);
+			return "\\" + toHex(iChar) + " " + sChar.substring(1);
 		}
 	};
 

--- a/src/sap.ui.core/src/sap/ui/Global.js
+++ b/src/sap.ui.core/src/sap/ui/Global.js
@@ -169,8 +169,8 @@ sap.ui.define([
 
 		var sFullClass = sClassName.replace(/\//gi,"\."),
 			iLastDotPos = sFullClass.lastIndexOf("."),
-			sPackage = sFullClass.substr(0, iLastDotPos),
-			sClass = sFullClass.substr(iLastDotPos + 1),
+			sPackage = sFullClass.substring(0, iLastDotPos),
+			sClass = sFullClass.substring(iLastDotPos + 1),
 			oPackage = ObjectPath.create(sPackage),
 			oClass = oPackage[sClass],
 			aMethods = (sMethods || "new").split(" "),

--- a/src/sap.ui.core/src/sap/ui/base/BindingInfo.js
+++ b/src/sap.ui.core/src/sap/ui/base/BindingInfo.js
@@ -39,8 +39,8 @@ sap.ui.define([
 			// if a model separator is found in the path, extract model name and path
 			const iSeparatorPos = oPart.path.indexOf(">");
 			if (iSeparatorPos > 0) {
-				oPart.model = oPart.path.substr(0, iSeparatorPos);
-				oPart.path = oPart.path.substr(iSeparatorPos + 1);
+				oPart.model = oPart.path.substring(0, iSeparatorPos);
+				oPart.path = oPart.path.substring(iSeparatorPos + 1);
 				oPart[MODEL_NAME_EXTRACTED] = true;
 			}
 		}

--- a/src/sap.ui.core/src/sap/ui/core/DeclarativeSupport.js
+++ b/src/sap.ui.core/src/sap/ui/core/DeclarativeSupport.js
@@ -513,7 +513,7 @@ sap.ui.define([
 	 */
 	DeclarativeSupport.convertAttributeToSettingName = function(sAttribute, sId, bDeprecationWarning) {
 		if (sAttribute.indexOf("data-") === 0) {
-			sAttribute = sAttribute.substr(5);
+			sAttribute = sAttribute.substring(5);
 		} else if (bDeprecationWarning) {
 			Log.warning('[Deprecated] Control "' + sId + '": The attribute "' + sAttribute + '" is not prefixed with "data-*". Future version of declarative support will only suppport attributes with "data-*" prefix.');
 		} else {

--- a/src/sap.ui.core/src/sap/ui/core/IconPool.js
+++ b/src/sap.ui.core/src/sap/ui/core/IconPool.js
@@ -247,7 +247,7 @@ sap.ui.define([
 			}
 
 			// add trailing slash if necessary for more convenience
-			if (oConfig.fontURI.substr(oConfig.fontURI.length - 1) !== "/") {
+			if (oConfig.fontURI.substring(oConfig.fontURI.length - 1) !== "/") {
 				oConfig.fontURI += "/";
 			}
 

--- a/src/sap.ui.core/src/sap/ui/core/LocaleData.js
+++ b/src/sap.ui.core/src/sap/ui/core/LocaleData.js
@@ -1571,7 +1571,7 @@ sap.ui.define([
 				oScale = this._get("dateFields", sScale + "-" + sStyle);
 				for (var sEntry in oScale) {
 					if (sEntry.indexOf("relative-type-") === 0) {
-						iValue = parseInt(sEntry.substr(14));
+						iValue = parseInt(sEntry.substring(14));
 						aPatterns.push({
 							scale: sScale,
 							value: iValue,
@@ -1579,7 +1579,7 @@ sap.ui.define([
 						});
 					} else if (sEntry.indexOf("relativeTime-type-") == 0) {
 						oTimeEntry = oScale[sEntry];
-						iSign = sEntry.substr(18) === "past" ? -1 : 1;
+						iSign = sEntry.substring(18) === "past" ? -1 : 1;
 						aPluralCategories.forEach(function(sKey) { // eslint-disable-line no-loop-func
 							var sPattern = oTimeEntry["relativeTimePattern-count-" + sKey];
 

--- a/src/sap.ui.core/src/sap/ui/core/ScrollBar.js
+++ b/src/sap.ui.core/src/sap/ui/core/ScrollBar.js
@@ -197,7 +197,7 @@ sap.ui.define([
 
 		var iScrollBarSize = this.getSize();
 		if (iScrollBarSize.endsWith("px")) {
-			iScrollBarSize = iScrollBarSize.substr(0, iScrollBarSize.length - 2);
+			iScrollBarSize = iScrollBarSize.substring(0, iScrollBarSize.length - 2);
 		} else {
 			iScrollBarSize = this.getVertical() ? this.$().height() : this.$().width();
 		}
@@ -211,7 +211,7 @@ sap.ui.define([
 				// the following code is used if a container of the scrollbar is rendered invisible and afterwards is set to visible
 				stepSize = window.getComputedStyle(jQuery("body").get(0))["font-size"];
 				if (stepSize.endsWith("px")) {
-					stepSize = stepSize.substr(0, stepSize.length - 2);
+					stepSize = stepSize.substring(0, stepSize.length - 2);
 				}
 				stepSize = parseInt(stepSize);
 			}

--- a/src/sap.ui.core/src/sap/ui/core/boot/onInit.js
+++ b/src/sap.ui.core/src/sap/ui/core/boot/onInit.js
@@ -20,7 +20,7 @@ sap.ui.define([
 		if (aParts.length > 1) {
 			var mPaths = {};
 			var sModulePath = /^.*[\/\\]/.exec(aParts[0])[0];
-			sModulePath = sModulePath.substr(0, sModulePath.length - 1);
+			sModulePath = sModulePath.substring(0, sModulePath.length - 1);
 			mPaths[sModulePath] = aParts[1];
 			sap.ui.loader.config({
 				paths: mPaths

--- a/src/sap.ui.core/src/sap/ui/core/date/Islamic.js
+++ b/src/sap.ui.core/src/sap/ui/core/date/Islamic.js
@@ -245,9 +245,9 @@ sap.ui.define([
 
 	function parseDate(sDate) {
 		return {
-			year: parseInt(sDate.substr(0, 4)),
-			month: parseInt(sDate.substr(4, 2)),
-			day: parseInt(sDate.substr(6, 2))
+			year: parseInt(sDate.substring(0, 4)),
+			month: parseInt(sDate.substring(4, 2)),
+			day: parseInt(sDate.substring(6, 2))
 		};
 	}
 

--- a/src/sap.ui.core/src/sap/ui/core/format/DateFormat.js
+++ b/src/sap.ui.core/src/sap/ui/core/format/DateFormat.js
@@ -129,7 +129,7 @@ sap.ui.define([
 			// If style is mixed ("medium/short") split it and pass both parts separately
 			var iSlashIndex = sStyle.indexOf("/");
 			if (iSlashIndex > 0) {
-				return oLocaleData.getCombinedDateTimePattern(sStyle.substr(0, iSlashIndex), sStyle.substr(iSlashIndex + 1), sCalendarType);
+				return oLocaleData.getCombinedDateTimePattern(sStyle.substring(0, iSlashIndex), sStyle.substring(iSlashIndex + 1), sCalendarType);
 			} else {
 				return oLocaleData.getCombinedDateTimePattern(sStyle, sStyle, sCalendarType);
 			}
@@ -824,7 +824,7 @@ sap.ui.define([
 				iLength++;
 			}
 
-			return sValue.substr(0, iLength);
+			return sValue.substring(0, iLength);
 		},
 
 		/**
@@ -927,7 +927,7 @@ sap.ui.define([
 			}
 
 			iLength++; //"+" or "-"
-			sPart = this.findNumbers(sValue.substr(iLength), 2);
+			sPart = this.findNumbers(sValue.substring(iLength), 2);
 
 			var iTZDiffHour = parseInt(sPart);
 			iLength += 2; //hh: 2 digits for hours
@@ -935,7 +935,7 @@ sap.ui.define([
 			if (bColonSeparated) {
 				iLength++; //":"
 			}
-			sPart = this.findNumbers(sValue.substr(iLength), 2);
+			sPart = this.findNumbers(sValue.substring(iLength), 2);
 			var iTZDiff = 0;
 			// timezone pattern "X": will produce only 2 digits: "-08"
 			if (sPart) {
@@ -1172,7 +1172,7 @@ sap.ui.define([
 				var sCalendarType = oFormat.oFormatOptions.calendarType;
 
 				if (oField.digits === 2 && sYear.length > 2) {
-					sYear = sYear.substr(sYear.length - 2);
+					sYear = sYear.substring(sYear.length - 2);
 				}
 				// When parsing we assume dates less than 100 to be in the current/last century,
 				// so when formatting we have to make sure they are differentiable by prefixing with zeros
@@ -1245,7 +1245,7 @@ sap.ui.define([
 				var sCalendarType = oFormat.oFormatOptions.calendarType;
 
 				if (oField.digits === 2 && sWeekYear.length > 2) {
-					sWeekYear = sWeekYear.substr(sWeekYear.length - 2);
+					sWeekYear = sWeekYear.substring(sWeekYear.length - 2);
 				}
 				// When parsing we assume dates less than 100 to be in the current/last century,
 				// so when formatting we have to make sure they are differentiable by prefixing with zeros
@@ -2065,7 +2065,7 @@ sap.ui.define([
 				var iMilliseconds = oDate.getUTCMilliseconds();
 				var sMilliseconds = String(iMilliseconds);
 				var sFractionalseconds = sMilliseconds.padStart(3, "0");
-				sFractionalseconds = sFractionalseconds.substr(0, oField.digits);
+				sFractionalseconds = sFractionalseconds.substring(0, oField.digits);
 				sFractionalseconds = sFractionalseconds.padEnd(oField.digits, "0");
 				return sFractionalseconds;
 			},
@@ -2074,7 +2074,7 @@ sap.ui.define([
 					iLength = sPart.length,
 					bPartInvalid = oConfig.exactLength && iLength < oPart.digits;
 
-				sPart = sPart.substr(0, 3);
+				sPart = sPart.substring(0, 3);
 				sPart = sPart.padEnd(3, "0");
 
 				var iMilliseconds = parseInt(sPart);
@@ -2136,7 +2136,7 @@ sap.ui.define([
 				}
 
 				if (sValue.charAt(0) !== "Z") {
-					var oParsedTZ = oParseHelper.parseTZ(sValue.substr(iLength), true);
+					var oParsedTZ = oParseHelper.parseTZ(sValue.substring(iLength), true);
 
 					iLength += oParsedTZ.length;
 					iTZDiff = oParsedTZ.tzDiff;
@@ -2581,7 +2581,7 @@ sap.ui.define([
 		function isNumeric(oPart0) { return !!oPart0 && getSymbol(oPart0).isNumeric(oPart0.digits); }
 
 		for (var i = 0; i < aFormatArray.length; i++) {
-			sSubValue = sValue.substr(iIndex);
+			sSubValue = sValue.substring(iIndex);
 			oPart = aFormatArray[i];
 			oPrevPart = aFormatArray[i - 1];
 			oNextPart = aFormatArray[i + 1];

--- a/src/sap.ui.core/src/sap/ui/core/format/FileSizeFormat.js
+++ b/src/sap.ui.core/src/sap/ui/core/format/FileSizeFormat.js
@@ -221,19 +221,19 @@ sap.ui.define([
 			_oPattern;
 
 		if (sPattern.startsWith("{0}")) {
-			_oPattern = sPattern.substr(3, sPattern.length);
+			_oPattern = sPattern.substring(3, sPattern.length);
 			if ((typeof _oPattern == "string" && _oPattern != "" ? sValue.toLowerCase().endsWith(_oPattern.toLowerCase()) : false)) {
-				return sValue.substr(0, sValue.length - _oPattern.length);
+				return sValue.substring(0, sValue.length - _oPattern.length);
 			}
 		} else if (sPattern.endsWith("{0}")) {
-			_oPattern = sPattern.substr(0, sPattern.length - 3);
+			_oPattern = sPattern.substring(0, sPattern.length - 3);
 			if ((typeof _oPattern == "string" && _oPattern != "" ? sValue.toLowerCase().startsWith(_oPattern.toLowerCase()) : false)) {
-				return sValue.substr(_oPattern.length, sValue.length);
+				return sValue.substring(_oPattern.length, sValue.length);
 			}
 		} else {
 			_oPattern = sPattern.split("{0}");
 			if (_oPattern.length == 2 && ((typeof _oPattern[0] == "string" && _oPattern[0] != "" ? sValue.toLowerCase().startsWith(_oPattern[0].toLowerCase()) : false)) && ((typeof _oPattern[1] == "string" && _oPattern[1] != "" ? sValue.toLowerCase().endsWith(_oPattern[1].toLowerCase()) : false))) {
-				return sValue.substr(_oPattern[0].length, sValue.length - _oPattern[1].length);
+				return sValue.substring(_oPattern[0].length, sValue.length - _oPattern[1].length);
 			}
 		}
 

--- a/src/sap.ui.core/src/sap/ui/core/format/NumberFormat.js
+++ b/src/sap.ui.core/src/sap/ui/core/format/NumberFormat.js
@@ -1735,14 +1735,14 @@ sap.ui.define([
 
 		// if number is negative remove minus
 		if (bNegative) {
-			sNumber = sNumber.substr(1);
+			sNumber = sNumber.substring(1);
 		}
 
 		// if number contains fraction, extract it
 		iDotPos = sNumber.indexOf(".");
 		if (iDotPos > -1) {
-			sIntegerPart = sNumber.substr(0, iDotPos);
-			sFractionPart = sNumber.substr(iDotPos + 1);
+			sIntegerPart = sNumber.substring(0, iDotPos);
+			sFractionPart = sNumber.substring(iDotPos + 1);
 		} else {
 			sIntegerPart = sNumber;
 		}
@@ -1758,7 +1758,7 @@ sap.ui.define([
 		if (sFractionPart.length < oOptions.minFractionDigits) {
 			sFractionPart = sFractionPart.padEnd(oOptions.minFractionDigits, "0");
 		} else if (sFractionPart.length > oOptions.maxFractionDigits && !oOptions.preserveDecimals) {
-			sFractionPart = sFractionPart.substr(0, oOptions.maxFractionDigits);
+			sFractionPart = sFractionPart.substring(0, oOptions.maxFractionDigits);
 		}
 
 		if (oOptions.type === mNumberType.UNIT && !oOptions.showNumber) {

--- a/src/sap.ui.core/src/sap/ui/core/mvc/ControllerMetadata.js
+++ b/src/sap.ui.core/src/sap/ui/core/mvc/ControllerMetadata.js
@@ -162,7 +162,7 @@ sap.ui.define([
 	ControllerMetadata.prototype.getNamespace = function() {
 		var bIsAnonymous = this._sClassName.indexOf("anonymousExtension~") == 0;
 		var sNamespace = bIsAnonymous ? this._oParent._sClassName : this._sClassName;
-		return sNamespace.substr(0,sNamespace.lastIndexOf("."));
+		return sNamespace.substring(0,sNamespace.lastIndexOf("."));
 	};
 
 	/**

--- a/src/sap.ui.core/src/sap/ui/core/mvc/EventHandlerResolver.js
+++ b/src/sap.ui.core/src/sap/ui/core/mvc/EventHandlerResolver.js
@@ -82,7 +82,7 @@ sap.ui.define([
 				} else {
 					//check for command usage - create handler that triggers the CommandExecution
 					if (sName.startsWith("cmd:")) {
-						var sCommand = sName.substr(4);
+						var sCommand = sName.substring(4);
 						fnHandler = function(oEvent) {
 							var oCommandExecution = CommandExecution.find(oEvent.getSource(), sCommand);
 							if (oCommandExecution) {
@@ -299,8 +299,8 @@ sap.ui.define([
 				// if a model separator is found in the path, extract model name and path
 				var iSeparatorPos = oPart.path.indexOf(">");
 				if (iSeparatorPos > 0) {
-					oPart.model = oPart.path.substr(0, iSeparatorPos);
-					oPart.path = oPart.path.substr(iSeparatorPos + 1);
+					oPart.model = oPart.path.substring(0, iSeparatorPos);
+					oPart.path = oPart.path.substring(iSeparatorPos + 1);
 				}
 			}
 

--- a/src/sap.ui.core/src/sap/ui/core/plugin/LessSupport.js
+++ b/src/sap.ui.core/src/sap/ui/core/plugin/LessSupport.js
@@ -116,7 +116,7 @@
 					var _bUseLess = that.initLink(this);
 					bUseLess = _bUseLess || bUseLess;
 					if (_bUseLess){
-						aLibs.push(this.id.substr(13)); // length of "sap-ui-theme-"
+						aLibs.push(this.id.substring(13)); // length of "sap-ui-theme-"
 					}
 				});
 
@@ -172,7 +172,7 @@
 					delete this.iCheckThemeAppliedTimeout;
 					// remove the content of the LESS style element
 					jQuery("link[id^=sap-ui-theme-]").each(function() {
-						var sLibName = this.id.substr(13); // length of "sap-ui-theme-"
+						var sLibName = this.id.substring(13); // length of "sap-ui-theme-"
 						jQuery(document.getElementById("less:" + sLibName)).remove();
 					});
 					// remove the hooks from the Core
@@ -194,7 +194,7 @@
 
 				// add the section for the generated CSS code
 				jQuery("<style>").
-					attr("id", "less:" + oLink.id.substr(13)).
+					attr("id", "less:" + oLink.id.substring(13)).
 					attr("type", "text/css").
 					attr("media", this.media || "screen").
 					insertAfter(oLink);
@@ -216,10 +216,10 @@
 
 				// modify style sheet URL to point to the new theme
 				// be aware of custom css included with the colon (see includeLibraryTheme) // TODO: what is this??
-				var sLibName = oLink.id.substr(13); // length of "sap-ui-theme-"
+				var sLibName = oLink.id.substring(13); // length of "sap-ui-theme-"
 				var pos;
 				if ((pos = sLibName.indexOf("-[")) > 0) { // assumes that "-[" does not occur as part of a library name
-					sLibName = sLibName.substr(0, pos);
+					sLibName = sLibName.substring(0, pos);
 				}
 				var sBaseUrl = ThemeManager._getThemePath(sLibName, Theming.getTheme());
 
@@ -363,7 +363,7 @@
 			 */
 			LessSupport.prototype.unregisterLink = function(oLink) {
 				if (window.less && window.less.sheets) {
-					var sLibName = oLink.id.substr(13);
+					var sLibName = oLink.id.substring(13);
 					var iIndex = window.less.sheets.indexOf(oLink);
 					if (iIndex >= 0) {
 						window.less.sheets.splice(iIndex, 1);
@@ -462,7 +462,7 @@
 
 					// fill the href - lib map using less stylesheets
 					jQuery(window.less.sheets).each(function() {
-						mLessHrefToLib[this.href] = jQuery(this).attr("id").substr(13);
+						mLessHrefToLib[this.href] = jQuery(this).attr("id").substring(13);
 					});
 
 					// Save original function
@@ -480,7 +480,7 @@
 								mVariables = mLibVariables[sLibName] = {};
 							}
 							try {
-								mVariables[this.name.substr(1)] = this.value.eval(env).toCSS(env);
+								mVariables[this.name.substring(1)] = this.value.eval(env).toCSS(env);
 							} catch (ex) {
 								// causes an exception when variable is not defined. ignore it here, less will take care of it
 							}

--- a/src/sap.ui.core/src/sap/ui/core/rules/Config.support.js
+++ b/src/sap.ui.core/src/sap/ui/core/rules/Config.support.js
@@ -143,7 +143,7 @@ sap.ui.define([
 			}
 			for (var i = 0; i < aAppNames.length; i++) {
 				sAppName = aAppNames[i];
-				var sICFPath = sUI5ICFNode + (sAppName.charAt(0) === "/" ? sAppName.substr(1) : "sap/" + sAppName);
+				var sICFPath = sUI5ICFNode + (sAppName.charAt(0) === "/" ? sAppName.substring(1) : "sap/" + sAppName);
 				oIssueManager.addIssue({
 					severity: Severity.Medium,
 					details: "Application '" + sAppName + "' has no cache buster tokens in some or all of its requests.\n " +

--- a/src/sap.ui.core/src/sap/ui/core/rules/CoreHelper.support.js
+++ b/src/sap.ui.core/src/sap/ui/core/rules/CoreHelper.support.js
@@ -69,7 +69,7 @@ sap.ui.define(["sap/ui/core/Element", "sap/ui/core/Theming"],
 
 				if (styleSheet.href) {
 					// This will get only the name of the styleSheet example: "/customstyle.css"
-					styleSheetSourceName = styleSheet.href.substr(styleSheet.href.lastIndexOf("/"), styleSheet.href.length - 1);
+					styleSheetSourceName = styleSheet.href.substring(styleSheet.href.lastIndexOf("/"), styleSheet.href.length - 1);
 				} else {
 					styleSheetSourceName = " <style> tag ";
 				}

--- a/src/sap.ui.core/src/sap/ui/core/support/Support.js
+++ b/src/sap.ui.core/src/sap/ui/core/support/Support.js
@@ -260,7 +260,7 @@ sap.ui.define([
 		var sData = oEvent.data;
 
 		if (typeof sData === "string" && sData.indexOf("SAPUI5SupportTool*") === 0) {
-			sData = sData.substr(18); // length of SAPUI5SupportTool*
+			sData = sData.substring(18); // length of SAPUI5SupportTool*
 		} else {
 			return;
 		}
@@ -316,7 +316,7 @@ sap.ui.define([
 				var sRootPath = sap.ui.require.toUrl("");
 				var sBootstrapSrc = oBootstrap.getAttribute('src');
 				if (typeof sBootstrapSrc === 'string' && sBootstrapSrc.indexOf(sRootPath) === 0) {
-					sBootstrapScript = sBootstrapSrc.substr(sRootPath.length);
+					sBootstrapScript = sBootstrapSrc.substring(sRootPath.length);
 				}
 			}
 		}

--- a/src/sap.ui.core/src/sap/ui/core/theming/Parameters.js
+++ b/src/sap.ui.core/src/sap/ui/core/theming/Parameters.js
@@ -388,7 +388,7 @@ sap.ui.define([
 			if (!sParamValue) {
 				var iIndex = mOptions.parameterName.indexOf(":");
 				if (iIndex != -1) {
-					var sParamNameWithoutColon = mOptions.parameterName.substr(iIndex + 1);
+					var sParamNameWithoutColon = mOptions.parameterName.substring(iIndex + 1);
 					sParamValue = oParams[sParamNameWithoutColon];
 				}
 			}
@@ -806,7 +806,7 @@ sap.ui.define([
 			};
 			sTheme = Theming.getTheme();
 			forEachStyleSheet(function(sId) {
-				var sLibname = sId.substr(13); // length of sap-ui-theme-
+				var sLibname = sId.substring(13); // length of sap-ui-theme-
 				if (mLibraryParameters[sLibname]) {
 					// if parameters are already provided for this lib, use them (e.g. from LessSupport)
 					extend(mParameters["default"], mLibraryParameters[sLibname]);

--- a/src/sap.ui.core/src/sap/ui/core/tmpl/Template.js
+++ b/src/sap.ui.core/src/sap/ui/core/tmpl/Template.js
@@ -512,7 +512,7 @@ function(
 							if (aTmplInfo.length == 3) {
 								sController = aTmplInfo[2];
 							}
-							sContent = sContent.substr(aTmplInfo[0].length);
+							sContent = sContent.substring(aTmplInfo[0].length);
 						}
 					},
 					error: function() {

--- a/src/sap.ui.core/src/sap/ui/core/tmpl/_parsePath.js
+++ b/src/sap.ui.core/src/sap/ui/core/tmpl/_parsePath.js
@@ -20,8 +20,8 @@ sap.ui.define([], function() {
 		// if a model name is specified in the binding path
 		// we extract this binding path
 		if (iSeparatorPos > 0) {
-			sModelName = sPath.substr(0, iSeparatorPos);
-			sPath = sPath.substr(iSeparatorPos + 1);
+			sModelName = sPath.substring(0, iSeparatorPos);
+			sPath = sPath.substring(iSeparatorPos + 1);
 		}
 
 		// returns the path information

--- a/src/sap.ui.core/src/sap/ui/core/util/MockServer.js
+++ b/src/sap.ui.core/src/sap/ui/core/util/MockServer.js
@@ -805,7 +805,7 @@ sap.ui
 						sValue = parseFloat(sValue);
 					} else if ((sValue.charAt(0) === "'") && (sValue.charAt(sValue.length - 1) === "'")) {
 						//fix for filtering on properties of type string
-						sValue = sValue.substr(1, sValue.length - 2);
+						sValue = sValue.substring(1, sValue.length - 2);
 					}
 					// support for 1 level complex type property
 					var iComplexType = sPath.indexOf("/");
@@ -1044,7 +1044,7 @@ sap.ui
 							return (path + '/').indexOf(currentPath) === 0;
 						}).forEach(function(path, _, innerSelect) {
 							// then get the next property in given path
-							var propertyKey = path.substr(currentPath.length).split('/')[0];
+							var propertyKey = path.substring(currentPath.length).split('/')[0];
 							// Check if we have that propertyKey on the current object
 							if (data[propertyKey] !== undefined) {
 								// in this case recurse again while adding this to the current path

--- a/src/sap.ui.core/src/sap/ui/core/webc/WebComponentMetadata.js
+++ b/src/sap.ui.core/src/sap/ui/core/webc/WebComponentMetadata.js
@@ -113,7 +113,7 @@ function(ElementMetadata, WebComponentRenderer, camelize) {
 
 		// Generate accessors for proxied public getters - only if not created explicitly already
 		this._aGetters.forEach(function(name) {
-			var functionName = "get" + name.substr(0, 1).toUpperCase() + name.substr(1);
+			var functionName = "get" + name.substring(0, 1).toUpperCase() + name.substring(1);
 			if (!proto[functionName]) {
 				proto[functionName] = function() {
 					return this.__callPublicGetter(name);

--- a/src/sap.ui.core/src/sap/ui/core/ws/SapPcpWebSocket.js
+++ b/src/sap.ui.core/src/sap/ui/core/ws/SapPcpWebSocket.js
@@ -143,7 +143,7 @@ sap.ui.define(['./WebSocket', "sap/base/Log"],
 
 		if (iSplitPos !== -1) {
 			oEventData.pcpFields = this._extractPcpFields(oMessageEvent.data.substring(0, iSplitPos));
-			oEventData.data = oMessageEvent.data.substr(iSplitPos + SapPcpWebSocket._SEPARATOR.length);
+			oEventData.data = oMessageEvent.data.substring(iSplitPos + SapPcpWebSocket._SEPARATOR.length);
 		} else {
 			Log.warning("Invalid PCP message received: " + oMessageEvent.data);
 			oEventData.pcpFields = {};

--- a/src/sap.ui.core/src/sap/ui/model/ClientPropertyBinding.js
+++ b/src/sap.ui.core/src/sap/ui/model/ClientPropertyBinding.js
@@ -48,7 +48,7 @@ sap.ui.define(['./PropertyBinding'],
 	 * @return {object} the current value of the bound target
 	 */
 	ClientPropertyBinding.prototype._getValue = function(){
-		var sProperty = this.sPath.substr(this.sPath.lastIndexOf("/") + 1);
+		var sProperty = this.sPath.substring(this.sPath.lastIndexOf("/") + 1);
 		if (this.oContext && sProperty == "__name__") {
 			var aPath = this.oContext.getPath().split("/");
 			return aPath[aPath.length - 1];

--- a/src/sap.ui.core/src/sap/ui/model/Model.js
+++ b/src/sap.ui.core/src/sap/ui/model/Model.js
@@ -797,7 +797,7 @@ sap.ui.define([
 		}
 		// invariant: path never ends with a slash ... if root is requested we return /
 		if (sResolvedPath && sResolvedPath !== "/" && sResolvedPath.endsWith("/")) {
-			sResolvedPath = sResolvedPath.substr(0, sResolvedPath.length - 1);
+			sResolvedPath = sResolvedPath.substring(0, sResolvedPath.length - 1);
 		}
 		return sResolvedPath;
 	};

--- a/src/sap.ui.core/src/sap/ui/model/Sorter.js
+++ b/src/sap.ui.core/src/sap/ui/model/Sorter.js
@@ -74,7 +74,7 @@ sap.ui.define([
 				// Model names are ignored, this must be kept for compatibility reasons. But using model names in the
 				// sorter path make no technical sense as the binding cannot access any other models.
 				Log.error("Model names are not allowed in sorter-paths: \"" + this.sPath + "\"");
-				this.sPath = this.sPath.substr(iSeparatorPos + 1);
+				this.sPath = this.sPath.substring(iSeparatorPos + 1);
 			}
 
 			this.bDescending = bDescending;

--- a/src/sap.ui.core/src/sap/ui/model/base/ManagedObjectModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/base/ManagedObjectModel.js
@@ -428,7 +428,7 @@ sap.ui.define([
 		iLastSlash = sResolvedPath.lastIndexOf("/");
 		// In case there is only one slash at the beginning, sObjectPath must contain this slash
 		sObjectPath = sResolvedPath.substring(0, iLastSlash || 1);
-		sProperty = sResolvedPath.substr(iLastSlash + 1);
+		sProperty = sResolvedPath.substring(iLastSlash + 1);
 		var aNodeStack = [], oObject = this._getObject(sObjectPath, null, aNodeStack);
 		if (oObject) {
 			if (oObject instanceof ManagedObject) {
@@ -470,7 +470,7 @@ sap.ui.define([
 					sPathInsideProperty = "/" + aParts.join("/") + sPathInsideProperty;
 				}
 				var iDelimiter = sResolvedPath.lastIndexOf(sPathInsideProperty);
-				var sPathUpToProperty = sResolvedPath.substr(0, iDelimiter);
+				var sPathUpToProperty = sResolvedPath.substring(0, iDelimiter);
 
 				//re-invoke now instead of:
 				// -> array case /objectArray/0/value/0 directly to /objectArray

--- a/src/sap.ui.core/src/sap/ui/model/json/JSONModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/json/JSONModel.js
@@ -388,7 +388,7 @@ sap.ui.define([
 		iLastSlash = sResolvedPath.lastIndexOf("/");
 		// In case there is only one slash at the beginning, sObjectPath must contain this slash
 		sObjectPath = sResolvedPath.substring(0, iLastSlash || 1);
-		sProperty = sResolvedPath.substr(iLastSlash + 1);
+		sProperty = sResolvedPath.substring(iLastSlash + 1);
 
 		var oObject = this._getObject(sObjectPath);
 		if (oObject) {

--- a/src/sap.ui.core/src/sap/ui/model/odata/AnnotationParser.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/AnnotationParser.js
@@ -787,7 +787,7 @@ var AnnotationParser =  {
 	getEdmType: function(sPath, oProperties, sTarget, oSchema) {
 		var iPos = sPath.indexOf("/");
 		if (iPos > -1) {
-			var sPropertyName = sPath.substr(0, iPos);
+			var sPropertyName = sPath.substring(0, iPos);
 			var mNavProperty = AnnotationParser.findNavProperty(sTarget, sPropertyName);
 
 			if (mNavProperty) {
@@ -795,7 +795,7 @@ var AnnotationParser =  {
 
 				if (mToEntityType) {
 					sTarget = mToEntityType.entityType;
-					sPath = sPath.substr(iPos + 1);
+					sPath = sPath.substring(iPos + 1);
 				}
 			}
 		}

--- a/src/sap.ui.core/src/sap/ui/model/odata/ODataMessageParser.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/ODataMessageParser.js
@@ -333,7 +333,7 @@ ODataMessageParser.prototype._propagateMessages = function(aMessages, mRequestIn
 				// must be sent for affected entity)
 				var iPropertyPos = sTarget.lastIndexOf(")/");
 				if (iPropertyPos > 0) {
-					sTarget = sTarget.substr(0, iPropertyPos + 1);
+					sTarget = sTarget.substring(0, iPropertyPos + 1);
 				}
 
 				return sTarget;
@@ -847,15 +847,15 @@ ODataMessageParser.prototype._parseUrl = function(sUrl) {
 
 	iPos = sUrl.indexOf("#");
 	if (iPos > -1) {
-		mUrlData.hash = mUrlData.url.substr(iPos + 1);
-		mUrlData.url = mUrlData.url.substr(0, iPos);
+		mUrlData.hash = mUrlData.url.substring(iPos + 1);
+		mUrlData.url = mUrlData.url.substring(0, iPos);
 	}
 
 	iPos = sUrl.indexOf("?");
 	if (iPos > -1) {
-		var sParameters = mUrlData.url.substr(iPos + 1);
+		var sParameters = mUrlData.url.substring(iPos + 1);
 		mUrlData.parameters = URI.parseQuery(sParameters);
-		mUrlData.url = mUrlData.url.substr(0, iPos);
+		mUrlData.url = mUrlData.url.substring(0, iPos);
 	}
 
 	return mUrlData;

--- a/src/sap.ui.core/src/sap/ui/model/odata/ODataMetadata.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/ODataMetadata.js
@@ -737,7 +737,7 @@ sap.ui.define([
 			}
 
 			//extract property
-			sPropertyPath = aParts[1].substr(aParts[1].indexOf('/') + 1);
+			sPropertyPath = aParts[1].substring(aParts[1].indexOf('/') + 1);
 			oProperty = this._getPropertyMetadata(oEntityType,sPropertyPath);
 
 			assert(oProperty, sPropertyPath + " is not a valid property path");
@@ -745,8 +745,8 @@ sap.ui.define([
 				return undefined;
 			}
 
-			sMetaPath = sPropertyPath.substr(sPropertyPath.indexOf(oProperty.name));
-			sMetaPath = sMetaPath.substr(sMetaPath.indexOf('/') + 1);
+			sMetaPath = sPropertyPath.substring(sPropertyPath.indexOf(oProperty.name));
+			sMetaPath = sMetaPath.substring(sMetaPath.indexOf('/') + 1);
 		} else {
 			//getentityType from data Path
 			oEntityType = this._getEntityTypeByPath(aParts[0]);
@@ -761,7 +761,7 @@ sap.ui.define([
 			sPath = aParts[0].replace(/^\/|\/$/g, "");
 			sPropertyPath = sPath;
 			while (!oProperty && sPropertyPath.indexOf("/") > 0) {
-				sPropertyPath = sPropertyPath.substr(sPropertyPath.indexOf('/') + 1);
+				sPropertyPath = sPropertyPath.substring(sPropertyPath.indexOf('/') + 1);
 				oProperty = this._getPropertyMetadata(oEntityType, sPropertyPath);
 			}
 
@@ -817,7 +817,7 @@ sap.ui.define([
 			sMetaDataPath = aParts.splice(0,1);
 			oAnnotation = this._getAnnotationObject(oEntityType, oNode, aParts.join('/'));
 		} else if (aParts[0].indexOf('@') > -1) { //handle attributes
-			sAnnotation = aParts[0].substr(1);
+			sAnnotation = aParts[0].substring(1);
 			aAnnotationParts = sAnnotation.split(':');
 			oAnnotation = oNode[aAnnotationParts[0]];
 			if (!oAnnotation && oNode.extensions) {
@@ -907,8 +907,8 @@ sap.ui.define([
 		var oInfo = {};
 		if (sFullName) {
 			var iSepIdx = sFullName.lastIndexOf(".");
-			oInfo.name = sFullName.substr(iSepIdx + 1);
-			oInfo.namespace = sFullName.substr(0, iSepIdx);
+			oInfo.name = sFullName.substring(iSepIdx + 1);
+			oInfo.namespace = sFullName.substring(0, iSepIdx);
 		}
 		return oInfo;
 	};
@@ -1031,7 +1031,7 @@ sap.ui.define([
 	 */
 	ODataMetadata.prototype._getFunctionImportMetadataByName = function(sFunctionName) {
 		if (sFunctionName.indexOf("/") > -1) {
-			sFunctionName = sFunctionName.substr(sFunctionName.indexOf("/") + 1);
+			sFunctionName = sFunctionName.substring(sFunctionName.indexOf("/") + 1);
 		}
 		return this._getFunctionImportMetadataIterate(function(oFunctionImport) {
 			return oFunctionImport.name === sFunctionName;
@@ -1048,7 +1048,7 @@ sap.ui.define([
 	 */
 	ODataMetadata.prototype._getFunctionImportMetadata = function(sFunctionName, sMethod) {
 		if (sFunctionName.indexOf("/") > -1) {
-			sFunctionName = sFunctionName.substr(sFunctionName.indexOf("/") + 1);
+			sFunctionName = sFunctionName.substring(sFunctionName.indexOf("/") + 1);
 		}
 		return this._getFirstMatchingFunctionImportMetadata(function(oFunctionImport) {
 			return oFunctionImport.name === sFunctionName && oFunctionImport.httpMethod === sMethod;
@@ -1516,7 +1516,7 @@ sap.ui.define([
 		if (sPath) {
 			iIndex = sPath.lastIndexOf(")");
 			if (iIndex !== -1) {
-				sTempPath = sPath.substr(0, iIndex + 1);
+				sTempPath = sPath.substring(0, iIndex + 1);
 				var oEntitySet = this._getEntitySetByPath(sTempPath);
 				if (oEntitySet) {
 					if (oEntitySet.__entityType.isFunction) {
@@ -1531,7 +1531,7 @@ sap.ui.define([
 
 						} else {
 							aParts = sTempPath.split("/");
-							sTempPath = '/' + oEntitySet.name + aParts[aParts.length - 1].substr(aParts[aParts.length - 1].indexOf("(")) + sPath.substr(iIndex + 1);
+							sTempPath = '/' + oEntitySet.name + aParts[aParts.length - 1].substring(aParts[aParts.length - 1].indexOf("(")) + sPath.substring(iIndex + 1);
 							if (sTempPath !== sPath) {
 								sCanonicalPath = sTempPath;
 							}

--- a/src/sap.ui.core/src/sap/ui/model/odata/ODataModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/ODataModel.js
@@ -680,8 +680,8 @@ sap.ui.define([
 
 		//we need to handle url params that can be passed from the manual CRUD methods due to compatibility
 		if (sPath && sPath.indexOf('?') != -1 ) {
-			sUrlParams = sPath.substr(sPath.indexOf('?') + 1);
-			sPath = sPath.substr(0, sPath.indexOf('?'));
+			sUrlParams = sPath.substring(sPath.indexOf('?') + 1);
+			sPath = sPath.substring(0, sPath.indexOf('?'));
 		}
 
 		sResolvedPath = this._normalizePath(sPath, oContext);
@@ -689,7 +689,7 @@ sap.ui.define([
 		if (!bBatch) {
 			sUrl = this.sServiceUrl + sResolvedPath;
 		} else {
-			sUrl = sResolvedPath.substr(sResolvedPath.indexOf('/') + 1);
+			sUrl = sResolvedPath.substring(sResolvedPath.indexOf('/') + 1);
 		}
 
 		aUrlParams = ODataUtils._createUrlParamsArray(oUrlParams);
@@ -826,7 +826,7 @@ sap.ui.define([
 
 				// reset change key if refresh was triggered on that entry
 				if (that.sChangeKey && mChangedEntities) {
-					var sEntry = that.sChangeKey.substr(that.sChangeKey.lastIndexOf('/') + 1);
+					var sEntry = that.sChangeKey.substring(that.sChangeKey.lastIndexOf('/') + 1);
 					if (mChangedEntities[sEntry]) {
 						delete that.oRequestQueue[that.sChangeKey];
 						that.sChangeKey = null;
@@ -1248,7 +1248,7 @@ sap.ui.define([
 					if (sKey && oContext && bIsRelative) {
 						var sContextPath = oContext.getPath();
 						// remove starting slash
-						sContextPath = sContextPath.substr(1);
+						sContextPath = sContextPath.substring(1);
 						// when model is refreshed, parent entity might not be available yet
 						if (that.oData[sContextPath]) {
 							that.oData[sContextPath][sPath] = {__ref: sKey};
@@ -1518,10 +1518,10 @@ sap.ui.define([
 	ODataModel.prototype._getKey = function(oObject, bDecode) {
 		var sKey, sURI;
 		if (oObject instanceof Context) {
-			sKey = oObject.getPath().substr(1);
+			sKey = oObject.getPath().substring(1);
 		} else if (oObject && oObject.__metadata && oObject.__metadata.uri) {
 			sURI = oObject.__metadata.uri;
-			sKey = sURI.substr(sURI.lastIndexOf("/") + 1);
+			sKey = sURI.substring(sURI.lastIndexOf("/") + 1);
 		}
 		if (bDecode) {
 			sKey = decodeURIComponent(sKey);
@@ -1661,8 +1661,8 @@ sap.ui.define([
 				if (!this.bMetaModelLoaded) {
 					return null;
 				}
-				sDataPath = sResolvedPath.substr(0, iSeparator);
-				sMetaPath = sResolvedPath.substr(iSeparator + 3);
+				sDataPath = sResolvedPath.substring(0, iSeparator);
+				sMetaPath = sResolvedPath.substring(iSeparator + 3);
 				oMetaContext = oMetaModel.getMetaContext(sDataPath);
 				oNode = oMetaModel.getProperty(sMetaPath, oMetaContext);
 			} else {
@@ -1673,7 +1673,7 @@ sap.ui.define([
 			if (oContext) {
 				sKey = oContext.getPath();
 				// remove starting slash
-				sKey = sKey.substr(1);
+				sKey = sKey.substring(1);
 				oNode = this.oData[sKey];
 			}
 			if (!sPath) {
@@ -2165,7 +2165,7 @@ sap.ui.define([
 			sEntry = sPath.replace(this.sServiceUrl + '/','');
 			iIndex = sEntry.indexOf("?");
 			if (iIndex > -1) {
-				sEntry = sEntry.substr(0, iIndex);
+				sEntry = sEntry.substring(0, iIndex);
 			}
 			if (this.oData.hasOwnProperty(sEntry)) {
 				sETagHeader = this.getProperty('/' + sEntry + '/__metadata/etag');
@@ -2478,10 +2478,10 @@ sap.ui.define([
 		}
 
 		_fnSuccess = function(oData, oResponse) {
-			sEntry = sUrl.substr(sUrl.lastIndexOf('/') + 1);
+			sEntry = sUrl.substring(sUrl.lastIndexOf('/') + 1);
 			//remove query params if any
 			if (sEntry.indexOf('?') != -1) {
-				sEntry = sEntry.substr(0, sEntry.indexOf('?'));
+				sEntry = sEntry.substring(0, sEntry.indexOf('?'));
 			}
 			delete that.oData[sEntry];
 			delete that.mContexts["/" + sEntry]; // contexts are stored starting with /
@@ -2713,7 +2713,7 @@ sap.ui.define([
 
 		// for batch remove starting / if any
 		if (sPath.startsWith("/")) {
-			sPath = sPath.substr(1);
+			sPath = sPath.substring(1);
 		}
 
 		if (oParameters) {
@@ -2761,7 +2761,7 @@ sap.ui.define([
 			// remove URL params
 			var sNormalizedPath = sPath;
 			if (sPath.indexOf('?') != -1 ) {
-				sNormalizedPath = sPath.substr(0, sPath.indexOf('?'));
+				sNormalizedPath = sPath.substring(0, sPath.indexOf('?'));
 			}
 			oEntityType = this.oMetadata._getEntityTypeByPath(sNormalizedPath);
 			if (oEntityType) {
@@ -3172,7 +3172,7 @@ sap.ui.define([
 		sChangeKey = sChangeKey.substring(0, sChangeKey.indexOf("/"));
 		sChangeKey = this.sServiceUrl + '/' + sChangeKey;
 
-		sProperty = sPath.substr(sPath.lastIndexOf("/") + 1);
+		sProperty = sPath.substring(sPath.lastIndexOf("/") + 1);
 
 		oData = this._getObject(sObjectPath, oContext);
 		if (!oData) {
@@ -3373,7 +3373,7 @@ sap.ui.define([
 			delete this.mContexts[sPath]; // contexts are stored starting with /
 			// remove starting / if any
 			if (sPath.startsWith("/")) {
-				sPath = sPath.substr(1);
+				sPath = sPath.substring(1);
 			}
 			delete this.oRequestQueue[sPath];
 			delete this.oData[sPath];
@@ -3514,7 +3514,7 @@ sap.ui.define([
 
 		// remove query params from path if any
 		if (sPath && sPath.indexOf('?') != -1 ) {
-			sPath = sPath.substr(0, sPath.indexOf('?'));
+			sPath = sPath.substring(0, sPath.indexOf('?'));
 		}
 
 		if (!oContext && !sPath.startsWith("/")) {
@@ -3546,7 +3546,7 @@ sap.ui.define([
 	 */
 	ODataModel.prototype.isList = function(sPath, oContext) {
 		sPath = this.resolve(sPath, oContext);
-		return sPath && sPath.substr(sPath.lastIndexOf("/")).indexOf("(") === -1;
+		return sPath && sPath.substring(sPath.lastIndexOf("/")).indexOf("(") === -1;
 	};
 
 	/**

--- a/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataListBinding.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataListBinding.js
@@ -496,7 +496,7 @@ sap.ui.define([
 					break; // avoid gaps
 				}
 				oContext = this.oModel.getContext('/' + sKey,
-					sDeepPath + sKey.substr(sKey.indexOf("(")));
+					sDeepPath + sKey.substring(sKey.indexOf("(")));
 			}
 			aContexts.push(oContext);
 		}

--- a/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
@@ -1468,7 +1468,7 @@ sap.ui.define([
 		if (!bBatch) {
 			sUrl = this.sServiceUrl + sNormalizedPath;
 		} else {
-			sUrl = sNormalizedPath.substr(sNormalizedPath.indexOf('/') + 1);
+			sUrl = sNormalizedPath.substring(sNormalizedPath.indexOf('/') + 1);
 		}
 
 		return this._addUrlParams(sUrl, aUrlParams);
@@ -1510,7 +1510,7 @@ sap.ui.define([
 			each(oData.results, function(i, entry) {
 				var sKey = that._getKey(entry);
 				sKey = that._importData(entry, mChangedEntities, oResponse, /*oRequest*/undefined,
-					sPath.substr(0, sPath.lastIndexOf("/")), sDeepPath, sKey,
+					sPath.substring(0, sPath.lastIndexOf("/")), sDeepPath, sKey,
 					/*bFunctionImport*/undefined, /*sPathFromCanonicalParent*/undefined,
 					bSideEffects);
 				if (sKey) {
@@ -1522,7 +1522,7 @@ sap.ui.define([
 			// data is single entity
 			if (sKey) {
 				sPath =  "/" + sKey;
-				sDeepPath += sKey.substr(sKey.indexOf("(")); /*e.g. SalesOrder(123)/ToLineItems + (345)*/
+				sDeepPath += sKey.substring(sKey.indexOf("(")); /*e.g. SalesOrder(123)/ToLineItems + (345)*/
 			} else {
 				sKey = this._getKey(oData);
 			}
@@ -1584,7 +1584,7 @@ sap.ui.define([
 					} else {
 						if (oCurrentEntry[sName] && oCurrentEntry[sName].__ref) {
 							if (oCurrentEntry[sName].__ref !== oResult) {
-								that.mInvalidatedPaths[sPath.substr(sPath.lastIndexOf("(")) + "/" + sName] = "/" + oResult;
+								that.mInvalidatedPaths[sPath.substring(sPath.lastIndexOf("(")) + "/" + sName] = "/" + oResult;
 							}
 						}
 						oEntry[sName] = { __ref: oResult };
@@ -1592,7 +1592,7 @@ sap.ui.define([
 				} else if (!oProperty || !oProperty.__deferred) { //do not store deferred navprops
 					//'null' is a valid value for navigation properties (e.g. if no entity is assigned). We need to invalidate the path cache
 					if (oCurrentEntry[sName] && oProperty === null) {
-						that.mInvalidatedPaths[sPath.substr(sPath.lastIndexOf("(")) + "/" + sName] = null;
+						that.mInvalidatedPaths[sPath.substring(sPath.lastIndexOf("(")) + "/" + sName] = null;
 					}
 					oEntry[sName] = oProperty;
 				}
@@ -2375,7 +2375,7 @@ sap.ui.define([
 			if (oContext && bIsRelative && bLink) {
 				sContextPath = oContext.getPath();
 				// remove starting slash
-				sContextPath = sContextPath.substr(1);
+				sContextPath = sContextPath.substring(1);
 				// when model is refreshed, parent entity might not be available yet
 				oEntity = that._getEntity(sContextPath);
 				if (oEntity) {
@@ -2390,7 +2390,7 @@ sap.ui.define([
 			if (oError.statusCode == '404' && oContext && bIsRelative) {
 				var sContextPath = oContext.getPath();
 				// remove starting slash
-				sContextPath = sContextPath.substr(1);
+				sContextPath = sContextPath.substring(1);
 				// when model is refreshed, parent entity might not be available yet
 				oEntity = that._getEntity(sContextPath);
 				if (oEntity) {
@@ -2854,12 +2854,12 @@ sap.ui.define([
 	ODataModel.prototype._getKey = function(vValue) {
 		var sKey, sURI;
 		if (vValue instanceof BaseContext) {
-			sKey = vValue.getPath().substr(1);
+			sKey = vValue.getPath().substring(1);
 		} else if (vValue && vValue.__metadata && vValue.__metadata.uri) {
 			sURI = vValue.__metadata.uri;
-			sKey = sURI.substr(sURI.lastIndexOf("/") + 1);
+			sKey = sURI.substring(sURI.lastIndexOf("/") + 1);
 		} else if (typeof vValue === 'string') {
-			sKey = vValue.substr(vValue.lastIndexOf("/") + 1);
+			sKey = vValue.substring(vValue.lastIndexOf("/") + 1);
 		}
 		if (!this.oData[sKey]) {
 			sKey = sKey && ODataUtils._normalizeKey(sKey);
@@ -3203,8 +3203,8 @@ sap.ui.define([
 						return null;
 					}
 					iSeparator = sResolvedPath.indexOf('/##');
-					sDataPath = sResolvedPath.substr(0, iSeparator);
-					sMetaPath = sResolvedPath.substr(iSeparator + 3);
+					sDataPath = sResolvedPath.substring(0, iSeparator);
+					sMetaPath = sResolvedPath.substring(iSeparator + 3);
 					oMetaContext = oMetaModel.getMetaContext(sDataPath);
 					oNode = oMetaModel.getProperty(sMetaPath, oMetaContext);
 				} else {
@@ -3975,7 +3975,7 @@ sap.ui.define([
 					iIndex = sKey.indexOf(sUpdateKey);
 					if (iIndex > -1) {
 						if (iIndex + sUpdateKey.length !== sKey.length) {
-							var sEnd = sKey.substr(iIndex + sUpdateKey.length);
+							var sEnd = sKey.substring(iIndex + sUpdateKey.length);
 							that.mPathCache[sKey].canonicalPath = that.mInvalidatedPaths[sUpdateKey] === null ? null : that.mInvalidatedPaths[sUpdateKey] + sEnd;
 						} else {
 							that.mPathCache[sKey].canonicalPath = that.mInvalidatedPaths[sUpdateKey];
@@ -5510,7 +5510,7 @@ sap.ui.define([
 		return this._processRequest(function(requestHandle) {
 			sUrl = that._createRequestUrlWithNormalizedPath(sNormalizedPath, aUrlParams,
 				that.bUseBatch);
-			sKey = sUrl.substr(sUrl.lastIndexOf('/') + 1);
+			sKey = sUrl.substring(sUrl.lastIndexOf('/') + 1);
 			//remove query params if any
 			sKey = sKey.split("?")[0];
 			oContextToRemove = that.mContexts["/" + sKey];
@@ -7223,7 +7223,7 @@ sap.ui.define([
 			that = this;
 
 		if (oContext) {
-			sKey = oContext.getPath().substr(1);
+			sKey = oContext.getPath().substring(1);
 			sGroupId = this._resolveGroup(sKey).groupId;
 			that.oMetadata.loaded().then(function() {
 				that.abortInternalRequest(sGroupId, {requestKey: sKey});
@@ -7715,7 +7715,7 @@ sap.ui.define([
 	ODataModel.prototype._normalizePath = function(sPath, oContext, bCanonical) {
 		// remove query params from path if any
 		if (sPath && sPath.indexOf('?') !== -1 ) {
-			sPath = sPath.substr(0, sPath.indexOf('?'));
+			sPath = sPath.substring(0, sPath.indexOf('?'));
 		}
 		if (!oContext && !sPath.startsWith("/")) {
 			Log.fatal(this + " path " + sPath + " must be absolute if no Context is set");
@@ -7801,7 +7801,7 @@ sap.ui.define([
 	 */
 	ODataModel.prototype.isList = function(sPath, oContext) {
 		sPath = this.resolve(sPath, oContext);
-		return sPath && sPath.substr(sPath.lastIndexOf("/")).indexOf("(") === -1;
+		return sPath && sPath.substring(sPath.lastIndexOf("/")).indexOf("(") === -1;
 	};
 
 	/**
@@ -8270,8 +8270,8 @@ sap.ui.define([
 			sStartingPath = sCanonicalPath || sPath;
 			if (!sCanonicalPath) {
 				iIndex = sStartingPath.lastIndexOf("/");
-				sEndingPathPart = sStartingPath.substr(iIndex);
-				sStartingPath = sStartingPath.substr(0, iIndex);
+				sEndingPathPart = sStartingPath.substring(iIndex);
+				sStartingPath = sStartingPath.substring(0, iIndex);
 			}
 			sNextMatch = this.resolveFromCache(sStartingPath);
 

--- a/src/sap.ui.core/src/sap/ui/model/xml/XMLModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/xml/XMLModel.js
@@ -226,7 +226,7 @@ sap.ui.define([
 	 */
 	XMLModel.prototype.setProperty = function(sPath, oValue, oContext, bAsyncUpdate) {
 		var sObjectPath = sPath.substring(0, sPath.lastIndexOf("/") + 1),
-			sProperty = sPath.substr(sPath.lastIndexOf("/") + 1);
+			sProperty = sPath.substring(sPath.lastIndexOf("/") + 1);
 
 		// check if path / context is valid
 		if (!this.resolve(sPath, oContext)) {
@@ -241,7 +241,7 @@ sap.ui.define([
 		if (sProperty.indexOf("@") == 0) {
 			oObject = this._getObject(sObjectPath, oContext);
 			if (oObject[0]) {
-				oObject[0].setAttribute(sProperty.substr(1), oValue);
+				oObject[0].setAttribute(sProperty.substring(1), oValue);
 				this.checkUpdate(false, bAsyncUpdate);
 				return true;
 			}
@@ -332,7 +332,7 @@ sap.ui.define([
 		while (oNode && oNode.length > 0 && aParts[iIndex]) {
 			sPart = aParts[iIndex];
 			if (sPart.indexOf("@") == 0) {
-				oNode = this._getAttribute(oNode[0], sPart.substr(1));
+				oNode = this._getAttribute(oNode[0], sPart.substring(1));
 			} else if (sPart == "text()") {
 				oNode = oNode[0] ? oNode[0].textContent : "";
 			} else if (isNaN(sPart)) {
@@ -405,7 +405,7 @@ sap.ui.define([
 		var iColonPos = sName.indexOf(":"),
 			sPrefix = "";
 		if (iColonPos > 0) {
-			sPrefix = sName.substr(0, iColonPos);
+			sPrefix = sName.substring(0, iColonPos);
 		}
 		return this.oNameSpaces[sPrefix];
 	};
@@ -421,7 +421,7 @@ sap.ui.define([
 		var iColonPos = sName.indexOf(":"),
 			sLocalName = sName;
 		if (iColonPos > 0) {
-			sLocalName = sName.substr(iColonPos + 1);
+			sLocalName = sName.substring(iColonPos + 1);
 		}
 		return sLocalName;
 	};
@@ -445,7 +445,7 @@ sap.ui.define([
 			if (name == "xmlns") {
 				oPrefixes[value] = "";
 			} else if (name.indexOf("xmlns") == 0) {
-				oPrefixes[value] = name.substr(6);
+				oPrefixes[value] = name.substring(6);
 			}
 		});
 		return oPrefixes;

--- a/src/sap.ui.core/src/sap/ui/performance/trace/FESR.js
+++ b/src/sap.ui.core/src/sap/ui/performance/trace/FESR.js
@@ -166,7 +166,7 @@ sap.ui.define([
 				vField = "-1";
 			}
 		} else {
-			vField = bCutFromFront ? vField.substr(-iLength, iLength) : vField.substr(0, iLength);
+			vField = bCutFromFront ? vField.substring(-iLength, iLength) : vField.substring(0, iLength);
 		}
 		return vField;
 	}

--- a/src/sap.ui.core/src/sap/ui/performance/trace/Passport.js
+++ b/src/sap.ui.core/src/sap/ui/performance/trace/Passport.js
@@ -99,7 +99,7 @@ sap.ui.define(["sap/ui/performance/XHRInterceptor", "sap/ui/thirdparty/URI"], fu
 		prefix = prefix.concat(getBytesFromString(new Array(32 + 1 - prefix.length).join(' ')));
 
 		if (component) {
-			component = getBytesFromString(component.substr(-32,32));
+			component = getBytesFromString(component.substring(-32,32));
 			component = component.concat(getBytesFromString(new Array(32 + 1 - component.length).join(' ')));
 			SAPEPPTemplateLow.splice.apply(SAPEPPTemplateLow, CompNamePosLEn.concat(component));
 			SAPEPPTemplateLow.splice.apply(SAPEPPTemplateLow, PreCompNamePosLEn.concat(component));
@@ -112,7 +112,7 @@ sap.ui.define(["sap/ui/performance/XHRInterceptor", "sap/ui/thirdparty/URI"], fu
 		SAPEPPTemplateLow.splice.apply(SAPEPPTemplateLow, traceFlgsOffset.concat(trcLvl));
 
 		if (action) {
-			action = getBytesFromString(action.substr(-40,40));
+			action = getBytesFromString(action.substring(-40,40));
 			action = action.concat(getBytesFromString(new Array(40 + 1 - action.length).join(' ')));
 			SAPEPPTemplateLow.splice.apply(SAPEPPTemplateLow, actionOffset.concat(action));
 		}

--- a/src/sap.ui.core/src/sap/ui/performance/trace/_InteractionImpl.js
+++ b/src/sap.ui.core/src/sap/ui/performance/trace/_InteractionImpl.js
@@ -51,7 +51,7 @@ sap.ui.define([
 		var hex = sValue.toString();
 		var str = '';
 		for (var n = 0; n < hex.length; n += 2) {
-			str += String.fromCharCode(parseInt(hex.substr(n, 2), 16));
+			str += String.fromCharCode(parseInt(hex.substring(n, 2), 16));
 		}
 		return str.trim();
 	}

--- a/src/sap.ui.core/src/sap/ui/qunit/qunit-junit.js
+++ b/src/sap.ui.core/src/sap/ui/qunit/qunit-junit.js
@@ -18,7 +18,7 @@
 	var bLegacySupport = !(parseFloat(QUnit.version) >= 2.0);
 
 	// test-page url/name as module prefix
-	var sTestPageName = document.location.pathname.substr(1).replace(/\./g, "_").replace(/\//g, ".") + document.location.search.replace(/\./g, '_');
+	var sTestPageName = document.location.pathname.substring(1).replace(/\./g, "_").replace(/\//g, ".") + document.location.search.replace(/\./g, '_');
 
 	// avoid . in module names to avoid displaying issues in Jenkins results
 	function formatModuleName(sName) {

--- a/src/sap.ui.core/src/sap/ui/qunit/qunit-redirect.js
+++ b/src/sap.ui.core/src/sap/ui/qunit/qunit-redirect.js
@@ -13,7 +13,7 @@
 				sBaseUrl = null,
 				sTestTimeout,
 				sOrigin = window.location.origin ? window.location.origin : (window.location.protocol + "//" + window.location.host),
-				sTestUrl = window.location.href.substr(sOrigin.length);
+				sTestUrl = window.location.href.substring(sOrigin.length);
 
 		for (var i = 0; i < aScripts.length; i++) {
 			var oScript = aScripts[i];

--- a/src/sap.ui.core/src/sap/ui/security/FrameOptions.js
+++ b/src/sap.ui.core/src/sap/ui/security/FrameOptions.js
@@ -137,10 +137,10 @@ sap.ui.define(['sap/base/Log'], function(Log) {
 			sPattern = sPattern.replace(/\*/gi, ".*");  // replace *   with .*
 			sPattern = sPattern.replace(/:\.\*$/gi, ":\\d*"); // replace :.* with :\d* (only at the end)
 
-			if (sPattern.substr(sPattern.length - 1, 1) !== '$') {
+			if (sPattern.substring(sPattern.length - 1, 1) !== '$') {
 				sPattern = sPattern + '$'; // if not already there add $ at the end
 			}
-			if (sPattern.substr(0, 1) !== '^') {
+			if (sPattern.substring(0, 1) !== '^') {
 				sPattern = '^' + sPattern; // if not already there add ^ at the beginning
 			}
 

--- a/src/sap.ui.core/src/sap/ui/test/_OpaUriParameterParser.js
+++ b/src/sap.ui.core/src/sap/ui/test/_OpaUriParameterParser.js
@@ -37,8 +37,8 @@ sap.ui.define([
 
         for (var sUriParamName in mUriParams) {
             if (sUriParamName.startsWith(_OpaUriParameterParser.PREFIX)) {
-                var sOpaParamName = sUriParamName.substr(_OpaUriParameterParser.PREFIX.length);
-                sOpaParamName = sOpaParamName.charAt(0).toLowerCase() + sOpaParamName.substr(1);
+                var sOpaParamName = sUriParamName.substring(_OpaUriParameterParser.PREFIX.length);
+                sOpaParamName = sOpaParamName.charAt(0).toLowerCase() + sOpaParamName.substring(1);
                 mOpaParams[sOpaParamName] = _OpaUriParameterParser._parseParam(mUriParams[sUriParamName]);
             }
         }

--- a/src/sap.ui.core/src/sap/ui/test/gherkin/dataTableUtils.js
+++ b/src/sap.ui.core/src/sap/ui/test/gherkin/dataTableUtils.js
@@ -79,7 +79,7 @@ sap.ui.define([
 			titleCase : function(sString) {
 				dataTableUtils._testNormalizationInput(sString, "titleCase");
 				return normalize(sString)
-					.replace(/\w*/g, function(s){return s.charAt(0).toUpperCase() + s.substr(1).toLowerCase();});
+					.replace(/\w*/g, function(s){return s.charAt(0).toUpperCase() + s.substring(1).toLowerCase();});
 			},
 
 			/**

--- a/src/sap.ui.core/src/sap/ui/test/matchers/BindingPath.js
+++ b/src/sap.ui.core/src/sap/ui/test/matchers/BindingPath.js
@@ -212,7 +212,7 @@ sap.ui.define([
 			var oMatcherRegex;
 			var aDelimiterMatch = vMatcherPath.source.match(/\^?\//);
 			if (bWithContext && aDelimiterMatch) {
-				oMatcherRegex = new RegExp(vMatcherPath.source.substr(aDelimiterMatch.index + 1), vMatcherPath.flags);
+				oMatcherRegex = new RegExp(vMatcherPath.source.substring(aDelimiterMatch.index + 1), vMatcherPath.flags);
 			} else if (!bWithContext && !aDelimiterMatch) {
 				oMatcherRegex = new RegExp("\/" + vMatcherPath.source, vMatcherPath.flags);
 			} else {
@@ -222,7 +222,7 @@ sap.ui.define([
 		} else if (sPath) {
 			var bHasDelimiter = sPath.charAt(0) === "/";
 			if (bWithContext && bHasDelimiter) {
-				vMatcherPath = vMatcherPath.substr(1);
+				vMatcherPath = vMatcherPath.substring(1);
 			} else if (!bWithContext && !bHasDelimiter) {
 				vMatcherPath = "/" + vMatcherPath;
 			}

--- a/src/sap.ui.core/test/sap/ui/core/BindableResponseHeaders.html
+++ b/src/sap.ui.core/test/sap/ui/core/BindableResponseHeaders.html
@@ -34,7 +34,7 @@
 
 				var iPos = request.url.indexOf("?");
 				if (iPos > -1) {
-					request.url = request.url.substr(0, iPos);
+					request.url = request.url.substring(0, iPos);
 				}
 
 
@@ -93,7 +93,7 @@
 				apiVersion: 2,
 				render: function(oRm, oControl) {
 					var sId = oControl.getId();
-	
+
 					oRm.openStart("div", oControl);
 					oRm.style("width", "100%");
 					oRm.style("height", "100%");
@@ -101,7 +101,7 @@
 					oRm.style("margin-bottom", "1rem");
 					oRm.attr("title", "Age: " + oControl.getAge());
 					oRm.openEnd();
-	
+
 						var fAge = Math.round((Date.now() - oControl.getAge()) / 1000);
 						oRm.openStart("div", sId + "-label");
 						oRm.style("display", "inline-block");
@@ -109,14 +109,14 @@
 						oRm.openEnd();
 						oRm.text(oControl.getLabel());
 						oRm.close("div");
-	
+
 						oRm.openStart("div", sId + "-value");
 						oRm.style("display", "inline-block");
 						oRm.style("width", "28%");
 						oRm.openEnd();
 						oRm.text(oControl.getValue());
 						oRm.close("div");
-	
+
 						oRm.openStart("div", sId + "-age");
 						oRm.style("display", "inline-block");
 						oRm.style("width", "28%");
@@ -125,14 +125,14 @@
 						oRm.text(oControl.getValue());
 						oRm.text("s");
 						oRm.close("div");
-	
+
 						oRm.openStart("button", sId + "-refresh");
 						oRm.style("display", "inline-block");
 						oRm.style("width", "10%");
 						oRm.openEnd();
 						oRm.text("Refresh");
 						oRm.close("button");
-	
+
 					oRm.close("div");
 				}
 			},

--- a/src/sap.ui.core/test/sap/ui/core/DateFormat.controller.js
+++ b/src/sap.ui.core/test/sap/ui/core/DateFormat.controller.js
@@ -264,7 +264,7 @@ sap.ui.define([
 		},
 
 		formatLocaleIcon: function(sLocale) {
-			return "flags/" + sLocale.substr(3) + ".png";
+			return "flags/" + sLocale.substring(3) + ".png";
 		},
 
 		onLocaleChange: function() {

--- a/src/sap.ui.core/test/sap/ui/core/FormatHelper.js
+++ b/src/sap.ui.core/test/sap/ui/core/FormatHelper.js
@@ -78,10 +78,10 @@ sap.ui.define([
 					.style("height", "40px")
 					.openEnd();
 
-					if (aTerritories.includes(sLocale.substr(3))) {
+					if (aTerritories.includes(sLocale.substring(3))) {
 						oRM.voidStart("img")
 							.attr("title", sLocale)
-							.attr("src", "flags/" + sLocale.substr(3) + ".png")
+							.attr("src", "flags/" + sLocale.substring(3) + ".png")
 							.style("width", "30px")
 							.style("margin", "10px")
 							.voidEnd();
@@ -288,7 +288,7 @@ sap.ui.define([
 			this.bUseRawValues = true;
 		},
 		parseValue: function(sValue) {
-			var aParts = sValue.substr(1).split("&"),
+			var aParts = sValue.substring(1).split("&"),
 				oParams = {}, aParams, vValue;
 			aParts.forEach(function(oParam) {
 				var aSplit = oParam.split("="),

--- a/src/sap.ui.core/test/sap/ui/core/NumberFormat.controller.js
+++ b/src/sap.ui.core/test/sap/ui/core/NumberFormat.controller.js
@@ -229,8 +229,8 @@ sap.ui.define([
 
 		formatImageSrc: function(sLocale) {
 			if (sLocale && sLocale.length > 3) {
-				if (FormatHelper.territories.includes(sLocale.substr(3))) {
-					return "flags/" + sLocale.substr(3) + ".png";
+				if (FormatHelper.territories.includes(sLocale.substring(3))) {
+					return "flags/" + sLocale.substring(3) + ".png";
 				}
 			}
 		},
@@ -338,7 +338,7 @@ sap.ui.define([
 		},
 
 		formatLocaleIcon: function(sLocale) {
-			return "flags/" + sLocale.substr(3) + ".png";
+			return "flags/" + sLocale.substring(3) + ".png";
 		},
 
 		onLocaleChange: function(oEvent) {

--- a/src/sap.ui.core/test/sap/ui/core/frameoptions/htmlparent.html
+++ b/src/sap.ui.core/test/sap/ui/core/frameoptions/htmlparent.html
@@ -14,8 +14,8 @@
 				if (url == "sameorigin_denied.html" || url == "allowlistservice_allowed.html" ||
 					url == "allowlistservice_denied.html" || url == "allowlistservice_inactive.html" ||
 					url == "allowlistservice_metatag_allowed.html" || url == "allowlistservice_metatag_denied.html") {
-					url = location.protocol + "//" + location.hostname.substr(0,location.hostname.indexOf(".")) + ":" +
-						location.port + location.pathname.substr(0,location.pathname.lastIndexOf("/") + 1) + url;
+					url = location.protocol + "//" + location.hostname.substring(0,location.hostname.indexOf(".")) + ":" +
+						location.port + location.pathname.substring(0,location.pathname.lastIndexOf("/") + 1) + url;
 				}
 				document.getElementById("iframe").src = url;
 			}

--- a/src/sap.ui.core/test/sap/ui/core/frameoptions/ui5parent.html
+++ b/src/sap.ui.core/test/sap/ui/core/frameoptions/ui5parent.html
@@ -20,8 +20,8 @@
 				if (url == "sameorigin_denied.html" || url == "allowlistservice_allowed.html" ||
 					url == "allowlistservice_denied.html" || url == "allowlistservice_inactive.html" ||
 					url == "allowlistservice_metatag_allowed.html" || url == "allowlistservice_metatag_denied.html") {
-					url = location.protocol + "//" + location.hostname.substr(0,location.hostname.indexOf(".")) + ":" +
-						location.port + location.pathname.substr(0,location.pathname.lastIndexOf("/") + 1) + url;
+					url = location.protocol + "//" + location.hostname.substring(0,location.hostname.indexOf(".")) + ":" +
+						location.port + location.pathname.substring(0,location.pathname.lastIndexOf("/") + 1) + url;
 				}
 				document.getElementById("iframe").src = url;
 			}

--- a/src/sap.ui.core/test/sap/ui/core/qunit/Fragment.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/Fragment.qunit.js
@@ -80,14 +80,14 @@ sap.ui.define([
 
 			var id = oFragment.getId();
 
-			assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated");
+			assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated");
 			assert.ok(document.getElementById(id), "XML Fragment should be rendered");
 
 			var aContent = oFragment.getContent();
 			var btn1 = aContent[0];
 			var btn2 = aContent[1];
 			assert.equal(btn1.getId(), "btn1InXmlFragment", "Button with given ID should have exactly this ID");
-			assert.equal(btn2.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+			assert.equal(btn2.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 			// Data binding
 			assert.equal(btn2.$().text(), DATABOUND_TEXT, "Second Button should have text from data binding");
@@ -115,14 +115,14 @@ sap.ui.define([
 
 			var id = oFragment.getId();
 
-			assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated");
+			assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated");
 			assert.ok(document.getElementById(id), "XML Fragment should be rendered");
 
 			var aContent = oFragment.getContent();
 			var btn1 = aContent[0];
 			var btn2 = aContent[1];
 			assert.equal(btn1.getId(), "btnInXmlFragment", "Button with given ID should have exactly this ID");
-			assert.equal(btn2.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+			assert.equal(btn2.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 			// Data binding
 			assert.equal(btn2.$().text(), DATABOUND_TEXT, "Second Button should have text from data binding");
@@ -146,14 +146,14 @@ sap.ui.define([
 
 			var id = oFragment.getId();
 
-			assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated");
+			assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated");
 			assert.ok(document.getElementById(id), "XML Fragment should be rendered");
 
 			var aContent = oFragment.getContent();
 			var btn1 = aContent[0];
 			var btn2 = aContent[1];
 			assert.equal(btn1.getId(), "myXmlFrag--btnInXmlFragment", "Button with given ID should have this ID with Fragment ID prefix");
-			assert.equal(btn2.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+			assert.equal(btn2.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 			// Data binding
 			assert.equal(btn2.$().text(), DATABOUND_TEXT, "Second Button should have text from data binding");
@@ -196,14 +196,14 @@ sap.ui.define([
 
 			var id = oFragment.getId();
 
-			assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated");
+			assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated");
 			assert.ok(document.getElementById(id), "JS Fragment should be rendered");
 
 			var aContent = oFragment.getContent();
 			var btn1 = aContent[0];
 			var btn2 = aContent[1];
 			assert.equal(btn1.getId(), "btnInJsFragment", "Button with given ID should have exactly this ID");
-			assert.equal(btn2.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+			assert.equal(btn2.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 			// Data binding
 			assert.equal(btn2.$().text(), DATABOUND_TEXT, "Second Button should have text from data binding");
@@ -228,14 +228,14 @@ sap.ui.define([
 
 			var id = oFragment.getId();
 
-			assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated");
+			assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated");
 			assert.ok(document.getElementById(id), "JS Fragment should be rendered");
 
 			var aContent = oFragment.getContent();
 			var btn1 = aContent[0];
 			var btn2 = aContent[1];
 			assert.equal(btn1.getId(), "myJsFrag--btnInJsFragment", "Button with given ID should have this ID with Fragment ID prefix");
-			assert.equal(btn2.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+			assert.equal(btn2.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 			// Data binding
 			assert.equal(btn2.$().text(), DATABOUND_TEXT, "Second Button should have text from data binding");
@@ -346,14 +346,14 @@ sap.ui.define([
 
 		var id = oXmlFragmentInXmlView.getId();
 		assert.ok(document.getElementById(id), "XML Fragment should be rendered");
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
 
 		var btn1id = oXmlFragmentInXmlView.getContent()[0].getId();
 		assert.equal(btn1id, oXmlView.getId() + "--btnInXmlFragment", "static Control ID inside Fragment should be prefixed by View ID");
 		triggerClickEvent(btn1id);
 
 		var btn2 = oXmlFragmentInXmlView.getContent()[1];
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
 		assert.equal(btn2.$().text(), DATABOUND_TEXT_IN_VIEW, "Second Button should have text from data binding");
 
 		// find controls by ID
@@ -367,14 +367,14 @@ sap.ui.define([
 
 		var id = oXmlFragmentWithIdInXmlView.getId();
 		assert.ok(document.getElementById(id), "Fragment should be rendered");
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
 
 		var btn1id = oXmlFragmentWithIdInXmlView.getContent()[0].getId();
 		assert.equal(btn1id, oXmlView.getId() + "--xmlInXml--btnInXmlFragment", "static Control ID inside Fragment should be prefixed by View ID and Fragment ID");
 		triggerClickEvent(btn1id);
 
 		var btn2 = oXmlFragmentWithIdInXmlView.getContent()[1];
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
 		assert.equal(btn2.$().text(), DATABOUND_TEXT_IN_VIEW, "Second Button should have text from data binding");
 
 		// find controls by ID
@@ -390,14 +390,14 @@ sap.ui.define([
 
 		var id = oJsFragmentInXmlView.getId();
 		assert.ok(document.getElementById(id), "Fragment should be rendered");
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
 
 		var btn1id = oJsFragmentInXmlView.getContent()[0].getId();
 		assert.equal(btn1id, oXmlView.getId() + "--btnInJsFragment", "static Control ID inside Fragment should be prefixed by View ID");
 		triggerClickEvent(btn1id);
 
 		var btn2 = oJsFragmentInXmlView.getContent()[1];
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
 		assert.equal(btn2.$().text(), DATABOUND_TEXT_IN_VIEW, "Second Button should have text from data binding");
 
 		// find controls by ID
@@ -411,14 +411,14 @@ sap.ui.define([
 
 		var id = oJsFragmentWithIdInXmlView.getId();
 		assert.ok(document.getElementById(id), "Fragment should be rendered");
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
 
 		var btn1id = oJsFragmentWithIdInXmlView.getContent()[0].getId();
 		assert.equal(btn1id, oXmlView.getId() + "--jsInXml--btnInJsFragment", "static Control ID inside Fragment should be prefixed by View ID and Fragment ID");
 		triggerClickEvent(btn1id);
 
 		var btn2 = oJsFragmentWithIdInXmlView.getContent()[1];
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
 		assert.equal(btn2.$().text(), DATABOUND_TEXT_IN_VIEW, "Second Button should have text from data binding");
 
 		// find controls by ID
@@ -535,7 +535,7 @@ sap.ui.define([
 
 			var aContent = oFragment.getContent();
 			var btn1 = aContent[0];
-			assert.equal(btn1.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+			assert.equal(btn1.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 			oFragment.destroy();
 		});
@@ -555,7 +555,7 @@ sap.ui.define([
 
 			var aContent = oFragment.getContent();
 			var btn1 = aContent[0];
-			assert.equal(btn1.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+			assert.equal(btn1.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 			oFragment.destroy();
 		});
@@ -632,14 +632,14 @@ sap.ui.define([
 
 			var id = oFragment.getId();
 
-			assert.equal(id.substr(0,8), "__layout", "Fragment ID should be generated");
+			assert.equal(id.substring(0,8), "__layout", "Fragment ID should be generated");
 			assert.ok(document.getElementById(id), "JS Fragment should be rendered");
 
 			var aContent = oFragment.getContent();
 			var btn1 = aContent[0];
 			var btn2 = aContent[1];
 			assert.equal(btn1.getId(), "myJsFragLoadApi--btnInJsFragment", "Button with given ID should have this ID with Fragment ID prefix");
-			assert.equal(btn2.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+			assert.equal(btn2.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 			triggerClickEvent(btn1.getId());
 
 			// Data binding

--- a/src/sap.ui.core/test/sap/ui/core/qunit/Fragment_legacyAPIs.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/Fragment_legacyAPIs.qunit.js
@@ -114,14 +114,14 @@ sap.ui.define([
 
 		var id = oFragment.getId();
 
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated");
 		assert.ok(document.getElementById(id), "XML Fragment should be rendered");
 
 		var aContent = oFragment.getContent();
 		var btn1 = aContent[0];
 		var btn2 = aContent[1];
 		assert.equal(btn1.getId(), "btnInXmlFragment", "Button with given ID should have exactly this ID");
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 		// Data binding
 		assert.equal(btn2.$().text(), DATABOUND_TEXT, "Second Button should have text from data binding");
@@ -139,14 +139,14 @@ sap.ui.define([
 
 		var id = oFragment.getId();
 
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated");
 		assert.ok(document.getElementById(id), "XML Fragment should be rendered");
 
 		var aContent = oFragment.getContent();
 		var btn1 = aContent[0];
 		var btn2 = aContent[1];
 		assert.equal(btn1.getId(), "myXmlFrag--btnInXmlFragment", "Button with given ID should have this ID with Fragment ID prefix");
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 		// Data binding
 		assert.equal(btn2.$().text(), DATABOUND_TEXT, "Second Button should have text from data binding");
@@ -182,14 +182,14 @@ sap.ui.define([
 
 		var id = oFragment.getId();
 
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated");
 		assert.ok(document.getElementById(id), "HTML Fragment should be rendered");
 
 		var aContent = oFragment.getContent();
 		var btn1 = aContent[0];
 		var btn2 = aContent[1];
 		assert.equal(btn1.getId(), "btnInHtmlFragment", "Button with given ID should have exactly this ID");
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 		// Data binding
 		assert.equal(btn2.$().text(), DATABOUND_TEXT, "Second Button should have text from data binding");
@@ -210,14 +210,14 @@ sap.ui.define([
 
 		var id = oFragment.getId();
 
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated");
 		assert.ok(document.getElementById(id), "HTML Fragment should be rendered");
 
 		var aContent = oFragment.getContent();
 		var btn1 = aContent[0];
 		var btn2 = aContent[1];
 		assert.equal(btn1.getId(), "myHtmlFrag--btnInHtmlFragment", "Button with given ID should have this ID with Fragment ID prefix");
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 		// Data binding
 		assert.equal(btn2.$().text(), DATABOUND_TEXT, "Second Button should have text from data binding");
@@ -255,14 +255,14 @@ sap.ui.define([
 
 		var id = oFragment.getId();
 
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated");
 		assert.ok(document.getElementById(id), "JS Fragment should be rendered");
 
 		var aContent = oFragment.getContent();
 		var btn1 = aContent[0];
 		var btn2 = aContent[1];
 		assert.equal(btn1.getId(), "btnInJsFragment", "Button with given ID should have exactly this ID");
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 		// Data binding
 		assert.equal(btn2.$().text(), DATABOUND_TEXT, "Second Button should have text from data binding");
@@ -280,14 +280,14 @@ sap.ui.define([
 
 		var id = oFragment.getId();
 
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated");
 		assert.ok(document.getElementById(id), "JS Fragment should be rendered");
 
 		var aContent = oFragment.getContent();
 		var btn1 = aContent[0];
 		var btn2 = aContent[1];
 		assert.equal(btn1.getId(), "myJsFrag--btnInJsFragment", "Button with given ID should have this ID with Fragment ID prefix");
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 		// Data binding
 		assert.equal(btn2.$().text(), DATABOUND_TEXT, "Second Button should have text from data binding");
@@ -459,14 +459,14 @@ sap.ui.define([
 
 		var id = oXmlFragmentInXmlView.getId();
 		assert.ok(document.getElementById(id), "XML Fragment should be rendered");
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
 
 		var btn1id = oXmlFragmentInXmlView.getContent()[0].getId();
 		assert.equal(btn1id, oXmlView.getId() + "--btnInXmlFragment", "static Control ID inside Fragment should be prefixed by View ID");
 		triggerClickEvent(btn1id);
 
 		var btn2 = oXmlFragmentInXmlView.getContent()[1];
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
 		assert.equal(btn2.$().text(), DATABOUND_TEXT_IN_VIEW, "Second Button should have text from data binding");
 
 		// find controls by ID
@@ -480,14 +480,14 @@ sap.ui.define([
 
 		var id = oXmlFragmentWithIdInXmlView.getId();
 		assert.ok(document.getElementById(id), "Fragment should be rendered");
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
 
 		var btn1id = oXmlFragmentWithIdInXmlView.getContent()[0].getId();
 		assert.equal(btn1id, oXmlView.getId() + "--xmlInXml--btnInXmlFragment", "static Control ID inside Fragment should be prefixed by View ID and Fragment ID");
 		triggerClickEvent(btn1id);
 
 		var btn2 = oXmlFragmentWithIdInXmlView.getContent()[1];
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
 		assert.equal(btn2.$().text(), DATABOUND_TEXT_IN_VIEW, "Second Button should have text from data binding");
 
 		// find controls by ID
@@ -503,14 +503,14 @@ sap.ui.define([
 
 		var id = oJsFragmentInXmlView.getId();
 		assert.ok(document.getElementById(id), "Fragment should be rendered");
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
 
 		var btn1id = oJsFragmentInXmlView.getContent()[0].getId();
 		assert.equal(btn1id, oXmlView.getId() + "--btnInJsFragment", "static Control ID inside Fragment should be prefixed by View ID");
 		triggerClickEvent(btn1id);
 
 		var btn2 = oJsFragmentInXmlView.getContent()[1];
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
 		assert.equal(btn2.$().text(), DATABOUND_TEXT_IN_VIEW, "Second Button should have text from data binding");
 
 		// find controls by ID
@@ -524,14 +524,14 @@ sap.ui.define([
 
 		var id = oJsFragmentWithIdInXmlView.getId();
 		assert.ok(document.getElementById(id), "Fragment should be rendered");
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
 
 		var btn1id = oJsFragmentWithIdInXmlView.getContent()[0].getId();
 		assert.equal(btn1id, oXmlView.getId() + "--jsInXml--btnInJsFragment", "static Control ID inside Fragment should be prefixed by View ID and Fragment ID");
 		triggerClickEvent(btn1id);
 
 		var btn2 = oJsFragmentWithIdInXmlView.getContent()[1];
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
 		assert.equal(btn2.$().text(), DATABOUND_TEXT_IN_VIEW, "Second Button should have text from data binding");
 
 		// find controls by ID
@@ -549,14 +549,14 @@ sap.ui.define([
 
 		var id = oHtmlFragmentInXmlView.getId();
 		assert.ok(document.getElementById(id), "Fragment should be rendered");
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
 
 		var btn1id = oHtmlFragmentInXmlView.getContent()[0].getId();
 		assert.equal(btn1id, oXmlView.getId() + "--btnInHtmlFragment", "static Control ID inside Fragment should be prefixed by View ID");
 		triggerClickEvent(btn1id);
 
 		var btn2 = oHtmlFragmentInXmlView.getContent()[1];
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
 		assert.equal(btn2.$().text(), DATABOUND_TEXT_IN_VIEW, "Second Button should have text from data binding");
 
 		// find controls by ID
@@ -573,14 +573,14 @@ sap.ui.define([
 
 		var id = oHtmlFragmentWithIdInXmlView.getId();
 		assert.ok(document.getElementById(id), "Fragment should be rendered");
-		assert.equal(id.substr(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
+		assert.equal(id.substring(0, 8), "__layout", "Fragment ID should be generated, with no View prefix");
 
 		var btn1id = oHtmlFragmentWithIdInXmlView.getContent()[0].getId();
 		assert.equal(btn1id, oXmlView.getId() + "--htmlInXml--btnInHtmlFragment", "static Control ID inside Fragment should be prefixed by View ID and Fragment ID");
 		triggerClickEvent(btn1id);
 
 		var btn2 = oHtmlFragmentWithIdInXmlView.getContent()[1];
-		assert.equal(btn2.getId().substr(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
+		assert.equal(btn2.getId().substring(0, 8), "__button", "Second Button ID should be generated, with no View prefix");
 		assert.equal(btn2.$().text(), DATABOUND_TEXT_IN_VIEW, "Second Button should have text from data binding");
 
 		// find controls by ID
@@ -752,7 +752,7 @@ sap.ui.define([
 
 		var aContent = oFragment.getContent();
 		var btn1 = aContent[0];
-		assert.equal(btn1.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+		assert.equal(btn1.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 		oFragment.destroy();
 	});
@@ -768,7 +768,7 @@ sap.ui.define([
 
 		var aContent = oFragment.getContent();
 		var btn1 = aContent[0];
-		assert.equal(btn1.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+		assert.equal(btn1.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 		oFragment.destroy();
 	});
@@ -787,7 +787,7 @@ sap.ui.define([
 
 		var aContent = oFragment.getContent();
 		var btn1 = aContent[0];
-		assert.equal(btn1.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+		assert.equal(btn1.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 		oFragment.destroy();
 	});
@@ -855,7 +855,7 @@ sap.ui.define([
 
 			var aContent = oFragment.getContent();
 			var btn1 = aContent[0];
-			assert.equal(btn1.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+			assert.equal(btn1.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 
 			oFragment.destroy();
 		});
@@ -874,14 +874,14 @@ sap.ui.define([
 
 			var id = oFragment.getId();
 
-			assert.equal(id.substr(0,8), "__layout", "Fragment ID should be generated");
+			assert.equal(id.substring(0,8), "__layout", "Fragment ID should be generated");
 			assert.ok(document.getElementById(id), "JS Fragment should be rendered");
 
 			var aContent = oFragment.getContent();
 			var btn1 = aContent[0];
 			var btn2 = aContent[1];
 			assert.equal(btn1.getId(), "myJsFragLoadApi--btnInJsFragment", "Button with given ID should have this ID with Fragment ID prefix");
-			assert.equal(btn2.getId().substr(0, 8), "__button", "Button with no given ID should have a generated ID");
+			assert.equal(btn2.getId().substring(0, 8), "__button", "Button with no given ID should have a generated ID");
 			triggerClickEvent(btn1.getId());
 
 			// Data binding

--- a/src/sap.ui.core/test/sap/ui/core/qunit/json/JSONListBinding.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/json/JSONListBinding.qunit.js
@@ -578,8 +578,8 @@ sap.ui.define([
 
 		var listBinding = bindings[0];
 		var oSorter = new Sorter("firstName", false, false, function(a, b) {
-			a = a.substr(1);
-			b = b.substr(1);
+			a = a.substring(1);
+			b = b.substring(1);
 			if (a < b) {
 				return -1;
 			}

--- a/src/sap.ui.core/test/sap/ui/core/qunit/json/JSONPropertyBinding.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/json/JSONPropertyBinding.qunit.js
@@ -104,7 +104,7 @@ sap.ui.define([
 		},
 		createPropertyBindings: function(path, property, context) {
 			// create bindings
-			return this.currentTestData[path.substr(1)].map(function(entry, i) {
+			return this.currentTestData[path.substring(1)].map(function(entry, i) {
 				return this.oModel.bindProperty(path + "/" + i + "/" + property, context);
 				//this.oModel.bindProperty(".teamMembers.lastName", entry.lastName);
 			}, this);
@@ -293,7 +293,7 @@ sap.ui.define([
 		},
 		createPropertyBindings: function(path, property, context) {
 			// create bindings
-			return this.currentTestData[path.substr(1)].map(function(entry, i) {
+			return this.currentTestData[path.substring(1)].map(function(entry, i) {
 				return this.oModel.bindProperty(path + "/" + i + "/" + property, context);
 				//this.oModel.bindProperty(".teamMembers.lastName", entry.lastName);
 			}, this);
@@ -396,7 +396,7 @@ sap.ui.define([
 		},
 		createPropertyBindings: function(path, property, context) {
 			// create bindings
-			return this.currentTestData[path.substr(1)].map(function(entry, i) {
+			return this.currentTestData[path.substring(1)].map(function(entry, i) {
 				return this.oModel.bindProperty(path + "/" + i + "/" + property, context);
 				//this.oModel.bindProperty(".teamMembers.lastName", entry.lastName);
 			}, this);
@@ -550,7 +550,7 @@ sap.ui.define([
 		},
 		createPropertyBindings: function(path, property, context) {
 			// create bindings
-			return this.currentTestData[path.substr(1)].map(function(entry, i) {
+			return this.currentTestData[path.substring(1)].map(function(entry, i) {
 				return this.oModel.bindProperty(path + "/" + i + "/" + property, context);
 				//this.oModel.bindProperty(".teamMembers.lastName", entry.lastName);
 			}, this);

--- a/src/sap.ui.core/test/sap/ui/core/qunit/odata/ODataModel_legacyAPIs.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/odata/ODataModel_legacyAPIs.qunit.js
@@ -106,7 +106,7 @@ sap.ui.define([
 
 	// assertion methods for the next 3 constructor tests
 	function assertCommonArguments(assert, oModel) {
-		assert.equal(oModel.sServiceUrl, sURI.substr(0, sURI.length - 1), 'serviceUrl');
+		assert.equal(oModel.sServiceUrl, sURI.substring(0, sURI.length - 1), 'serviceUrl');
 		assert.equal(oModel.bJSON, true, 'json');
 		assert.equal(oModel.sUser, 'user', 'user');
 		assert.equal(oModel.sPassword, 'pa$$w0rd', 'password');
@@ -1168,12 +1168,12 @@ sap.ui.define([
 			assert.equal(oEntry.Description, "Food Desc", "category ID check");
 			assert.ok(oEntry._bCreate, "check create flag");
 
-			assert.ok(oModel.oRequestQueue[oContext.getPath().substr(1)], "queue check");
+			assert.ok(oModel.oRequestQueue[oContext.getPath().substring(1)], "queue check");
 			assert.ok(oModel.mContexts[oContext.getPath()], "context check");
-			assert.equal(oModel.oData[oContext.getPath().substr(1)].CategoryName, "Food", "data check");
+			assert.equal(oModel.oData[oContext.getPath().substring(1)].CategoryName, "Food", "data check");
 			oModel.deleteCreatedEntry(oContext);
-			assert.equal(oModel.oRequestQueue[oContext.getPath().substr(1)], undefined, "queue check");
-			assert.equal(oModel.oData[oContext.getPath().substr(1)], undefined, "data check");
+			assert.equal(oModel.oRequestQueue[oContext.getPath().substring(1)], undefined, "queue check");
+			assert.equal(oModel.oData[oContext.getPath().substring(1)], undefined, "data check");
 			assert.equal(oModel.mContexts[oContext.getPath()], undefined, "context check");
 
 			// check default values

--- a/src/sap.ui.core/test/sap/ui/core/qunit/odata/data/ODataMessagesFakeService.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/odata/data/ODataMessagesFakeService.js
@@ -324,7 +324,7 @@ var mPredefinedServiceResponses = {
 				default:
 					if (sUrl.startsWith(mServiceData["serviceUrl"])) {
 						// This one's for us...
-						sRandomServiceUrl = sUrl.substr(mServiceData["serviceUrl"].length);
+						sRandomServiceUrl = sUrl.substring(mServiceData["serviceUrl"].length);
 					} else {
 						/* eslint-disable no-debugger */
 						debugger;

--- a/src/sap.ui.core/test/sap/ui/core/qunit/odata/data/ODataModelFakeService.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/odata/data/ODataModelFakeService.js
@@ -604,7 +604,7 @@ sap.ui.define([], function() {
       }
 
       // Look up response
-      respond.apply(this, getResponse(request.method, request.url.substr(baseURL.length), request.requestHeaders));
+      respond.apply(this, getResponse(request.method, request.url.substring(baseURL.length), request.requestHeaders));
     };
   };
 
@@ -618,7 +618,7 @@ sap.ui.define([], function() {
     for (var i = 1; i < parts.length - 1; i++) {
       part = parts[i];
       if (part.indexOf("\r\nContent-Type: multipart/mixed") == 0) {
-        nestedRequests = parseBatchRequest("\r\n" + part.substr(part.indexOf("--")));
+        nestedRequests = parseBatchRequest("\r\n" + part.substring(part.indexOf("--")));
         requests.push(nestedRequests);
       } else {
         var request = {};

--- a/src/sap.ui.core/test/sap/ui/core/qunit/odata/v2/ODataV2Model.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/odata/v2/ODataV2Model.qunit.js
@@ -3372,10 +3372,10 @@ sap.ui.define([
 			assert.equal(oEntry.CategoryID, 99, "category ID check");
 			assert.equal(oEntry.Description, "Food Desc", "category ID check");
 			assert.ok(oModel.mContexts[oContext.getPath()], "context check");
-			assert.equal(oModel.oData[oContext.getPath().substr(1)].CategoryName, "Food", "data check");
+			assert.equal(oModel.oData[oContext.getPath().substring(1)].CategoryName, "Food", "data check");
 
 			oContext.delete();
-			assert.equal(oModel.oData[oContext.getPath().substr(1)], undefined, "data check");
+			assert.equal(oModel.oData[oContext.getPath().substring(1)], undefined, "data check");
 			assert.equal(oModel.mContexts[oContext.getPath()], undefined, "context check");
 
 			// check default values
@@ -3459,7 +3459,7 @@ sap.ui.define([
 			}
 		};
 		each(aRequestEvents, function(i, sEvent) {
-			oInfo[sEvent.charAt(0).toLowerCase() + sEvent.substr(1)] = 0;
+			oInfo[sEvent.charAt(0).toLowerCase() + sEvent.substring(1)] = 0;
 			oModel["attach" + sEvent](fnHandler);
 		});
 		return fnHandler;

--- a/src/sap.ui.core/test/sap/ui/core/qunit/odata/v2/data/ODataTreeBindingFakeService.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/odata/v2/data/ODataTreeBindingFakeService.js
@@ -595,7 +595,7 @@ sap.ui.define("ODataTreeBindingFakeService", ["sap/base/Log"], function(Log) {
 				}
 
 				// Look up response
-				respond.apply(this, getResponse(request.method, request.url.substr(baseURL.length), request.requestHeaders));
+				respond.apply(this, getResponse(request.method, request.url.substring(baseURL.length), request.requestHeaders));
 			};
 		};
 
@@ -609,7 +609,7 @@ sap.ui.define("ODataTreeBindingFakeService", ["sap/base/Log"], function(Log) {
 			for (var i = 1; i < parts.length - 1; i++) {
 				part = parts[i];
 				if (part.indexOf("\r\nContent-Type: multipart/mixed") == 0) {
-					nestedRequests = parseBatchRequest("\r\n" + part.substr(part.indexOf("--")));
+					nestedRequests = parseBatchRequest("\r\n" + part.substring(part.indexOf("--")));
 					requests.push(nestedRequests);
 				} else {
 					var request = {};

--- a/src/sap.ui.core/test/sap/ui/core/qunit/thirdparty/qunit-2.18.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/thirdparty/qunit-2.18.js
@@ -4976,7 +4976,7 @@
                 }
 
                 if (matchesIndex === matchesBest.length) {
-                  highlighted += char + hClose + target.substr(i + 1);
+                  highlighted += char + hClose + target.substring(i + 1);
                   break;
                 }
               } else {

--- a/src/sap.ui.core/test/sap/ui/core/qunit/thirdparty/sinon-14.0.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/thirdparty/sinon-14.0.js
@@ -12238,7 +12238,7 @@
 						if (array) {
 							str = str.split('\n').map(function(line) {
 								return '  ' + line;
-							}).join('\n').substr(2);
+							}).join('\n').substring(2);
 						} else {
 							str = '\n' + str.split('\n').map(function(line) {
 								return '   ' + line;
@@ -12255,7 +12255,7 @@
 				}
 				name = JSON.stringify('' + key);
 				if (name.match(/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/)) {
-					name = name.substr(1, name.length - 2);
+					name = name.substring(1, name.length - 2);
 					name = ctx.stylize(name, 'name');
 				} else {
 					name = name.replace(/'/g, "\\'")
@@ -13046,7 +13046,7 @@
 						var fileName = data[0].replace(/\\\\/g, '\\');
 
 						if (/^".*"$/.test(fileName)) {
-							fileName = fileName.substr(1, fileName.length - 2);
+							fileName = fileName.substring(1, fileName.length - 2);
 						}
 
 						index[keyPrefix + 'FileName'] = fileName;
@@ -13220,7 +13220,7 @@
 					for (var j = 0; j < hunk.lines.length; j++) {
 						var line = hunk.lines[j],
 							operation = line.length > 0 ? line[0] : ' ',
-							content = line.length > 0 ? line.substr(1) : line;
+							content = line.length > 0 ? line.substring(1) : line;
 
 						if (operation === ' ' || operation === '-') {
 							// Context sanity check
@@ -13275,7 +13275,7 @@
 					for (var j = 0; j < _hunk.lines.length; j++) {
 						var line = _hunk.lines[j],
 							operation = line.length > 0 ? line[0] : ' ',
-							content = line.length > 0 ? line.substr(1) : line,
+							content = line.length > 0 ? line.substring(1) : line,
 							delimiter = _hunk.linedelimiters[j];
 
 						if (operation === ' ') {
@@ -13849,7 +13849,7 @@
 						}
 					}
 
-					if (match.substr(1) === change.substr(1)) {
+					if (match.substring(1) === change.substring(1)) {
 						changes.push(change);
 						state.index++;
 					} else {
@@ -13883,7 +13883,7 @@
 
 			function skipRemoveSuperset(state, removeChanges, delta) {
 				for (var i = 0; i < delta; i++) {
-					var changeContent = removeChanges[removeChanges.length - delta + i].substr(1);
+					var changeContent = removeChanges[removeChanges.length - delta + i].substring(1);
 
 					if (state.lines[state.index + i] !== ' ' + changeContent) {
 						return false;
@@ -16738,7 +16738,7 @@
 
 			// Match any characters still remaining.
 			if (index < str.length) {
-				path += str.substr(index)
+				path += str.substring(index)
 			}
 
 			// If the path exists, push it onto the end.

--- a/src/sap.ui.core/test/sap/ui/core/qunit/ui5classes/DataType.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/ui5classes/DataType.qunit.js
@@ -972,7 +972,7 @@ sap.ui.define([
 		assert.equal(_uri.isValid("http://www.sap.com"), true, "the given url should be valid for the URI type");
 		assert.equal(_uri.normalize("http://www.sap.com"), "http://www.sap.com", "the url must not be normalized");
 		_uri.setNormalizer(function (sValue) {
-			return "/proxy/http/" + sValue.substr(7);
+			return "/proxy/http/" + sValue.substring(7);
 		});
 		assert.ok(!!_uri._fnNormalizer, "normalizer should be set");
 		assert.equal(_uri.normalize("http://www.sap.com"), "/proxy/http/www.sap.com", "the url should be normalized");

--- a/src/sap.ui.core/test/sap/ui/core/qunit/xml/XMLListBinding.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/xml/XMLListBinding.qunit.js
@@ -469,8 +469,8 @@ sap.ui.define([
 
 		var oSorter = new Sorter("@firstName", false);
 		oSorter.fnCompare = function(a, b) {
-			a = a.substr(1);
-			b = b.substr(1);
+			a = a.substring(1);
+			b = b.substring(1);
 			if (a < b) {
 				return -1;
 			}

--- a/src/sap.ui.core/test/sap/ui/qunit/TestRunner.js
+++ b/src/sap.ui.core/test/sap/ui/qunit/TestRunner.js
@@ -16,7 +16,7 @@
 		// the context path - this section makes sure to remove the duplicate
 		// test-resources segments in the path
 		if (sTestPage.indexOf("/test-resources/test-resources") === 0 || sTestPage.indexOf("/test-resources/resources") === 0) {
-			sTestPage = sTestPage.substr("/test-resources".length);
+			sTestPage = sTestPage.substring("/test-resources".length);
 		}
 		this.aPages.push(sTestPage);
 	};

--- a/src/sap.ui.core/test/testsuite/js/testframe.js
+++ b/src/sap.ui.core/test/testsuite/js/testframe.js
@@ -57,7 +57,7 @@ sap.ui.define([
 			var loc = top.location.pathname;
 			var index = loc.indexOf("testframe.html");
 			if (index > -1) { // try to build an absolute URL, so settings changes do not lead to a 404 on the initial screen
-				sURL = loc.substr(0, index) + "welcome.html";
+				sURL = loc.substring(0, index) + "welcome.html";
 			}
 			testfwk.setContentURL(sURL, null); // no theme constraints
 		}


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated and [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) is recommended.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#string

From [WDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr):
> Note: substr() is not part of the main ECMAScript specification — it's defined in [Annex B: Additional ECMAScript Features for Web Browsers](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) and [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) methods instead to make their code maximally cross-platform friendly. The [String.prototype.substring() page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr) has some comparisons between the three methods.