### PR TITLE
chore: fix type definition for addRoute

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/routing/Router.js
+++ b/src/sap.ui.core/src/sap/ui/core/routing/Router.js
@@ -373,7 +373,7 @@ sap.ui.define([
 			 * Adds a route to the router.
 			 *
 			 * @param {sap.ui.core.routing.$RouteSettings} oConfig Configuration object for the route, see {@link sap.ui.core.routing.Route#constructor}
-			 * @param {sap.ui.core.routing.Route} oParent The parent route - if a parent route is given, the <code>routeMatched</code> event of this route will also trigger the <code>routeMatched</code> of the parent and it will also create the view of the parent (if provided).
+			 * @param {sap.ui.core.routing.Route} [oParent] The parent route - if a parent route is given, the <code>routeMatched</code> event of this route will also trigger the <code>routeMatched</code> of the parent and it will also create the view of the parent (if provided).
 			 * @public
 			 */
 			addRoute : function (oConfig, oParent) {


### PR DESCRIPTION
I think `addRoute` is missing the proper JSDoc for declaring it as optional making it a bit cumbersome to use this in TypeScript. The internals behind it, especially the route itself, already has this properly marked as optional. 

When this change lands on new npm types packages, it'll help people using TypeScript.