### PR TITLE
[FIX] sap.ui.core.format.DateFormat: escape calendar week pattern

### DIFF
--- a/src/sap.ui.core/src/sap/ui/core/format/DateFormat.js
+++ b/src/sap.ui.core/src/sap/ui/core/format/DateFormat.js
@@ -10,6 +10,7 @@ sap.ui.define([
 	"sap/base/i18n/date/CalendarType",
 	"sap/base/i18n/date/CalendarWeekNumbering",
 	"sap/base/i18n/date/TimezoneUtils",
+	"sap/base/strings/escapeRegExp",
 	"sap/base/strings/formatMessage",
 	"sap/base/util/deepEqual",
 	"sap/base/util/extend",
@@ -20,7 +21,7 @@ sap.ui.define([
 	"sap/ui/core/date/UI5Date",
 	"sap/ui/core/date/UniversalDate",
 	"sap/ui/core/format/FormatUtils"
-], function(Log, Formatting, Localization, CalendarType, CalendarWeekNumbering, TimezoneUtils, formatMessage,
+], function(Log, Formatting, Localization, CalendarType, CalendarWeekNumbering, TimezoneUtils, escapeRegExp, formatMessage,
 		deepEqual, extend, Locale, LocaleData, Supportability, CalendarUtils, UI5Date, UniversalDate, FormatUtils) {
 	"use strict";
 
@@ -1432,8 +1433,11 @@ sap.ui.define([
 					bValid = oParseHelper.checkValid(oPart.type, bPartInvalid, oFormat);
 				} else {
 					sPart = oFormat.oLocaleData.getCalendarWeek(oPart.digits === 3 ? "narrow" : "wide");
-					sPart = sPart.replace("{0}", "([0-9]+)");
-					var rWeekNumber = new RegExp(sPart),
+					// Escape the literal parts of the localized pattern so that regex
+					// metacharacters in the calendar-week text (e.g. the "." in the
+					// Hungarian narrow pattern "{0}. NH") are matched literally rather
+					// than interpreted - or throwing on unbalanced brackets.
+					var rWeekNumber = new RegExp(sPart.split("{0}").map(escapeRegExp).join("([0-9]+)")),
 						oResult = rWeekNumber.exec(sValue);
 					if (oResult) {
 						// e.g. for input "CW 01" create pattern "CW ([0-9]+)"

--- a/src/sap.ui.core/test/sap/ui/core/qunit/types/DateFormat.qunit.js
+++ b/src/sap.ui.core/test/sap/ui/core/qunit/types/DateFormat.qunit.js
@@ -2063,6 +2063,18 @@ sap.ui.define([
 			});
 			assert.strictEqual(oDateFormat.format(UI5Date.getInstance(2015, 0, 1)), "Calendar Week 01", "week number in Japanese calendar");
 			assert.notOk(isNaN(oDateFormat.parse("Calendar Week 01").getTime()), "Date can be correctly parsed in Japanese calendar 'Calendar Week 01'");
+
+			// The Hungarian narrow calendar-week pattern contains a literal ".": "{0}. NH".
+			// When parsing, that "." must be matched literally and not interpreted as a
+			// regex wildcard (see the escaping in the "w" pattern symbol's parse function).
+			oDateFormat = DateFormat.getDateInstance({
+				pattern: "www"
+			}, new Locale("hu"));
+			var sHuNarrowWeek = oDateFormat.format(UI5Date.getInstance(2015, 0, 1));
+			assert.ok(/^\d+\. NH$/.test(sHuNarrowWeek), "hu narrow calendar week is formatted as 'N. NH' (was '" + sHuNarrowWeek + "')");
+			assert.notOk(isNaN(oDateFormat.parse(sHuNarrowWeek).getTime()), "the formatted hu narrow calendar week can be parsed back");
+			assert.strictEqual(oDateFormat.parse(sHuNarrowWeek.replace(". NH", "X NH")), null,
+				"hu narrow calendar week with a non-matching separator is rejected (dot is matched literally, not as a wildcard)");
 		});
 
 		QUnit.test("format and parse weekYear/weekInYear pattern with 2 digits", function (assert) {


### PR DESCRIPTION
## Summary

When parsing the wide/narrow week-in-year field, `DateFormat` turns the localized calendar-week text from `LocaleData#getCalendarWeek` into a `RegExp` without escaping its literal part:

```js
sPart = oFormat.oLocaleData.getCalendarWeek(...);   // e.g. hu narrow: "{0}. NH"
sPart = sPart.replace("{0}", "([0-9]+)");
var rWeekNumber = new RegExp(sPart);                 // "([0-9]+). NH"