### PR TITLE
[FIX] sap/base/util/Version: avoid global window in compareTo

### DIFF
--- a/src/sap.ui.core/src/sap/base/util/Version.js
+++ b/src/sap.ui.core/src/sap/base/util/Version.js
@@ -140,7 +140,11 @@ sap.ui.define([], function() {
 		 * @public
 		 */
 		this.compareTo = function(vOtherMajor, iOtherMinor, iOtherPatch, sOtherSuffix) {
-			var vOther = Version.apply(window, arguments);
+			// Version acts as a cast operator when not called with 'new', so the 'this'
+			// context is irrelevant here. Passing 'null' avoids referencing the global
+			// 'window', which is not available in non-browser environments such as Web
+			// Workers or Node.js and would otherwise make compareTo/inRange throw there.
+			var vOther = Version.apply(null, arguments);
 			/*eslint-disable no-nested-ternary */
 			return vMajor - vOther.getMajor() ||
 					iMinor - vOther.getMinor() ||


### PR DESCRIPTION
## Summary

`sap/base/util/Version#compareTo` calls `Version.apply(window, arguments)` to reuse `Version` as a cast operator. The `this` context is irrelevant there (`Version` returns a new instance when not called with `new`), but referencing the global `window` makes `compareTo()` and `inRange()` throw a `ReferenceError` in environments without a `window` — e.g. Web Workers and Node.js. `sap/base/util` is meant to be environment-agnostic, and this is the only raw `window` reference in the whole package.

## Fix

Pass `null` instead of `window` so the utility stays environment-agnostic. No behavior change in the browser (public API unchanged).

## How to reproduce

In a Web Worker or Node.js context:
```js
Version("1.2.3").compareTo("1.2.4"); // ReferenceError: window is not defined