### PR TITLE
sap.ui.rta: Replace deprecated JS API substr

### DIFF
--- a/src/sap.ui.rta/src/sap/ui/rta/appVariant/AppVariantUtils.js
+++ b/src/sap.ui.rta/src/sap/ui/rta/appVariant/AppVariantUtils.js
@@ -62,7 +62,7 @@ sap.ui.define([
 				sTrimmedId = sTrimmedId.substring(0, sTrimmedId.length - sGuidLength);
 			} else {
 				// If the length of GUID is longer than the length of rest of the id(without GUID), then just trim the GUID so that the whole id length remains 56 characters
-				return sId.substr(0, HANA_CLOUD_ID_LENGTH);
+				return sId.substring(0, HANA_CLOUD_ID_LENGTH);
 			}
 
 			// After adjusting the id, if the last character of string has period '.', just append the guid string otherwise append period '.' in between

--- a/src/sap.ui.rta/src/sap/ui/rta/appVariant/manageApps/webapp/controller/ManageApps.controller.js
+++ b/src/sap.ui.rta/src/sap/ui/rta/appVariant/manageApps/webapp/controller/ManageApps.controller.js
@@ -222,7 +222,7 @@ sap.ui.define([
 				oItem = oItem.getParent();
 			}
 
-			sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
+			sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" > "));
 
 			if (!oI18n) {
 				this._createResourceBundle();

--- a/src/sap.ui.rta/src/sap/ui/rta/command/ControlVariantConfigure.js
+++ b/src/sap.ui.rta/src/sap/ui/rta/command/ControlVariantConfigure.js
@@ -129,7 +129,7 @@ sap.ui.define([
 				appComponent: this.oAppComponent
 			};
 			Object.keys(mChangeProperties).forEach(function(sProperty) {
-				var sOriginalProperty = `original${sProperty.charAt(0).toUpperCase()}${sProperty.substr(1)}`;
+				var sOriginalProperty = `original${sProperty.charAt(0).toUpperCase()}${sProperty.substring(1)}`;
 				if (sProperty === "visible") {
 					mPropertyBag[sProperty] = true; /* visibility of the variant always set back to true on undo */
 				} else if (mChangeProperties[sOriginalProperty]) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated and [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) is recommended.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#string

From [WDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr):
> Note: substr() is not part of the main ECMAScript specification — it's defined in [Annex B: Additional ECMAScript Features for Web Browsers](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) and [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) methods instead to make their code maximally cross-platform friendly. The [String.prototype.substring() page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr) has some comparisons between the three methods.