### PR TITLE
sap.ui.table: Replace deprecated JS API substr

### DIFF
--- a/src/sap.ui.table/src/sap/ui/table/Column.js
+++ b/src/sap.ui.table/src/sap/ui/table/Column.js
@@ -832,22 +832,22 @@ sap.ui.define([
 				// determine the filter operator depending on the
 				if (sValue.indexOf("=") === 0) {
 					sOperator = FilterOperator.EQ;
-					sParsedValue = sValue.substr(1);
+					sParsedValue = sValue.substring(1);
 				} else if (sValue.indexOf("!=") === 0) {
 					sOperator = FilterOperator.NE;
-					sParsedValue = sValue.substr(2);
+					sParsedValue = sValue.substring(2);
 				} else if (sValue.indexOf("<=") === 0) {
 					sOperator = FilterOperator.LE;
-					sParsedValue = sValue.substr(2);
+					sParsedValue = sValue.substring(2);
 				} else if (sValue.indexOf("<") === 0) {
 					sOperator = FilterOperator.LT;
-					sParsedValue = sValue.substr(1);
+					sParsedValue = sValue.substring(1);
 				} else if (sValue.indexOf(">=") === 0) {
 					sOperator = FilterOperator.GE;
-					sParsedValue = sValue.substr(2);
+					sParsedValue = sValue.substring(2);
 				} else if (sValue.indexOf(">") === 0) {
 					sOperator = FilterOperator.GT;
-					sParsedValue = sValue.substr(1);
+					sParsedValue = sValue.substring(1);
 				} else if (aBetween) {
 					if (aBetween[1] && aBetween[2]) {
 						sOperator = FilterOperator.BT;
@@ -862,13 +862,13 @@ sap.ui.define([
 					}
 				} else if (bIsString && sValue.indexOf("*") === 0 && sValue.lastIndexOf("*") === sValue.length - 1) {
 					sOperator = FilterOperator.Contains;
-					sParsedValue = sValue.substr(1, sValue.length - 2);
+					sParsedValue = sValue.substring(1, sValue.length - 2);
 				} else if (bIsString && sValue.indexOf("*") === 0) {
 					sOperator = FilterOperator.EndsWith;
-					sParsedValue = sValue.substr(1);
+					sParsedValue = sValue.substring(1);
 				} else if (bIsString && sValue.lastIndexOf("*") === sValue.length - 1) {
 					sOperator = FilterOperator.StartsWith;
-					sParsedValue = sValue.substr(0, sValue.length - 1);
+					sParsedValue = sValue.substring(0, sValue.length - 1);
 				} else {
 					if (this.getDefaultFilterOperator()) {
 						sOperator = this.getDefaultFilterOperator();
@@ -878,7 +878,7 @@ sap.ui.define([
 						} else {
 							sOperator = FilterOperator.EQ;
 						}
-					sParsedValue = sValue.substr(0);
+					sParsedValue = sValue.substring(0);
 				}
 				if (!sSecondaryParsedValue) {
 					oFilter = new Filter(sPath, sOperator, this._parseFilterValue(sParsedValue));

--- a/src/sap.ui.table/src/sap/ui/table/Table.js
+++ b/src/sap.ui.table/src/sap/ui/table/Table.js
@@ -3906,7 +3906,7 @@ sap.ui.define([
 			const sPath = mSettings.rows.path;
 			const iSeparatorPos = sPath.indexOf(">");
 			if (iSeparatorPos > 0) {
-				sModelName = sPath.substr(0, iSeparatorPos);
+				sModelName = sPath.substring(0, iSeparatorPos);
 			}
 		}
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated and [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) is recommended.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#string

From [WDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr):
> Note: substr() is not part of the main ECMAScript specification — it's defined in [Annex B: Additional ECMAScript Features for Web Browsers](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) and [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) methods instead to make their code maximally cross-platform friendly. The [String.prototype.substring() page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr) has some comparisons between the three methods.