### PR TITLE
[FIX] sap.ui.test.actions.Drop: error when getting drop aggregation

### DIFF
--- a/src/sap.ui.core/src/sap/ui/test/actions/Drop.js
+++ b/src/sap.ui.core/src/sap/ui/test/actions/Drop.js
@@ -85,7 +85,8 @@ sap.ui.define([
 					return aAggregations[mAggregation].dnd.droppable;
 				})[0];
 				if (sDropAggregation) {
-					oActionDomRef = oControl.getDomRefForSetting(sDropAggregation) || oControl["get" + sDropAggregation]()[0];
+					const oAggregation = oControl["get" + capitalize(sDropAggregation)]()[0]
+					oActionDomRef = oControl.getDomRefForSetting(sDropAggregation) || this.$(oAggregation)[0];
 				}
 			}
 


### PR DESCRIPTION
I got following error when trying to simulate drop on sap.f.GridContainer and the commit is to fix this error.

> Exception thrown by the testcode:'TypeError: t[("get" + a)] is not a function
> TypeError: t[("get" + a)] is not a function
>     at c.executeOn (https://sapui5.hana.ondemand.com/1.120.27/resources/sap/ui/test/actions/Drop.js?eval:6:550)
