### PR TITLE
chore: fix type definition for clearTextFirst

### DIFF
--- a/src/sap.ui.core/src/sap/ui/test/RecordReplay.js
+++ b/src/sap.ui.core/src/sap/ui/test/RecordReplay.js
@@ -147,7 +147,7 @@ sap.ui.define([
 	 * Currently supported interaction types are {@link sap.ui.test.RecordReplay.InteractionType}
 	 * To see the interaction details and options, see {@link sap.ui.test.actions}
 	 * @param {string} oOptions.enterText Text for the EnterText interaction
-	 * @param {string} [oOptions.clearTextFirst=true] Clear existing text before interaction
+	 * @param {boolean} [oOptions.clearTextFirst=true] Clear existing text before interaction
 	 * @param {boolean} oOptions.pressEnterKey If ENTER key will be entered after the text
 	 * @param {boolean} oOptions.keepFocus If the input will remain focused after text is entered
 	 * @returns {Promise<undefined|Error>} Promise to be resolved when the interaction is done or rejected if interaction is not possible


### PR DESCRIPTION
It seems `clearTextFirst` type is wrong. I believe it should be `boolean`, not `string`. When this change lands on new npm types packages, it'll help people using TypeScript.