### PR TITLE
sap.ui.layout: Replace deprecated JS API substr

### DIFF
--- a/src/sap.ui.layout/src/sap/ui/layout/AssociativeSplitter.js
+++ b/src/sap.ui.layout/src/sap/ui/layout/AssociativeSplitter.js
@@ -106,7 +106,7 @@ sap.ui.define([
 			return;
 		}
 
-		iBar = parseInt(this._oLastDOMclicked.id.substr((sId + "-splitbar-").length));
+		iBar = parseInt(this._oLastDOMclicked.id.substring((sId + "-splitbar-").length));
 		oContentArea = this._getContentAreas()[iBar];
 		oContentArea._currentPosition = this._calculatedSizes[iBar];
 		oContentArea._lastPosition = oContentArea._lastPosition || oContentArea._currentPosition;

--- a/src/sap.ui.layout/src/sap/ui/layout/GridData.js
+++ b/src/sap.ui.layout/src/sap/ui/layout/GridData.js
@@ -271,8 +271,8 @@ sap.ui.define(['sap/ui/core/LayoutData', './library', "sap/base/Log"],
 				var span = aSpan[0];
 				if (span) {
 					span = span.toUpperCase();
-					if (span.substr(0,2) === "XL") {
-						return parseInt(span.substr(2));
+					if (span.substring(0,2) === "XL") {
+						return parseInt(span.substring(2));
 					}
 				}
 			}
@@ -300,8 +300,8 @@ sap.ui.define(['sap/ui/core/LayoutData', './library', "sap/base/Log"],
 				var span = aSpan[0];
 				if (span) {
 					span = span.toUpperCase();
-					if (span.substr(0,1) === "L") {
-						return parseInt(span.substr(1));
+					if (span.substring(0,1) === "L") {
+						return parseInt(span.substring(1));
 					}
 				}
 			}
@@ -327,8 +327,8 @@ sap.ui.define(['sap/ui/core/LayoutData', './library', "sap/base/Log"],
 				var span = aSpan[0];
 				if (span) {
 					span = span.toUpperCase();
-					if (span.substr(0,1) === "M") {
-						return parseInt(span.substr(1));
+					if (span.substring(0,1) === "M") {
+						return parseInt(span.substring(1));
 					}
 				}
 			}
@@ -355,8 +355,8 @@ sap.ui.define(['sap/ui/core/LayoutData', './library', "sap/base/Log"],
 				var span = aSpan[0];
 				if (span) {
 					span = span.toUpperCase();
-					if (span.substr(0,1) === "S") {
-						return parseInt(span.substr(1));
+					if (span.substring(0,1) === "S") {
+						return parseInt(span.substring(1));
 					}
 				}
 			}

--- a/src/sap.ui.layout/src/sap/ui/layout/GridRenderer.js
+++ b/src/sap.ui.layout/src/sap/ui/layout/GridRenderer.js
@@ -186,8 +186,8 @@ sap.ui.define(["sap/ui/Device", "sap/ui/layout/library"],
 							}
 						}
 
-						if (span.substr(0, 1) === "L") {
-							sSpanL = span.substr(1, 2);
+						if (span.substring(0, 1) === "L") {
+							sSpanL = span.substring(1, 2);
 						}
 
 						// Catch the Individual Spans
@@ -197,18 +197,18 @@ sap.ui.define(["sap/ui/Device", "sap/ui/layout/library"],
 						var iSpanSmall = oLay.getSpanS();
 
 						span = span.toUpperCase();
-						if ((span.substr(0, 2) === "XL") && (iSpanXLarge > 0)	&& (iSpanXLarge < 13)) {
+						if ((span.substring(0, 2) === "XL") && (iSpanXLarge > 0)	&& (iSpanXLarge < 13)) {
 							oRm.class("sapUiRespGridSpanXL" + iSpanXLarge);
 							bCellSpanXLChanged = true;
-						} else if ((span.substr(0, 1) === "L") && (iSpanLarge > 0)	&& (iSpanLarge < 13)) {
+						} else if ((span.substring(0, 1) === "L") && (iSpanLarge > 0)	&& (iSpanLarge < 13)) {
 							oRm.class("sapUiRespGridSpanL" + iSpanLarge);
 							sSpanL = iSpanLarge;
-						} else if ((span.substr(0, 1) === "M") && (iSpanMedium > 0)	&& (iSpanMedium < 13)) {
+						} else if ((span.substring(0, 1) === "M") && (iSpanMedium > 0)	&& (iSpanMedium < 13)) {
 							oRm.class("sapUiRespGridSpanM" + iSpanMedium);
-						} else if ((span.substr(0, 1) === "S") && (iSpanSmall > 0) && (iSpanSmall < 13)) {
+						} else if ((span.substring(0, 1) === "S") && (iSpanSmall > 0) && (iSpanSmall < 13)) {
 							oRm.class("sapUiRespGridSpanS" + iSpanSmall);
 						} else {
-							if ((span.substr(0, 2) !== "XL") || bDefaultSpanXLChanged || bCellSpanXLChanged){
+							if ((span.substring(0, 2) !== "XL") || bDefaultSpanXLChanged || bCellSpanXLChanged){
 								oRm.class("sapUiRespGridSpan" + span);
 							}
 						}
@@ -264,23 +264,23 @@ sap.ui.define(["sap/ui/Device", "sap/ui/layout/library"],
 						}
 						if (indent) {
 							indent = indent.toUpperCase();
-							if (indent.substr(0, 1) === "L") {
-								sIndentL = indent.substr(1, 2);
+							if (indent.substring(0, 1) === "L") {
+								sIndentL = indent.substring(1, 2);
 							}
 
 
 
-							if ((indent.substr(0, 2) === "XL") && (iIndentXLarge > 0) && (iIndentXLarge < 12)) {
+							if ((indent.substring(0, 2) === "XL") && (iIndentXLarge > 0) && (iIndentXLarge < 12)) {
 									oRm.class("sapUiRespGridIndentXL" + iIndentXLarge);
 									bDefaultIndentXLChanged = true;
-							} else if ((indent.substr(0, 1) === "L") && (iIndentLarge > 0)
+							} else if ((indent.substring(0, 1) === "L") && (iIndentLarge > 0)
 									&& (iIndentLarge < 12)) {
 								oRm.class("sapUiRespGridIndentL" + iIndentLarge);
 								sIndentL = iIndentLarge;
-							} else if ((indent.substr(0, 1) === "M")
+							} else if ((indent.substring(0, 1) === "M")
 									&& (iIndentMedium > 0) && (iIndentMedium < 12)) {
 								oRm.class("sapUiRespGridIndentM"	+ iIndentMedium);
-							} else if ((indent.substr(0, 1) === "S")
+							} else if ((indent.substring(0, 1) === "S")
 									&& (iIndentSmall > 0) && (iIndentSmall < 12)) {
 								oRm.class("sapUiRespGridIndentS" + iIndentSmall);
 							} else {
@@ -395,7 +395,7 @@ sap.ui.define(["sap/ui/Device", "sap/ui/layout/library"],
 								indent = aInitialIndent[j];
 							}
 						}
-						if (((indent.substr(0,1) !== "X") && (indent.substr(1,1) !== "0")) || ((indent.substr(0,1) == "X") && (indent.substr(2,1) !== "0"))) {
+						if (((indent.substring(0,1) !== "X") && (indent.substring(1,1) !== "0")) || ((indent.substring(0,1) == "X") && (indent.substring(2,1) !== "0"))) {
 							oRm.class("sapUiRespGridIndent" + indent.toUpperCase());
 						}
 					}

--- a/src/sap.ui.layout/src/sap/ui/layout/Splitter.js
+++ b/src/sap.ui.layout/src/sap/ui/layout/Splitter.js
@@ -434,7 +434,7 @@ sap.ui.define([
 		this._disableAutoResize(/* temporarily: */ true);
 
 		var iPos = oEvent[this._moveCord];
-		var iBar = parseInt(oBar.id.substr((sId + "-splitbar-").length));
+		var iBar = parseInt(oBar.id.substring((sId + "-splitbar-").length));
 		var $bar = jQuery(oBar);
 		var mCalcSizes = this._calculatedSizes;
 		var iBarSize = this._bHorizontal ? $bar.outerWidth() : $bar.outerHeight();
@@ -1086,7 +1086,7 @@ sap.ui.define([
 
 		var iBigStep  = 999999;
 
-		var iBar = parseInt(oEvent.target.id.substr(sBarId.length));
+		var iBar = parseInt(oEvent.target.id.substring(sBarId.length));
 		var mCalcSizes = this._calculatedSizes;
 		// TODO: These two lines are incomprehensible magic - find better solution
 		this._move.c1Size = mCalcSizes[iBar];

--- a/src/sap.ui.layout/src/sap/ui/layout/cssgrid/GridBoxLayout.js
+++ b/src/sap.ui.layout/src/sap/ui/layout/cssgrid/GridBoxLayout.js
@@ -309,9 +309,9 @@ sap.ui.define([
 				}
 
 				sSpan = sSpan.toUpperCase();
-				switch (sSpan.substr(0, 1)) {
+				switch (sSpan.substring(0, 1)) {
 					case "X":
-						if (sSpan.substr(1, 1) === "L") {
+						if (sSpan.substring(1, 1) === "L") {
 							sSpanXLargeClass = this._getBoxesPerRowClass(sSpan, 2);
 						}
 						break;
@@ -349,7 +349,7 @@ sap.ui.define([
 	 * @returns {string|undefined} The class which should be used
 	 */
 	GridBoxLayout.prototype._getBoxesPerRowClass = function (sSpan, iIndex) {
-		var iSpan = parseInt(sSpan.substr(iIndex, sSpan.length));
+		var iSpan = parseInt(sSpan.substring(iIndex, sSpan.length));
 		if (iSpan && iSpan > 0 && iSpan < 13) {
 			return "sapUiLayoutCSSGridBoxLayoutSpan" + sSpan;
 		}

--- a/src/sap.ui.layout/test/sap/ui/layout/BlockLayout.html
+++ b/src/sap.ui.layout/test/sap/ui/layout/BlockLayout.html
@@ -155,7 +155,7 @@
 						var oCell1 = fnCreateCell(1),
 								oCell2 = fnCreateCell(1, "An Icon", new Icon({src: "sap-icon://arrow-right"})),
 								oCell3 = fnCreateCell(1, "Tomato Heading", [
-									new Text({text: sText.substr(0, 20)})
+									new Text({text: sText.substring(0, 20)})
 								], "Center"),
 								oCell4 = fnCreateCell(3, null, fnCreateForm(), null, new Link({text:"Test link", href:"http://www.sap.com"}));
 

--- a/src/sap.ui.layout/test/sap/ui/layout/acc/BlockLayout.js
+++ b/src/sap.ui.layout/test/sap/ui/layout/acc/BlockLayout.js
@@ -133,7 +133,7 @@ sap.ui.define([
 		var oCell1 = fnCreateCell(1),
 				oCell2 = fnCreateCell(1, "An Icon", new Icon({src: "sap-icon://arrow-right"})),
 				oCell3 = fnCreateCell(1, "Tomato Heading", [
-					new Text({text: sText.substr(0, 20)})
+					new Text({text: sText.substring(0, 20)})
 				], "Center"),
 				oCell4 = fnCreateCell(3, null, fnCreateForm());
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated and [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) is recommended.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#string

From [WDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr):
> Note: substr() is not part of the main ECMAScript specification — it's defined in [Annex B: Additional ECMAScript Features for Web Browsers](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) and [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) methods instead to make their code maximally cross-platform friendly. The [String.prototype.substring() page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr) has some comparisons between the three methods.