### PR TITLE
[FIX] sap.ui.core.format.ListFormat: keep '$' in values literal

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/format/ListFormat.js
+++ b/src/sap.ui.core/src/sap/ui/core/format/ListFormat.js
@@ -36,6 +36,24 @@ sap.ui.define([
 	};
 
 	/**
+	 * Returns a replacer function for <code>String.prototype.replace</code> that inserts the given
+	 * value literally.
+	 *
+	 * Passing the value directly as the replacement string would interpret <code>$</code> sequences
+	 * in it (e.g. <code>$&</code>, <code>$$</code>, <code>$`</code>) as special replacement patterns
+	 * and thereby corrupt list values that contain such sequences.
+	 *
+	 * @param {string} sValue The value to insert literally
+	 * @returns {function():string} A replacer function returning the value unchanged
+	 * @private
+	 */
+	function asReplacement(sValue) {
+		return function() {
+			return sValue;
+		};
+	}
+
+	/**
 	 * Get an instance of the ListFormat which can be used for formatting.
 	 *
 	 * @param {object} [oFormatOptions] Object which defines the format options
@@ -106,8 +124,8 @@ sap.ui.define([
 			var sResult =  aValues[0]; // 1
 
 			for (var i = 1; i < aValues.length; i++) {
-				sResult = sPattern.replace("{0}", sResult); // 1, {1}
-				sResult = sResult.replace("{1}", aValues[i]); // 1, 2
+				sResult = sPattern.replace("{0}", asReplacement(sResult)); // 1, {1}
+				sResult = sResult.replace("{1}", asReplacement(aValues[i])); // 1, 2
 			}
 
 			return sResult;
@@ -119,7 +137,7 @@ sap.ui.define([
 			sPattern = mListPatterns[aValues.length];
 
 			for (var i = 0; i < aValues.length; i++) {
-				sPattern = sPattern.replace('{' + i + '}', aValues[i]);
+				sPattern = sPattern.replace('{' + i + '}', asReplacement(aValues[i]));
 			}
 			sValue = sPattern;
 
@@ -132,11 +150,11 @@ sap.ui.define([
 			sEnd = aValues.pop();
 			aMiddle = aValues;
 
-			sStart = mListPatterns.start.replace("{0}", aStart);
-			sEnd = mListPatterns.end.replace("{1}", sEnd);
+			sStart = mListPatterns.start.replace("{0}", asReplacement(aStart));
+			sEnd = mListPatterns.end.replace("{1}", asReplacement(sEnd));
 			sMiddle = replaceMiddlePatterns(aMiddle, mListPatterns.middle);
 
-			sValue = sStart.replace("{1}", sEnd.replace("{0}", sMiddle));
+			sValue = sStart.replace("{1}", asReplacement(sEnd.replace("{0}", asReplacement(sMiddle))));
 		}
 
 		return sValue;

--- a/src/sap.ui.core/test/sap/ui/core/qunit/types/ListFormat.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/types/ListFormat.qunit.js
@@ -186,4 +186,19 @@ sap.ui.define(['sap/ui/core/format/ListFormat', 'sap/ui/core/Locale', "sap/base/
 		assert.deepEqual(aExpectedResult, aActualResult, "Values are correctly parsed but differs from the original input.");
 	});
 
+	QUnit.test("items containing '$' replacement patterns are inserted literally", function (assert) {
+		// '$' sequences in the values must not be interpreted as
+		// String.prototype.replace replacement patterns (e.g. "$&", "$$", "$'").
+		var oListFormat = ListFormat.getInstance(this.oLocale);
+
+		assert.equal(oListFormat.format(["Preis $&", "B"]), "Preis $& und B",
+			"'$&' in a value (exact-count pattern) is kept literally");
+		assert.equal(oListFormat.format(["100$$", "B"]), "100$$ und B",
+			"'$$' in a value is kept literally");
+		assert.equal(oListFormat.format(["a$'b", "B", "C"]), "a$'b, B und C",
+			"\"$'\" in the start element is kept literally");
+		assert.equal(oListFormat.format(["A", "B", "c$&d"]), "A, B und c$&d",
+			"'$&' in the end element is kept literally");
+	});
+
 });


### PR DESCRIPTION
## Summary

`sap.ui.core.format.ListFormat#format` builds its result with `String.prototype.replace` and passes the list values directly as the replacement string. `$` sequences in a value (`$&`, `$$`, `$'`, `` $` ``) are therefore interpreted as special replacement patterns and corrupt the output.

Examples (de-DE):
- `format(["a$'b", "B"])` → garbled text instead of `"a$'b und B"`
- `format(["100$$", "B"])` → `"100$ und B"` instead of `"100$$ und B"`
- `format(["Total: $&", "B"])` → `"Total: {0} und B"` instead of `"Total: $& und B"`

This affects any list whose values may contain `$` (prices, titles, user-entered text).

## Fix

Insert the values through a replacement **function** (`asReplacement`) so they are taken literally, at every dynamic-replacement site in `format`. No API/behavior change for values without `$`.

## Testing

Added a regression test to `ListFormat.qunit.js` covering `$&`, `$$` and `$'` in the exact-count, start and end elements. The test fails before the fix and passes after. Verified in Node as well.