### PR TITLE
sap.ui.commons: Replace deprecated JS API substr

### DIFF
--- a/src/sap.ui.commons/src/sap/ui/commons/Carousel.js
+++ b/src/sap.ui.commons/src/sap/ui/commons/Carousel.js
@@ -690,7 +690,7 @@ sap.ui.define([
 			var childWidth, childHeight;
 			try {
 				childWidth = aContent[i].getWidth();
-				if (childWidth.substr( -1) == "%") {
+				if (childWidth.substring( -1) == "%") {
 					childWidth = this.getDefaultItemWidth();
 				}
 			} catch (e) {
@@ -698,7 +698,7 @@ sap.ui.define([
 			}
 			try {
 				childHeight = aContent[i].getHeight();
-				if (childHeight.substr( -1) == "%") {
+				if (childHeight.substring( -1) == "%") {
 					childHeight = this.getDefaultItemHeight();
 				}
 			} catch (e) {

--- a/src/sap.ui.commons/src/sap/ui/commons/DropdownBox.js
+++ b/src/sap.ui.commons/src/sap/ui/commons/DropdownBox.js
@@ -191,7 +191,7 @@ sap.ui.define([
 				// history might be not up do date -> rebuild; suppose the text before cursor is just typed in to use filter
 				var $Ref = jQuery(this.getInputDomRef());
 				var iCursorPos = $Ref.cursorPos();
-				this._doTypeAhead($Ref.val().substr(0, iCursorPos), "");
+				this._doTypeAhead($Ref.val().substring(0, iCursorPos), "");
 			}
 			return this;
 		} else {
@@ -210,7 +210,7 @@ sap.ui.define([
 				// history might be not up do date -> rebuild; suppose the text before cursor is just typed in to use filter
 				var $Ref = jQuery(this.getInputDomRef());
 				var iCursorPos = $Ref.cursorPos();
-				this._doTypeAhead($Ref.val().substr(0, iCursorPos), "");
+				this._doTypeAhead($Ref.val().substring(0, iCursorPos), "");
 			}
 			return this;
 		} else {
@@ -253,7 +253,7 @@ sap.ui.define([
 				// history might be not up do date -> rebuild; suppose the text before cursor is just typed in to use filter
 				var $Ref = jQuery(this.getInputDomRef());
 				var iCursorPos = $Ref.cursorPos();
-				this._doTypeAhead($Ref.val().substr(0, iCursorPos), "");
+				this._doTypeAhead($Ref.val().substring(0, iCursorPos), "");
 			}
 			return oItem;
 		} else {
@@ -330,7 +330,7 @@ sap.ui.define([
 			// history might be not up do date -> rebuild; suppose the text before cursor is just typed in to use filter
 			var $Ref = jQuery(this.getInputDomRef());
 			var iCursorPos = $Ref.cursorPos();
-			this._doTypeAhead($Ref.val().substr(0, iCursorPos), "");
+			this._doTypeAhead($Ref.val().substring(0, iCursorPos), "");
 		}
 
 	};
@@ -424,7 +424,7 @@ sap.ui.define([
 			// history might be not up do date -> rebuild; suppose the text before cursor is just typed in to use filter
 			var $Ref = jQuery(this.getInputDomRef());
 			var iCursorPos = $Ref.cursorPos();
-			this._doTypeAhead($Ref.val().substr(0, iCursorPos), "");
+			this._doTypeAhead($Ref.val().substring(0, iCursorPos), "");
 		}
 
 		ComboBox.prototype._handleItemsChanged.apply(this, arguments);
@@ -624,7 +624,7 @@ sap.ui.define([
 				iCursorPos++;
 			} // 'normalize' cursor position for upcoming handling...
 			this._iCursorPosBeforeBackspace = null; // forget being called by backspace handling
-			bValid = this._doTypeAhead($Ref.val().substr(0, iCursorPos - 1), "");
+			bValid = this._doTypeAhead($Ref.val().substring(0, iCursorPos - 1), "");
 		} else if (!(bValid = this._doTypeAhead("", $Ref.val()))) {
 			// this must happen to check for valid entry after paste and if required -> rollback
 			$Ref.val(this._oValueBeforePaste);
@@ -743,9 +743,9 @@ sap.ui.define([
 			this.noTypeAheadByOpen = undefined;
 		}
 		if (iKC === KeyCodes.BACKSPACE) {// only happens in FF or other non-IE-browsers. Webkit or IE does not support BACKSPACE in keypress, but in Webkit it's called from keydown
-			this._doTypeAhead(sVal.substr(0, iCursorPos - 1), "");
+			this._doTypeAhead(sVal.substring(0, iCursorPos - 1), "");
 		} else {
-			this._doTypeAhead(sVal.substr(0, iCursorPos), oNewChar);
+			this._doTypeAhead(sVal.substring(0, iCursorPos), oNewChar);
 		}
 
 		if (sVal != $Ref.val()) {
@@ -880,7 +880,7 @@ sap.ui.define([
 			sVal = $Ref.val();
 		if (sVal.length > 0 && iNewCursor > 0) {
 			// if nothing is selected do not initialate value
-			this._doTypeAhead(sVal.substr(0,iNewCursor), "");
+			this._doTypeAhead(sVal.substring(0,iNewCursor), "");
 			if (!this.oPopup || !this.oPopup.isOpen()) {
 				// as popup is not open restore listbox item like on popup close
 				this._cleanupClose(this._getListBox());
@@ -949,7 +949,7 @@ sap.ui.define([
 		var $Ref = jQuery(this.getInputDomRef()),
 			iNewCursor = $Ref.cursorPos() + (iMoveBy || 0),
 			sVal = $Ref.val();
-		this._doTypeAhead(sVal.substr(0,iNewCursor), "");
+		this._doTypeAhead(sVal.substring(0,iNewCursor), "");
 		if (!this.oPopup || !this.oPopup.isOpen()) {
 			// as popup is not open restore listbox item like on popup close
 			this._cleanupClose(this._getListBox());

--- a/src/sap.ui.commons/src/sap/ui/commons/ListBoxRenderer.js
+++ b/src/sap.ui.commons/src/sap/ui/commons/ListBoxRenderer.js
@@ -271,7 +271,7 @@ sap.ui.define(['sap/ui/thirdparty/jquery', 'sap/base/security/encodeXML', 'sap/u
 	ListBoxRenderer.fixWidth = function(sCssWidth) {
 		if (ListBoxRenderer.borderWidths > 0) {
 			if (/px$/i.test(sCssWidth)) {
-				var iWidth = parseInt(sCssWidth.substr(0, sCssWidth.length - 2));
+				var iWidth = parseInt(sCssWidth.substring(0, sCssWidth.length - 2));
 				var newWidth = iWidth - ListBoxRenderer.borderWidths;
 				if (newWidth >= 0) {
 					return newWidth + "px";

--- a/src/sap.ui.commons/src/sap/ui/commons/RoadMapRenderer.js
+++ b/src/sap.ui.commons/src/sap/ui/commons/RoadMapRenderer.js
@@ -486,7 +486,7 @@ sap.ui.define(['sap/ui/thirdparty/jquery', 'sap/ui/Device', 'sap/base/security/e
 		var bIsShortened = false;
 		while (sText.length > 0 && jClone.height() > jStepLabel.height()) {
 			//TODO: Do we need special RTL handling here?
-			sText = sText.substr(0, sText.length - 1);
+			sText = sText.substring(0, sText.length - 1);
 			jClone.html(encodeXML(sText + "..."));
 			bIsShortened = true;
 		}

--- a/src/sap.ui.commons/test/sap/ui/commons/samples/layout/AbsoluteLayout_Basic.html
+++ b/src/sap.ui.commons/test/sap/ui/commons/samples/layout/AbsoluteLayout_Basic.html
@@ -31,7 +31,7 @@
 		<script>
 		var getUrlParameter = function(name) {
 			var url = document.URL;
-			var paramStr = url.substr((url.indexOf("?")+1));
+			var paramStr = url.substring((url.indexOf("?")+1));
 			var params = paramStr.split("&");
 			for(index in params){
 				var param = params[index];


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated and [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) is recommended.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#string

From [WDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr):
> Note: substr() is not part of the main ECMAScript specification — it's defined in [Annex B: Additional ECMAScript Features for Web Browsers](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) and [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) methods instead to make their code maximally cross-platform friendly. The [String.prototype.substring() page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr) has some comparisons between the three methods.