### PR TITLE
[FIX] sap.m.PlanningCalendar: week numbers for custom day-based view keys | Fixes #4407

### DIFF
--- a/src/sap.m/src/sap/m/PlanningCalendar.js
+++ b/src/sap.m/src/sap/m/PlanningCalendar.js
@@ -2099,6 +2099,7 @@ sap.ui.define([
 							primaryCalendarType: this.getPrimaryCalendarType(),
 							interval: iIntervals,
 							viewKey: sKey,
+							intervalType: sIntervalType,
 							showWeekNumbers: this.getShowWeekNumbers(),
 							calendarWeekNumbering: this.getCalendarWeekNumbering()
 						});
@@ -2108,6 +2109,7 @@ sap.ui.define([
 						this._oCalendarWeeks.setPrimaryCalendarType(this.getPrimaryCalendarType());
 						this._oCalendarWeeks.setStartDate(this.getStartDate());
 						this._oCalendarWeeks.setViewKey(sKey);
+						this._oCalendarWeeks.setIntervalType(sIntervalType);
 					}
 					this._oInfoToolbar.addContent(this._oCalendarWeeks);
 				break;
@@ -2150,6 +2152,7 @@ sap.ui.define([
 							primaryCalendarType: this.getPrimaryCalendarType(),
 							interval: iIntervals,
 							viewKey: CalendarIntervalType.Month,
+							intervalType: CalendarIntervalType.Month,
 							showWeekNumbers: this.getShowWeekNumbers(),
 							calendarWeekNumbering: this.getCalendarWeekNumbering()
 						});
@@ -2159,6 +2162,7 @@ sap.ui.define([
 						this._oCalendarWeeks.setPrimaryCalendarType(this.getPrimaryCalendarType());
 						this._oCalendarWeeks.setStartDate(this.getStartDate());
 						this._oCalendarWeeks.setViewKey(CalendarIntervalType.Month);
+						this._oCalendarWeeks.setIntervalType(CalendarIntervalType.Month);
 					}
 					this._oInfoToolbar.addContent(this._oCalendarWeeks);
 					break;

--- a/src/sap.m/test/sap/m/qunit/PlanningCalendar.qunit.js
+++ b/src/sap.m/test/sap/m/qunit/PlanningCalendar.qunit.js
@@ -5013,6 +5013,40 @@ sap.ui.define([
 		});
 	});
 
