### PR TITLE
chore: fix type definition/gap for `read` in ODataModel V2

### DIFF
--- a/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
+++ b/src/sap.ui.core/src/sap/ui/model/odata/v2/ODataModel.js
@@ -5947,6 +5947,7 @@ sap.ui.define([
 	 * @param {sap.ui.model.Context} [mParameters.context] If specified, <code>sPath</code> has to be relative to the path
 	 *   given with the context.
 	 * @param {Object<string,string>} [mParameters.urlParameters] A map containing the parameters that will be passed as query strings
+	 * @param {Object<string,string>} [mParameters.headers] A map of headers for this request
 	 * @param {sap.ui.model.Filter[]} [mParameters.filters] An array of filters to be included in the request URL
 	 * @param {sap.ui.model.Sorter[]} [mParameters.sorters] An array of sorters to be included in the request URL
 	 * @param {function} [mParameters.success] A callback function which is called when the data has


### PR DESCRIPTION
Hey there,

I noticed a small gap (again, for TS Types) in the `read` method of the V2 Model. The other methods like `create`, `update` and `remove` honor this contract in their JSDoc correctly already.

I've added it which will allow TS consumers to have proper types here.

Cheers 🍻