### PR TITLE
chore: fix/tighten type definition for pcp ws

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/ws/SapPcpWebSocket.js
+++ b/src/sap.ui.core/src/sap/ui/core/ws/SapPcpWebSocket.js
@@ -11,7 +11,7 @@ sap.ui.define(['./WebSocket', "sap/base/Log"],
 	 * Creates a new WebSocket connection and uses the pcp-protocol for communication.
 	 *
 	 * @param {string} sUrl relative or absolute URL for WebSocket connection.
-	 * @param {array} [aProtocols] array of protocols as strings, a single protocol as a string.
+	 * @param {string|string[]} [aProtocols] array of protocols as strings, a single protocol as a string.
 	 * Protocol(s) should be selected from {@link sap.ui.core.ws.SapPcpWebSocket.SUPPORTED_PROTOCOLS}.
 	 *
 	 * @public
@@ -39,7 +39,7 @@ sap.ui.define(['./WebSocket', "sap/base/Log"],
 	 * @param {sap.ui.base.EventProvider} oControlEvent.getSource
 	 * @param {object} oControlEvent.getParameters
 	 * @param {string} oControlEvent.getParameters.data Received data from the server.
-	 * @param {string} oControlEvent.getParameters.pcpFields Received pcpFields as a key-value map.
+	 * @param {Object<string,string>} oControlEvent.getParameters.pcpFields Received pcpFields as a key-value map.
 	 * @public
 	 */
 
@@ -48,7 +48,7 @@ sap.ui.define(['./WebSocket', "sap/base/Log"],
 	 *
 	 * @param {object} [oParameters] Parameters to pass along with the event
 	 * @param {string} [oParameters.data] Received data from the server.
-	 * @param {string} [oParameters.pcpFields] Received pcpFields as a key-value map.
+	 * @param {Object<string,string>} [oParameters.pcpFields] Received pcpFields as a key-value map.
 	 * @return {this} <code>this</code> to allow method chaining
 	 * @protected
 	 * @name sap.ui.core.ws.SapPcpWebSocket#fireMessage
@@ -245,7 +245,7 @@ sap.ui.define(['./WebSocket', "sap/base/Log"],
 	 * when the connection is established.
 	 *
 	 * @param {string|Blob|ArrayBuffer} message message to send
-	 * @param {object} [oPcpFields] additional pcp-fields as key-value map
+	 * @param {Object<string,any>} [oPcpFields] additional pcp-fields as key-value map
 	 * @return {this} Reference to <code>this</code> to allow method chaining
 	 * @public
 	 */

--- a/src/sap.ui.core/src/sap/ui/core/ws/WebSocket.js
+++ b/src/sap.ui.core/src/sap/ui/core/ws/WebSocket.js
@@ -16,7 +16,7 @@ sap.ui.define([
 	 * Creates a new WebSocket connection.
 	 *
 	 * @param {string} sUrl relative or absolute URL for WebSocket connection.
-	 * @param {array} [aProtocols] array of protocols as strings, a single protocol as a string
+	 * @param {string|string[]} [aProtocols] array of protocols as strings, a single protocol as a string
 	 * @public
 	 *
 	 * @class Basic WebSocket class.
@@ -393,7 +393,7 @@ sap.ui.define([
 	 * Opens the connection and binds the event-handlers.
 	 *
 	 * @param {string} sUrl	URL for WebSocket
-	 * @param {array} [aProtocols] array of protocols as strings, a single protocol as a string
+	 * @param {string|string[]} [aProtocols] array of protocols as strings, a single protocol as a string
 	 * @private
 	 */
 	WebSocket.prototype._openConnection = function(sUrl, aProtocols) {


### PR DESCRIPTION
Some fixing/tightening of the PCP WS types for improved consumption when using TS.

Wired the constructor change through to non-pcp ws and also checked "original" [types of ws](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/de1900d349d3f2d546321818d2f6f711d0378cda/types/websocket/index.d.ts#L632).

When this change lands on new npm types packages, it'll help people using TypeScript.