+	QUnit.test("WeeksRow is rendered and shows week numbers for custom day-based view keys", async function(assert) {
+		this.oPC.removeAllViews();
+		this.oPC.addView(new PlanningCalendarView({
+			key: "A",
+			intervalType: CalendarIntervalType.Day,
+			intervalsS: 30,
+			intervalsM: 30,
+			intervalsL: 30
+		}));
+		this.oPC.addView(new PlanningCalendarView({
+			key: "D",
+			intervalType: CalendarIntervalType.Day,
+			intervalsS: 7,
+			intervalsM: 7,
+			intervalsL: 7
+		}));
+
+		this.oPC.setViewKey("A");
+		await nextUIUpdate();
+
+		let oWeeksRow = document.querySelector('.sapUiCalWeeksRow');
+		assert.ok(oWeeksRow, "WeeksRow is rendered for custom key A");
+		let aWeekNumbers = oWeeksRow.querySelectorAll('.sapUiCalRowWeekNumber');
+		assert.ok(aWeekNumbers.length > 0, "Week numbers are rendered for custom key A");
+
+		this.oPC.setViewKey("D");
+		await nextUIUpdate();
+
+		oWeeksRow = document.querySelector('.sapUiCalWeeksRow');
+		assert.ok(oWeeksRow, "WeeksRow is rendered for custom key D");
+		aWeekNumbers = oWeeksRow.querySelectorAll('.sapUiCalRowWeekNumber');
+		assert.ok(aWeekNumbers.length > 0, "Week numbers are rendered for custom key D");
+	});
+
 	QUnit.test("WeeksRow is NOT rendered in views which does not support this feature", async function(assert) {
 		const aOtherViews = [CalendarIntervalType.Hour]; // Add any other custom or built-in view keys as needed
 		for (let i = 0; i < aOtherViews.length; i++) {

--- a/src/sap.ui.unified/src/sap/ui/unified/calendar/WeeksRow.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/calendar/WeeksRow.js
@@ -76,6 +76,12 @@ sap.ui.define([
 				viewKey : {type : "string", group : "Appearance", defaultValue : CalendarIntervalType.Hour},
 
 				/**
+				 * Defines the interval type that is used to choose the week number rendering mode.
+				 * If not set, the <code>viewKey</code> is used for backward compatibility.
+				 */
+				intervalType : {type : "sap.ui.unified.CalendarIntervalType", group : "Appearance", defaultValue : null},
+
+				/**
 				 * Determines if the week numbers are displayed.
 				 */
 				showWeekNumbers : {type : "boolean", group : "Appearance", defaultValue : false},

--- a/src/sap.ui.unified/src/sap/ui/unified/calendar/WeeksRowRenderer.js
+++ b/src/sap.ui.unified/src/sap/ui/unified/calendar/WeeksRowRenderer.js
@@ -28,6 +28,7 @@ sap.ui.define([
 		const bShowWeekNumbers = oWeeksRow.getShowWeekNumbers();
 		const sPrimaryCalendarType = oWeeksRow.getPrimaryCalendarType();
 		const sViewKey = oWeeksRow.getViewKey();
+		const sIntervalType = oWeeksRow.getIntervalType() || sViewKey;
 		if (!bShowWeekNumbers || sPrimaryCalendarType !== CalendarType.Gregorian) {
 			return;
 		}
@@ -39,7 +40,7 @@ sap.ui.define([
 		oRm.openStart("div");
 		oRm.class("sapMPlanWeeksLabelRow");
 		oRm.openEnd();
-		if (sViewKey === CalendarIntervalType.Month) {
+		if (sIntervalType === CalendarIntervalType.Month) {
 			const oResourceBundle = coreLibrary.getResourceBundleFor("sap.ui.unified");
 			oRm.openStart("div");
 			oRm.class("sapUiCalRowWeekLabel");
@@ -51,11 +52,11 @@ sap.ui.define([
 		oRm.openStart("div");
 		oRm.class("sapMPlanWeeksDataRow");
 		oRm.openEnd();
-		if (sViewKey === CalendarIntervalType.Day || sViewKey === CalendarIntervalType.Week ||
-				sViewKey === CalendarIntervalType.OneMonth || sViewKey === CalendarIntervalType.OneWeek ||
-				sViewKey === "OneMonth") {
+		if (sIntervalType === CalendarIntervalType.Day || sIntervalType === CalendarIntervalType.Week ||
+				sIntervalType === CalendarIntervalType.OneMonth || sIntervalType === CalendarIntervalType.OneWeek ||
+				sIntervalType === "OneMonth") {
 			this.renderDaysWeeks(oRm, oWeeksRow);
-		} else if (sViewKey === CalendarIntervalType.Month) {
+		} else if (sIntervalType === CalendarIntervalType.Month) {
 			this.renderMonthsWeeks(oRm, oWeeksRow);
 		}
 		oRm.close("div");


### PR DESCRIPTION
## Summary
This PR fixes a regression where week numbers are not rendered in PlanningCalendar week/day-based views when custom view keys are used (for example A, D), even if showWeekNumbers is enabled. This PR fixes #4407 

<img width="951" height="294" alt="image" src="https://github.com/user-attachments/assets/b924d18f-134e-4c01-b9f9-678b77db4404" />

## Problem
Since 1.145.0, week number rendering depends on viewKey matching specific built-in keys. For custom keys, week numbers are skipped.

## Root Cause
WeeksRow rendering logic was coupled to viewKey instead of the actual interval type.

## Fix
- Added intervalType to WeeksRow
- Propagated intervalType from PlanningCalendar when creating/updating WeeksRow
- Updated WeeksRowRenderer to use intervalType (with viewKey fallback for compatibility)

## Tests
- Added regression test for custom day-based view keys:
  - key A (Day interval)
  - key D (Day interval)
  - Both now render week numbers correctly.

## Issue
Fixes #4407