### PR TITLE
[FIX] sap.m.upload.ActionsPlaceholder: Add 'de' text for upload button

### DIFF
--- a/src/sap.m/src/sap/m/messagebundle_de.properties
+++ b/src/sap.m/src/sap/m/messagebundle_de.properties
@@ -551,6 +551,9 @@ UPLOADSET_WITH_TABLE_DOCUMENT_RENAME_APPLY_BUTTON_TEXT=Anwenden
 
 UPLOADSET_WITH_TABLE_CANCELBUTTON_TEXT=Abbrechen
 
+#XBUT: Text for Upload button in the upload set with table
+UPLOADSET_WITH_TABLE_UPLOADBUTTON_TEXT=Durchsuchen
+
 p13n.DEFAULT_TITLE_FILTER=Filter
 
 p13n.FILTER_OPERATOR_CONTAINS=enth\u00E4lt
@@ -1964,6 +1967,6 @@ TABLE_SELECT_LIMIT_TITLE=Selektionsgrenze
 
 TABLE_SELECT_LIMIT=Nur die ersten {0} der Elemente, die Sie ausgew\u00E4hlt haben, wurden der Auswahl hinzugef\u00FCgt.
 
-FILE_PREVIEW_DIALOG_MAX_PREVIEW_SIZE_EXCEEDED=F\u00FCr diese Datei ist keine Vorschau vorhanden, da die Dateigr\u00F6\u00DFe gr\u00F6\u00DFer als {0} MB ist. Laden Sie die Datei herunter und schauen Sie sie lokal an. 
+FILE_PREVIEW_DIALOG_MAX_PREVIEW_SIZE_EXCEEDED=F\u00FCr diese Datei ist keine Vorschau vorhanden, da die Dateigr\u00F6\u00DFe gr\u00F6\u00DFer als {0} MB ist. Laden Sie die Datei herunter und schauen Sie sie lokal an.
 
 FILE_PREVIEW_DIALOG_NO_PREVIEW_AVAILABLE_MSG=Vorschau f\u00FCr diese Datei nicht verf\u00FCgbar.


### PR DESCRIPTION
With commit 1d453c50d034cc1c278f551616b415c7a366c207 the ActionsPlaceholer got the ability top use i18n.
For my case I need the german text. So I added a suggestion in the property file for UPLOADSET_WITH_TABLE_UPLOADBUTTON_TEXT