### PR TITLE
sap.ui.fl: Replace deprecated JS API substr

### DIFF
--- a/src/sap.ui.fl/src/sap/ui/fl/Utils.js
+++ b/src/sap.ui.fl/src/sap/ui/fl/Utils.js
@@ -607,7 +607,7 @@ sap.ui.define([
 		handleUrlParameters(sParameters, sParameterName, sParameterValue, oURLParsingService) {
 			if (Utils.hasParameterAndValue(sParameterName, sParameterValue, oURLParsingService)) {
 				if (sParameters.startsWith("?")) {
-					sParameters = sParameters.substr(1, sParameters.length);
+					sParameters = sParameters.substring(1, sParameters.length);
 				}
 				const aFilterUrl = sParameters.split("&").filter((sParameter) => {
 					return sParameter !== `${sParameterName}=${sParameterValue}`;

--- a/src/sap.ui.fl/test/sap/ui/fl/qunit/write/_internal/delegates/ODataV4ReadDelegate.qunit.js
+++ b/src/sap.ui.fl/test/sap/ui/fl/qunit/write/_internal/delegates/ODataV4ReadDelegate.qunit.js
@@ -33,13 +33,13 @@ sap.ui.define(["sap/ui/fl/write/_internal/delegates/ODataV4ReadDelegate"], funct
 								iIndex = sPart.indexOf("@");
 								if (iIndex >= 0) {
 									// has annotation?
-									sProp = sPart.substr(0, iIndex);
+									sProp = sPart.substring(0, iIndex);
 									oItem = oItem[sProp]; // e.g. property
 									if (sProp === "$Path") {
 										// resolve path
 										oItem = oTestContext.testGetObject(`/TestEntityT1/${oItem}`);
 									}
-									sPart = sPart.substr(iIndex); // annotation
+									sPart = sPart.substring(iIndex); // annotation
 									oItem &&= sPart === "@" ? oTestContext.testGetAllAnnotations(oItem) : oItem[sPart];
 								} else {
 									oItem = oItem[sPart];


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated and [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) is recommended.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#string

From [WDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr):
> Note: substr() is not part of the main ECMAScript specification — it's defined in [Annex B: Additional ECMAScript Features for Web Browsers](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) and [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) methods instead to make their code maximally cross-platform friendly. The [String.prototype.substring() page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr) has some comparisons between the three methods.