### PR TITLE
sap.ui.mdc: Replace deprecated JS API substr

### DIFF
--- a/src/sap.ui.mdc/src/sap/ui/mdc/field/FieldBase.js
+++ b/src/sap.ui.mdc/src/sap/ui/mdc/field/FieldBase.js
@@ -3247,7 +3247,7 @@ sap.ui.define([
 
 		if (sOutput) { // only if something returned
 			// while typing the types user input should not be changed. As the output might have a diffrent upper/lower case, replace the beginning with the user input.
-			sOutput = typeof sOutput === 'string' ? sFilterValue + sOutput.substr(sFilterValue.length) : sFilterValue;
+			sOutput = typeof sOutput === 'string' ? sFilterValue + sOutput.substring(sFilterValue.length) : sFilterValue;
 
 			oContent.setDOMValue(sOutput);
 			oContent.focus(); // otherwise focus stays in table in some cases

--- a/src/sap.ui.mdc/src/sap/ui/mdc/util/TypeMap.js
+++ b/src/sap.ui.mdc/src/sap/ui/mdc/util/TypeMap.js
@@ -343,7 +343,7 @@ sap.ui.define([
 
 			case BaseType.Date:
 				if (vValue.indexOf("T") >= 0) { // old variant with DateTime for DateValues
-					vValue = vValue.substr(0, vValue.indexOf("T")); // just take the date part
+					vValue = vValue.substring(0, vValue.indexOf("T")); // just take the date part
 				}
 				return DateUtil.stringToType(vValue, oTypeInstance, sDatePattern);
 

--- a/src/sap.ui.mdc/src/sap/ui/mdc/util/TypeUtil.js
+++ b/src/sap.ui.mdc/src/sap/ui/mdc/util/TypeUtil.js
@@ -197,7 +197,7 @@ sap.ui.define([
 
 				case BaseType.Date:
 					if (sValue.indexOf("T") >= 0) { // old variant with DateTime for DateValues
-						sValue = sValue.substr(0, sValue.indexOf("T")); // just take the date part
+						sValue = sValue.substring(0, sValue.indexOf("T")); // just take the date part
 					}
 					return DateUtil.stringToType(sValue, oTypeInstance, sDatePattern);
 

--- a/src/sap.ui.mdc/test/sap/ui/mdc/internal/TableWithFilterBar/controller/AuthorDetails.controller.js
+++ b/src/sap.ui.mdc/test/sap/ui/mdc/internal/TableWithFilterBar/controller/AuthorDetails.controller.js
@@ -62,8 +62,8 @@ sap.ui.define([
 								var iIndex = sKeyPath.indexOf("/");
 								if (iIndex >= 0) {
 									// TODO: how to get the object if bound to key of an object?
-									var sPropertyPath = sKeyPath.substr(iIndex + 1);
-									sKeyPath = sKeyPath.substr(0, iIndex);
+									var sPropertyPath = sKeyPath.substring(iIndex + 1);
+									sKeyPath = sKeyPath.substring(0, iIndex);
 									var oKey = {};
 									oKey[sPropertyPath] = oCondition.values[0];
 									oItem[sKeyPath] = oKey;

--- a/src/sap.ui.mdc/test/sap/ui/mdc/sample/field/Test.controller.js
+++ b/src/sap.ui.mdc/test/sap/ui/mdc/sample/field/Test.controller.js
@@ -258,7 +258,7 @@ sap.ui.define([
 		handleIconPress: function(oEvent) {
 			var oButton = oEvent.oSource;
 			var oValueHelp = oButton.getParent().getParent();
-			var vKey = oButton.getIcon().substr(11);
+			var vKey = oButton.getIcon().substring(11);
 			oValueHelp.fireSelectEvent([Condition.createCondition(OperatorName.EQ, [vKey])]);
 		},
 
@@ -273,7 +273,7 @@ sap.ui.define([
 			}
 			for (var i = 0; i < aButtons.length; i++) {
 				var oButton = aButtons[i];
-				if (oButton.getIcon().substr(11) == vKey) {
+				if (oButton.getIcon().substring(11) == vKey) {
 					oButton.setType(ButtonType.Emphasized);
 				} else {
 					oButton.setType(ButtonType.Default);

--- a/src/sap.ui.mdc/test/sap/ui/mdc/sample/field/ValueHelp.delegate.js
+++ b/src/sap.ui.mdc/test/sap/ui/mdc/sample/field/ValueHelp.delegate.js
@@ -42,8 +42,8 @@ sap.ui.define([
 					for (var sId in aTables) {
 						var iIndex = sContentId.indexOf(sId);
 						if (iIndex >= 0) {
-							var sView = sContentId.substr(0, iIndex);
-							var sTableId = sView + (aTables[sContentId.substr(iIndex)]);
+							var sView = sContentId.substring(0, iIndex);
+							var sTableId = sView + (aTables[sContentId.substring(iIndex)]);
 							var oTable = Element.getElementById(sTableId);
 							if (oTable) {
 								oContent.setTable(oTable);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated and [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) is recommended.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#string

From [WDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr):
> Note: substr() is not part of the main ECMAScript specification — it's defined in [Annex B: Additional ECMAScript Features for Web Browsers](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) and [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) methods instead to make their code maximally cross-platform friendly. The [String.prototype.substring() page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr) has some comparisons between the three methods.