### PR TITLE
sap.ui.ux3: Replace deprecated JS API substr

### DIFF
--- a/src/sap.ui.ux3/src/sap/ui/ux3/Shell.js
+++ b/src/sap.ui.ux3/src/sap/ui/ux3/Shell.js
@@ -868,7 +868,7 @@ sap.ui.define([
 	Shell._updateToolIcon = function(oDomRef) {
 		if (oDomRef && oDomRef.firstChild) {
 			var $elem = jQuery(oDomRef);
-			var toolId = oDomRef.id.substr(oDomRef.id.indexOf(Shell.TOOL_PREFIX) + 6);
+			var toolId = oDomRef.id.substring(oDomRef.id.indexOf(Shell.TOOL_PREFIX) + 6);
 			var tool = sap.ui.getCore().byId(toolId);
 			var icon;
 			if ($elem.is(".sapUiUx3ShellToolSelected")) {
@@ -1058,7 +1058,7 @@ sap.ui.define([
 
 		// identify new tool
 		var tool;
-		var toolId = sId.substr(sId.indexOf(Shell.TOOL_PREFIX) + 6);
+		var toolId = sId.substring(sId.indexOf(Shell.TOOL_PREFIX) + 6);
 		if (toolId == (this.getId() + "-searchTool")) {
 			tool = this._getSearchTool();
 		} else if (toolId == (this.getId() + "-feederTool")) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated and [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) is recommended.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#string

From [WDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr):
> Note: substr() is not part of the main ECMAScript specification — it's defined in [Annex B: Additional ECMAScript Features for Web Browsers](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) and [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) methods instead to make their code maximally cross-platform friendly. The [String.prototype.substring() page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr) has some comparisons between the three methods.