### PR TITLE
chore: fix type definition for old- and newMessages in MessageProcessor

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/message/MessageProcessor.js
+++ b/src/sap.ui.core/src/sap/ui/core/message/MessageProcessor.js
@@ -69,9 +69,9 @@ sap.ui.define(['sap/ui/base/EventProvider', "sap/base/util/uid"],
 	 * @param {sap.ui.base.Event} oEvent
 	 * @param {sap.ui.base.EventProvider} oEvent.getSource
 	 * @param {object} oEvent.getParameters
-	 * @param {sap.ui.core.message.Message} oEvent.getParameters.oldMessages
+	 * @param {Array<sap.ui.core.message.Message>} oEvent.getParameters.oldMessages
 	 *            Messages already existing before the <code>messageChange</code> event was fired.
-	 * @param {sap.ui.core.message.Message} oEvent.getParameters.newMessages
+	 * @param {Array<sap.ui.core.message.Message>} oEvent.getParameters.newMessages
 	 *            New messages added by the trigger of the <code>messageChange</code> event.
 	 * @public
 	 */
@@ -123,9 +123,9 @@ sap.ui.define(['sap/ui/base/EventProvider', "sap/base/util/uid"],
 	 *
 	 * @param {object} mParameters
 	 *            Parameters to pass along with the event
-	 * @param {sap.ui.core.message.Message} mParameters.oldMessages
+	 * @param {Array<sap.ui.core.message.Message>} mParameters.oldMessages
 	 *            Messages already existing before the <code>messageChange</code> event was fired.
-	 * @param {sap.ui.core.message.Message} mParameters.newMessages
+	 * @param {Array<sap.ui.core.message.Message>} mParameters.newMessages
 	 *            New messages added by the trigger of the <code>messageChange</code> event.
 	 *
 	 * @returns {this} Reference to <code>this</code> in order to allow method chaining


### PR DESCRIPTION
This PR fixes the type definition for the props `oldMessages` and `newMessages`

They are already correctly typed in e.g.: `Messaging` and are obviously already named in plural
```
/**
	* Update Messages by providing two arrays of old and new messages.
	*
	* The old ones will be removed, the new ones will be added.
	*
	* @param {Array<sap.ui.core.message.Message>} aOldMessages Array of old messages to be removed
	* @param {Array<sap.ui.core.message.Message>} aNewMessages Array of new messages to be added
	* @public
	*/
updateMessages: function(aOldMessages, aNewMessages) {
```

I was not sure about the "proper" style you're trying to adhere to nowadays wrt the array syntax in JSDoc. I've seen both `Array<>` and simple `[]` but concluded that, based on its position (`@param`) and the pre-existing usage from other sources, like mentioned above, to go with the former.

When this change lands on new npm types packages, it'll help people using TypeScript.