### PR TITLE
[FIX] sap.m.IllustrationPool: gracefully remove DOM pool assets

### DIFF
--- a/src/sap.m/src/sap/m/IllustrationPool.js
+++ b/src/sap.m/src/sap/m/IllustrationPool.js
@@ -378,9 +378,10 @@ sap.ui.define([
 				oAssetDOM = document.getElementById(sExtractedAssetId);
 				if (oAssetDOM !== null) {
 					oDOMPool.removeChild(oAssetDOM);
-					aSymbolsInDOM.splice(aSymbolsInDOM.indexOf(sId), 1);
 				}
 			}
+
+            aSymbolsInDOM.splice(aSymbolsInDOM.indexOf(sId), 1);
 		};
 
 		/**


### PR DESCRIPTION
# Setup

1. Assume for whatever reason execution reaches line [464](https://github.com/UI5/openui5/blob/master/src/sap.m/src/sap/m/IllustrationPool.js#L464)
2. Execution of `_removeAssetFromDOMPool` starts
3. In the function body, there are 2 checks which assert:
3.1. `oDOMPool` (a "static" DOM element) exists
3.2. `oAssetDOM` (the thing we presumably no longer need and want to remove) exists
4. If for whatever reason any of these do not exist, the `_removeAssetFromDOMPool` will silently do nothing (it will leave `aSymbolsInDOM` intact)
5. Execution will return to line [461](https://github.com/UI5/openui5/blob/master/src/sap.m/src/sap/m/IllustrationPool.js#L461) to an unmodified array, freezing the application in an infinite loop.

# Some semantics

In my case,  `oAssetDOM` was being removed dynamically, by some other application code.

Leaving the question whether this element should be removed by some other application code aside, it seems to me the symbol removal should not be tied to the DOM element removal, unless I have missed some other dependency.

In any case, "get your app frozen if you remove the wrong DOM element" feels weird so I decided to check for second opinion by opening this PR.

