### PR TITLE
sap.m: Replace deprecated JS API substr

### DIFF
--- a/src/sap.m/src/sap/m/Button.js
+++ b/src/sap.m/src/sap/m/Button.js
@@ -398,7 +398,7 @@ sap.ui.define([
 
 		iPlusPos = vValue.indexOf("+");
 		if (iPlusPos !== -1) {
-			sInvisibleTextValue = oRb.getText("BUTTON_BADGE_MORE_THAN_ITEMS", [vValue.substr(0, iPlusPos)]);
+			sInvisibleTextValue = oRb.getText("BUTTON_BADGE_MORE_THAN_ITEMS", [vValue.substring(0, iPlusPos)]);
 		} else {
 			switch (vValue) {
 				case "":		sInvisibleTextValue = ""; break;

--- a/src/sap.m/src/sap/m/DateTimePicker.js
+++ b/src/sap.m/src/sap/m/DateTimePicker.js
@@ -937,7 +937,7 @@ sap.ui.define([
 			iSlashIndex = sPlaceholder.indexOf("/");
 
 		if (iSlashIndex > 0) {
-			return oLocaleData.getCombinedDateTimePattern(sPlaceholder.substr(0, iSlashIndex), sPlaceholder.substr(iSlashIndex + 1));
+			return oLocaleData.getCombinedDateTimePattern(sPlaceholder.substring(0, iSlashIndex), sPlaceholder.substring(iSlashIndex + 1));
 		} else {
 			return oLocaleData.getCombinedDateTimePattern(sPlaceholder, sPlaceholder);
 		}
@@ -1241,7 +1241,7 @@ sap.ui.define([
 
 		var iSlashIndex = sDisplayFormat.indexOf("/");
 		if (iSlashIndex > 0 && this._checkStyle(sDisplayFormat)) {
-			sDisplayFormat = sDisplayFormat.substr(iSlashIndex + 1);
+			sDisplayFormat = sDisplayFormat.substring(iSlashIndex + 1);
 		}
 
 		if (sDisplayFormat == DateTimeFormatStyles.Short || sDisplayFormat == DateTimeFormatStyles.Medium || sDisplayFormat == DateTimeFormatStyles.Long || sDisplayFormat == DateTimeFormatStyles.Full) {

--- a/src/sap.m/src/sap/m/FeedListItem.js
+++ b/src/sap.m/src/sap/m/FeedListItem.js
@@ -586,7 +586,7 @@ function(
 			var sCollapsedPlainText = sPlainText.substring(0, this._nMaxCollapsedLength);
 			var nLastSpace = sCollapsedPlainText.lastIndexOf(" ");
 			if (nLastSpace > 0) {
-				sCollapsedPlainText = sCollapsedPlainText.substr(0, nLastSpace);
+				sCollapsedPlainText = sCollapsedPlainText.substring(0, nLastSpace);
 			}
 			if (sPlainText.length === this._sFullText.length) {//no HTML tags detected
 				sText = sCollapsedPlainText;

--- a/src/sap.m/src/sap/m/IllustratedMessage.js
+++ b/src/sap.m/src/sap/m/IllustratedMessage.js
@@ -448,7 +448,7 @@ sap.ui.define([
 		// then try to fallback to "original" text without appended version (_v*** after the original type key)
 		// then try to fallback to "original" text from the IllustratedMessage.FALLBACK_TEXTS map
 		return oBundle.getText(sPrepend + this._sIllustrationType, undefined, true) ||
-			oBundle.getText(sPrepend + this._sIllustrationType.substr(0, this._sIllustrationType.indexOf('_v')) , undefined, true) ||
+			oBundle.getText(sPrepend + this._sIllustrationType.substring(0, this._sIllustrationType.indexOf('_v')) , undefined, true) ||
 			oBundle.getText(sPrepend + IllustratedMessage.FALLBACK_TEXTS[this._sIllustrationType], undefined, true);
 	};
 

--- a/src/sap.m/src/sap/m/IllustrationPool.js
+++ b/src/sap.m/src/sap/m/IllustrationPool.js
@@ -194,7 +194,7 @@ sap.ui.define([
 			}
 
 			// add trailing slash if necessary for more convenience
-			if (sPath.substr(sPath.length - 1) !== "/") {
+			if (sPath.substring(sPath.length - 1) !== "/") {
 				sPath += "/";
 			}
 

--- a/src/sap.m/src/sap/m/ObjectHeaderRenderer.js
+++ b/src/sap.m/src/sap/m/ObjectHeaderRenderer.js
@@ -1321,15 +1321,15 @@ sap.ui.define([
 		oRM.openEnd();
 
 		if (oOH.getTitle().length > nCutLen) {
-			sOHTitle = oOH.getTitle().substr(0, nCutLen).trim();
+			sOHTitle = oOH.getTitle().substring(0, nCutLen).trim();
 			sEllipsis = '...';
 		} else {
 			sOHTitle = oOH.getTitle();
 		}
 
 		if (bMarkers) {
-			var sOHTitleEnd = sOHTitle.substr(sOHTitle.lastIndexOf(" ") + 1);
-			var sOHTitleStart = sOHTitle.substr(0, sOHTitle.lastIndexOf(" ") + 1);
+			var sOHTitleEnd = sOHTitle.substring(sOHTitle.lastIndexOf(" ") + 1);
+			var sOHTitleStart = sOHTitle.substring(0, sOHTitle.lastIndexOf(" ") + 1);
 
 			if (sOHTitleEnd.length === 1) {
 				sOHTitleEnd = sOHTitle;

--- a/src/sap.m/src/sap/m/OverflowToolbarAssociativePopoverControls.js
+++ b/src/sap.m/src/sap/m/OverflowToolbarAssociativePopoverControls.js
@@ -326,7 +326,7 @@ sap.ui.define([
 		};
 
 		function fnCapitalize(sName) {
-			return sName.substring(0, 1).toUpperCase() + sName.substr(1);
+			return sName.substring(0, 1).toUpperCase() + sName.substring(1);
 		}
 
 		return OverflowToolbarAssociativePopoverControls;

--- a/src/sap.m/src/sap/m/P13nConditionPanel.js
+++ b/src/sap.m/src/sap/m/P13nConditionPanel.js
@@ -2754,7 +2754,7 @@ sap.ui.define([
 	 * @returns {string} the filled template text
 	 */
 	P13nConditionPanel._templateReplace = function(sTemplate, aValues) {
-		return sTemplate.replace(/\$\d/g, function(sMatch) { return aValues[parseInt(sMatch.substr(1))]; });
+		return sTemplate.replace(/\$\d/g, function(sMatch) { return aValues[parseInt(sMatch.substring(1))]; });
 	};
 
 	/**

--- a/src/sap.m/src/sap/m/PDFViewerRenderer.js
+++ b/src/sap.m/src/sap/m/PDFViewerRenderer.js
@@ -114,7 +114,7 @@ sap.ui.define(['sap/ui/Device', "sap/base/Log", "sap/base/security/URLListValida
 				var sParametrizedSource = oControl.getSource();
 				var iCrossPosition = oControl.getSource().indexOf("#");
 				if (iCrossPosition > -1) {
-					sParametrizedSource = sParametrizedSource.substr(0, iCrossPosition);
+					sParametrizedSource = sParametrizedSource.substring(0, iCrossPosition);
 				}
 				if (!(Device.browser.safari && sParametrizedSource.startsWith("blob:"))) {
 					sParametrizedSource += "#view=FitH";

--- a/src/sap.m/src/sap/m/StandardListItem.js
+++ b/src/sap.m/src/sap/m/StandardListItem.js
@@ -455,7 +455,7 @@ sap.ui.define([
 	 * @private
 	 */
 	StandardListItem.prototype._getCollapsedText = function(sText) {
-		return sText.substr(0, this._getWrapCharLimit());
+		return sText.substring(0, this._getWrapCharLimit());
 	};
 
 	StandardListItem.prototype._getWrapCharLimit = function() {

--- a/src/sap.m/src/sap/m/StepInput.js
+++ b/src/sap.m/src/sap/m/StepInput.js
@@ -1306,7 +1306,7 @@ function(
 				if (!this._bPaste) {
 					//if the characters after the decimal are more than the displayValuePrecision -> keep the current value after the decimal
 					if (iCharsAfterTheDecimalSign > iCharsSet) {
-						sValue = sCharsBeforeTheEventDecimalValue + (iCharsSet > 0 ? sDecimalSeparator + sCharsAfterTheEventDecimalValue.substr(0, iCharsSet) : '');
+						sValue = sCharsBeforeTheEventDecimalValue + (iCharsSet > 0 ? sDecimalSeparator + sCharsAfterTheEventDecimalValue.substring(0, iCharsSet) : '');
 						this._showWrongValueVisualEffect();
 					}
 

--- a/src/sap.m/src/sap/m/TabContainer.js
+++ b/src/sap.m/src/sap/m/TabContainer.js
@@ -391,7 +391,7 @@ sap.ui.define([
 					sPropertyKey = mTCItemToTSItemProperties[sPropertyKey];
 					var oTabStripItem = this._toTabStripItem(oEvent.getSource());
 					// call it directly with the setter name so overwritten functions can be called and not setProperty method directly
-					var sMethodName = "set" + sPropertyKey.substr(0,1).toUpperCase() + sPropertyKey.substr(1);
+					var sMethodName = "set" + sPropertyKey.substring(0,1).toUpperCase() + sPropertyKey.substring(1);
 					oTabStripItem && oTabStripItem[sMethodName](oEvent['mParameters'].propertyValue);
 				}
 			}.bind(this));

--- a/src/sap.m/src/sap/m/TabStrip.js
+++ b/src/sap.m/src/sap/m/TabStrip.js
@@ -976,7 +976,7 @@ function(
 			var oSelectItem = this._findSelectItemFromTabStripItem(oEvent.getSource());
 			var sPropertyKey = oEvent['mParameters'].propertyKey;
 			// call it directly with the setter name so overwritten functions can be called and not setProperty method directly
-			var sMethodName = "set" + sPropertyKey.substr(0,1).toUpperCase() + sPropertyKey.substr(1);
+			var sMethodName = "set" + sPropertyKey.substring(0,1).toUpperCase() + sPropertyKey.substring(1);
 			oSelectItem[sMethodName](oEvent['mParameters'].propertyValue);
 		};
 

--- a/src/sap.m/src/sap/m/TimePicker.js
+++ b/src/sap.m/src/sap/m/TimePicker.js
@@ -783,7 +783,7 @@ function(
 			sValue = sValue || this._$input.val();
 			sThatValue = sValue;
 			bThatValue2400 = TimePickerInternals._isHoursValue24(sThatValue, iIndexOfHH, iIndexOfH);
-			bContains24 = sValue.substr(iIndexOfH, 2) === "24";
+			bContains24 = sValue.substring(iIndexOfH, 2) === "24";
 			bEnabled2400 = this.getSupport2400() && bThatValue2400 && bContains24;
 			this._bValid = true;
 			if (sValue !== "") {

--- a/src/sap.m/src/sap/m/TimePickerClocks.js
+++ b/src/sap.m/src/sap/m/TimePickerClocks.js
@@ -405,7 +405,7 @@ sap.ui.define([
 						for (iIndex = this._clockConstraints[iActiveClock].min; iIndex <= this._clockConstraints[iActiveClock].max; iIndex++) {
 							if (iIndex % this._clockConstraints[iActiveClock].step === 0) {
 								sIndex = iIndex.toString();
-								if (sBuffer === sIndex.substr(0, sBuffer.length) || iBuffer === iIndex) {
+								if (sBuffer === sIndex.substring(0, sBuffer.length) || iBuffer === iIndex) {
 									iMatching++;
 									iValueMatching = iMatching === 1 ? iIndex : -1;
 									if (iBuffer === iIndex) {

--- a/src/sap.m/src/sap/m/TimePickerInternals.js
+++ b/src/sap.m/src/sap/m/TimePickerInternals.js
@@ -523,7 +523,7 @@ sap.ui.define([
 				iSubStringIndex = iIndexOfH;
 			}
 
-			var sValueWithoutHours = sValue.substr(0, iSubStringIndex) + sValue.substr(iSubStringIndex + iHoursDigits);
+			var sValueWithoutHours = sValue.substring(0, iSubStringIndex) + sValue.substring(iSubStringIndex + iHoursDigits);
 
 			if (oSignificantNumbers.test(sValueWithoutHours)) {
 				return sValue;
@@ -531,7 +531,7 @@ sap.ui.define([
 
 			sValue = sValue.replace(/[0-9]/g, "0");
 
-			return sValue.substr(0, iSubStringIndex) + "24" + sValue.substr(iSubStringIndex + iHoursDigits);
+			return sValue.substring(0, iSubStringIndex) + "24" + sValue.substring(iSubStringIndex + iHoursDigits);
 		};
 
 		/**
@@ -556,7 +556,7 @@ sap.ui.define([
 				iSubStringIndex = iIndexOfH;
 			}
 
-			return sValue.substr(0, iSubStringIndex) + strRepeat(0, iHoursDigits) + sValue.substr(iSubStringIndex + 2);
+			return sValue.substring(0, iSubStringIndex) + strRepeat(0, iHoursDigits) + sValue.substring(iSubStringIndex + 2);
 		};
 
 
@@ -575,7 +575,7 @@ sap.ui.define([
 				iSubStringIndex = iIndexOfH;
 			}
 
-			return sValue.substr(iSubStringIndex, 2) === "24";
+			return sValue.substring(iSubStringIndex, 2) === "24";
 		};
 
 		/**

--- a/src/sap.m/src/sap/m/TimePickerSliders.js
+++ b/src/sap.m/src/sap/m/TimePickerSliders.js
@@ -1108,7 +1108,7 @@ sap.ui.define([
 				iSubStringIndex = iIndexOfH;
 			}
 
-			return sValue.substr(0, iSubStringIndex) + "24" + sValue.substr(iSubStringIndex + iHoursDigits);
+			return sValue.substring(0, iSubStringIndex) + "24" + sValue.substring(iSubStringIndex + iHoursDigits);
 		};
 
 		/**
@@ -1133,7 +1133,7 @@ sap.ui.define([
 				iSubStringIndex = iIndexOfH;
 			}
 
-			return sValue.substr(0, iSubStringIndex) + strRepeat(0, iHoursDigits) + sValue.substr(iSubStringIndex + 2);
+			return sValue.substring(0, iSubStringIndex) + strRepeat(0, iHoursDigits) + sValue.substring(iSubStringIndex + 2);
 		};
 
 
@@ -1152,7 +1152,7 @@ sap.ui.define([
 				iSubStringIndex = iIndexOfH;
 			}
 
-			return sValue.substr(iSubStringIndex, 2) === "24";
+			return sValue.substring(iSubStringIndex, 2) === "24";
 		};
 
 		function strRepeat(sStr, iCount) {

--- a/src/sap.m/src/sap/m/library.js
+++ b/src/sap.m/src/sap/m/library.js
@@ -6300,7 +6300,7 @@ sap.ui.define([
 			if (!oAnnotation) {
 				return false;
 			}
-			var sProperty = sPath.substr(sPath.lastIndexOf("/") + 1);
+			var sProperty = sPath.substring(sPath.lastIndexOf("/") + 1);
 			mValueListAnnotation.inProperty = sProperty;
 
 			jQuery.each(oAnnotation.record, function(i, aPropertyValues){

--- a/src/sap.m/test/sap/m/Menu.js
+++ b/src/sap.m/test/sap/m/Menu.js
@@ -23,7 +23,7 @@ sap.ui.define([
 				oItem = oItem.getParent();
 			}
 
-			sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
+			sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" > "));
 
 			MessageToast.show("itemSelected: " + sItemPath);
 		}

--- a/src/sap.m/test/sap/m/MenuButton.html
+++ b/src/sap.m/test/sap/m/MenuButton.html
@@ -22,7 +22,7 @@
 					oItem = oItem.getParent();
 				}
 
-				sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
+				sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" > "));
 
 				sap.m.MessageToast.show("itemSelected: " + sItemPath);
 			},
@@ -123,7 +123,7 @@
 					oItem = oItem.getParent();
 				}
 
-				sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
+				sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" > "));
 
 				sap.m.MessageToast.show("itemSelected: " + sItemPath);
 			},
@@ -197,7 +197,7 @@
 					oItem = oItem.getParent();
 				}
 
-				sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
+				sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" > "));
 
 				sap.m.MessageToast.show("itemSelected: " + sItemPath);
 			},
@@ -285,7 +285,7 @@
 					oItem = oItem.getParent();
 				}
 
-				sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
+				sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" > "));
 
 				sap.m.MessageToast.show("itemSelected: " + sItemPath);
 			},
@@ -360,7 +360,7 @@
 					oItem = oItem.getParent();
 				}
 
-				sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
+				sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" > "));
 
 				sap.m.MessageToast.show("itemSelected: " + sItemPath);
 			},
@@ -404,7 +404,7 @@
 					oItem = oItem.getParent();
 				}
 
-				sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
+				sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" > "));
 
 				sap.m.MessageToast.show("itemSelected: " + sItemPath);
 			},
@@ -449,7 +449,7 @@
 					oItem = oItem.getParent();
 				}
 
-				sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
+				sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" > "));
 
 				sap.m.MessageToast.show("itemSelected: " + sItemPath);
 			},
@@ -666,7 +666,7 @@
 
 				oLabel6,
 				oMenuButton6,
-	
+
 				oLabel7,
 				oMenuButton7,
 

--- a/src/sap.m/test/sap/m/MenuButtonMenuPosition.html
+++ b/src/sap.m/test/sap/m/MenuButtonMenuPosition.html
@@ -22,7 +22,7 @@
 					oItem = oItem.getParent();
 				}
 
-				sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
+				sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" > "));
 
 				sap.m.MessageToast.show("itemSelected: " + sItemPath);
 			},

--- a/src/sap.m/test/sap/m/OverflowToolbar.js
+++ b/src/sap.m/test/sap/m/OverflowToolbar.js
@@ -168,7 +168,7 @@ sap.ui.define([
 				oItem = oItem.getParent();
 			}
 
-			sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
+			sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" > "));
 
 			MessageToast.show("itemSelected: " + sItemPath);
 		},

--- a/src/sap.m/test/sap/m/ViewSettingsDialog.html
+++ b/src/sap.m/test/sap/m/ViewSettingsDialog.html
@@ -279,7 +279,7 @@
 						// we use some internal logic to get the dialog instance and the filter instance from within the control
 						// if the control is not cloned, access the dialog and the filter by id directly
 						var source = oEvent.getSource(),
-							vsd = sap.ui.getCore().byId(source.getParent().getParent().getId().substr(0,4)),
+							vsd = sap.ui.getCore().byId(source.getParent().getParent().getId().substring(0,4)),
 							filters = vsd.getFilterItems(),
 							customFilter,
 							i = 0;
@@ -324,7 +324,7 @@
 						// we use some internal logic to get the dialog instance and the filter instance from within the control
 						// if the control is not cloned, access the dialog and the filter by id directly
 						var source = oEvent.getSource(),
-							vsd = sap.ui.getCore().byId(source.getParent().getParent().getId().substr(0,4)),
+							vsd = sap.ui.getCore().byId(source.getParent().getParent().getId().substring(0,4)),
 							filters = vsd.getFilterItems(),
 							customFilter,
 							i = 0;

--- a/src/sap.m/test/sap/m/acc/Menu.js
+++ b/src/sap.m/test/sap/m/acc/Menu.js
@@ -36,7 +36,7 @@ sap.ui.define([
 				oItem = oItem.getParent();
 			}
 
-			sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" - "));
+			sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" - "));
 
 			MessageToast.show("itemSelected: " + sItemPath);
 		}

--- a/src/sap.m/test/sap/m/demokit/iconExplorer/webapp/controller/Overview.controller.js
+++ b/src/sap.m/test/sap/m/demokit/iconExplorer/webapp/controller/Overview.controller.js
@@ -172,7 +172,7 @@ sap.ui.define([
 			} else if (sSelectedCopyMode === "sym") {
 				this._onCopyIconToClipboard(sIconURI);
 			} else if (sSelectedCopyMode === "uni") {
-				this._onCopyUnicodeToClipboard(sIconURI.substr(sIconURI.lastIndexOf("/") + 1, sIconURI.length - 1));
+				this._onCopyUnicodeToClipboard(sIconURI.substring(sIconURI.lastIndexOf("/") + 1, sIconURI.length - 1));
 			}
 		},
 

--- a/src/sap.m/test/sap/m/demokit/orderbrowser/webapp/model/formatter.js
+++ b/src/sap.m/test/sap/m/demokit/orderbrowser/webapp/model/formatter.js
@@ -44,7 +44,7 @@ sap.ui.define([
 		handleBinaryContent: function(vData){
 			if (vData) {
 				var sMetaData1 = 'data:image/jpeg;base64,';
-				var sMetaData2 = vData.substr(104); // stripping the first 104 bytes from the binary data when using base64 encoding.
+				var sMetaData2 = vData.substring(104); // stripping the first 104 bytes from the binary data when using base64 encoding.
 				return sMetaData1 + sMetaData2;
 			} else {
 				return "../images/Employee.png";

--- a/src/sap.m/test/sap/m/demokit/sample/Menu/Page.controller.js
+++ b/src/sap.m/test/sap/m/demokit/sample/Menu/Page.controller.js
@@ -34,7 +34,7 @@ sap.ui.define([
 					oItem = oItem.getParent();
 				}
 
-				sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
+				sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" > "));
 
 				MessageToast.show("Action triggered on item: " + sItemPath);
 			}

--- a/src/sap.m/test/sap/m/demokit/sample/MenuButton/MB.controller.js
+++ b/src/sap.m/test/sap/m/demokit/sample/MenuButton/MB.controller.js
@@ -27,7 +27,7 @@ sap.ui.define([
 					oItem = oItem.getParent();
 				}
 
-				sItemPath = sItemPath.substr(0, sItemPath.lastIndexOf(" > "));
+				sItemPath = sItemPath.substring(0, sItemPath.lastIndexOf(" > "));
 
 				MessageToast.show("Action triggered on item: " + sItemPath);
 			}

--- a/src/sap.m/test/sap/m/demokit/teamCalendar/webapp/controller/Main.controller.js
+++ b/src/sap.m/test/sap/m/demokit/teamCalendar/webapp/controller/Main.controller.js
@@ -37,7 +37,7 @@ sap.ui.define([
 		rowSelectionHandler: function(oEvent) {
 			var oSelectedRow = oEvent.getParameter("rows")[0],
 				sSelectedId = oSelectedRow.getId();
-			this._sSelectedMember = sSelectedId.substr(sSelectedId.lastIndexOf('-') + 1);
+			this._sSelectedMember = sSelectedId.substring(sSelectedId.lastIndexOf('-') + 1);
 			oSelectedRow.setSelected(false);
 			this._loadCalendar("SinglePlanningCalendar");
 		},

--- a/src/sap.m/test/sap/m/demokit/teamCalendar/webapp/model/formatter.js
+++ b/src/sap.m/test/sap/m/demokit/teamCalendar/webapp/model/formatter.js
@@ -30,7 +30,7 @@ sap.ui.define(
 		 * @returns {string} prefixed image URL (if necessary)
 		 */
 		fixImagePath : function (sImage) {
-			if (sImage && sImage.substr(0, 11) !== "sap-icon://") {
+			if (sImage && sImage.substring(0, 11) !== "sap-icon://") {
 				sImage = this.imagePath + sImage;
 
 			}

--- a/src/sap.m/test/sap/m/demokit/theming/webapp/controller/Overview.controller.js
+++ b/src/sap.m/test/sap/m/demokit/theming/webapp/controller/Overview.controller.js
@@ -225,7 +225,7 @@ sap.ui.define([
 					const value = match[2];
 
 					aParameterMetadata.push({
-						name: name.substr(1), // remove the leading @
+						name: name.substring(1), // remove the leading @
 						value,
 						nameTP: name,
 						nameCP: mCustomProperties[value],

--- a/src/sap.m/test/sap/m/qunit/Input.qunit.js
+++ b/src/sap.m/test/sap/m/qunit/Input.qunit.js
@@ -8215,7 +8215,7 @@ sap.ui.define([
 		var oItem = oSuggestionsPopover.getItemsContainer().getItems()[1]; // The first SsstandardListItem
 
 		// Simulate user input- the first 3 letters of a StandardListItem
-		this.oInput.setValue(oItem.getTitle().substr(0, 3));
+		this.oInput.setValue(oItem.getTitle().substring(0, 3));
 		this.oInput.focus();
 
 		// Act
@@ -8238,7 +8238,7 @@ sap.ui.define([
 		await nextUIUpdate(this.clock);
 
 		// Assert
-		assert.strictEqual(this.oInput.getValue(), oItem.getTitle().substr(0, 3), "User's input is kept.");
+		assert.strictEqual(this.oInput.getValue(), oItem.getTitle().substring(0, 3), "User's input is kept.");
 	});
 
 	QUnit.test("Behaviour for a 'contains' item selection", async function (assert) {
@@ -8250,7 +8250,7 @@ sap.ui.define([
 		var oItem = oSuggestionsPopover.getItemsContainer().getItems()[1]; // The first SsstandardListItem
 
 		// Simulate user input- some letters letters from a StandardListItem, but not the first ones
-		this.oInput.setValue(oItem.getTitle().substr(3));
+		this.oInput.setValue(oItem.getTitle().substring(3));
 		this.oInput.focus();
 
 		// Act
@@ -8287,7 +8287,7 @@ sap.ui.define([
 		var oItem = oSuggestionsPopover.getItemsContainer().getItems()[1]; // A StandardListItem
 
 		// Simulate user input- which matches some item
-		this.oInput.setValue(oItem.getTitle().substr(0, 3));
+		this.oInput.setValue(oItem.getTitle().substring(0, 3));
 		this.oInput.focus();
 
 		// Act


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated and [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) is recommended.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#string

From [WDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr):
> Note: substr() is not part of the main ECMAScript specification — it's defined in [Annex B: Additional ECMAScript Features for Web Browsers](https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html), which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) and [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) methods instead to make their code maximally cross-platform friendly. The [String.prototype.substring() page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#the_difference_between_substring_and_substr) has some comparisons between the three methods.