### PR TITLE
sap.ui.testrecorder: Replace deprecated JS API substr

### DIFF
--- a/src/sap.ui.testrecorder/test/sap/ui/testrecorder/qunit/inspector/ControlInspectorRepo.qunit.js
+++ b/src/sap.ui.testrecorder/test/sap/ui/testrecorder/qunit/inspector/ControlInspectorRepo.qunit.js
@@ -111,7 +111,7 @@ sap.ui.define([
 
 	QUnit.test("Should get all data of type", function (assert) {
 		["request", "selector", "snippet"].forEach(function (sType) {
-			var aResult = ControlInspectorRepo["get" + sType.charAt(0).toUpperCase() + sType.substr(1) + "s"]();
+			var aResult = ControlInspectorRepo["get" + sType.charAt(0).toUpperCase() + sType.substring(1) + "s"]();
 			assert.deepEqual(aResult[0], this.testData[0][sType]);
 			assert.deepEqual(aResult[1], this.testData[1][sType]);
 		}.bind(this));


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated and [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) is recommended.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#string

From [WDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr):
> Note: substr() is not part of the main ECMAScript specification — it's defined in [Annex B: Additional ECMAScript Features for Web Browsers](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) and [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) methods instead to make their code maximally cross-platform friendly. The [String.prototype.substring() page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr) has some comparisons between the three methods.