### PR TITLE
[FIX] sap/base/util/deepEqual: guard browser-global Node reference

### DIFF
--- a/src/sap.ui.core/src/sap/base/util/deepEqual.js
+++ b/src/sap.ui.core/src/sap/base/util/deepEqual.js
@@ -69,7 +69,11 @@ sap.ui.define(["sap/base/Log"], function(Log) {
 			if (!contains && Object.keys(a).length !== Object.keys(b).length) {
 				return false;
 			}
-			if (a instanceof Node) {
+			// 'Node' is a browser global and does not exist in non-browser
+			// environments such as Web Workers or Node.js. Guard the reference so
+			// deepEqual (a sap/base module) stays usable there instead of throwing
+			// a ReferenceError, while still comparing DOM nodes in the browser.
+			if (typeof Node !== "undefined" && a instanceof Node) {
 				return a.isEqualNode(b);
 			}
 			if (a instanceof Date) {


### PR DESCRIPTION
## Summary

`sap/base/util/deepEqual` compares DOM nodes via `a instanceof Node`. `Node` is a browser global that does not exist in non-browser environments such as Web Workers or Node.js, so `deepEqual()` throws a `ReferenceError: Node is not defined` there when comparing any two objects — even though it is part of the environment-agnostic `sap/base` package. The module's own `@evo-todo` already flags this ("dependency to global name 'Node' contradicts sap/base package"). This complements the recent removal of `window` usages from `sap/base` (6601e5b), which did not cover `Node`.

## Fix

Guard the reference with `typeof Node !== "undefined"` so DOM nodes are still compared in the browser while `deepEqual` stays usable in environments without a `Node` global. No behavior change in the browser (public API unchanged).

## How to reproduce

In a Web Worker or Node.js context:
```js
deepEqual({ a: 1 }, { a: 1 }); // ReferenceError: Node is not defined