### PR TITLE
fix(qunit): add allow-same-origin to iframe sandbox for BAS coverage

### DIFF
--- a/src/sap.ui.core/src/sap/ui/qunit/qunit-coverage-istanbul.js
+++ b/src/sap.ui.core/src/sap/ui/qunit/qunit-coverage-istanbul.js
@@ -207,7 +207,8 @@
 					oFrameEl.style.border = "none";
 					oFrameEl.style.width = "100%";
 					oFrameEl.style.height = "100vh";
-					oFrameEl.sandbox = "allow-scripts";
+					// oFrameEl.sandbox = "allow-scripts";
+					oFrameEl.sandbox = "allow-scripts allow-same-origin";
 
 					body.appendChild(oFrameEl);
 				});


### PR DESCRIPTION
Fixes #4438

**Change:** `oFrameEl.sandbox = "allow-scripts"` → `oFrameEl.sandbox = "allow-scripts allow-same-origin"`

The istanbul coverage report was failing in Business Application Studio 
because the generated iframe was missing `allow-same-origin` in its 
sandbox attribute, causing BAS auth cookies to be blocked (401 errors).

Fix: Added `allow-same-origin` to the sandbox attribute on line 210 of 
qunit-coverage-istanbul.js so the iframe correctly sends auth cookies 
within the same origin context.

Tested in BAS — coverage report loads and navigates correctly after fix.